### PR TITLE
Expand profiles.py: OMPL configurators + time parameterization

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -34,17 +34,15 @@ Sets:
 - `TESSERACT_TASK_COMPOSER_CONFIG_FILE` - task composer plugin config
 
 ### `run_benchmarks.sh`
-Runs planning benchmarks with timing, grouped by `num_planners` to show CPU scaling impact:
+Runs all planning benchmarks and shows summary report.
 
 ```bash
-./scripts/run_benchmarks.sh                    # timing + histogram (bench.svg)
-./scripts/run_benchmarks.sh -k "scaling"       # only CPU scaling tests
-./scripts/run_benchmarks.sh --benchmark-disable -n auto  # fast parallel, no timing
+./scripts/run_benchmarks.sh
 ```
 
-Output: `bench.svg` histogram grouped by planner count (1, 2, 4, 8 CPUs).
-
-Requires `pygal` for histogram: `pip install pygal`
+Tests all 5 examples:
+- Default pipeline timing (5 tests)
+- OMPL CPU scaling with 1/2/4/8 planners (skips if example needs TrajOpt)
 
 ### `run_tests.sh`
 Runs pytest with correct environment. Preferred way to run tests:

--- a/scripts/run_benchmarks.sh
+++ b/scripts/run_benchmarks.sh
@@ -8,11 +8,86 @@ cd "$PROJECT_ROOT"
 
 source "$SCRIPT_DIR/env.sh"
 
-# Group by param:num_planners to show CPU scaling impact clearly
-exec pytest tesseract_nanobind/tests/benchmarks \
+JSON_DEFAULTS=$(mktemp /tmp/bench_defaults_XXXXXX.json)
+JSON_SCALING=$(mktemp /tmp/bench_scaling_XXXXXX.json)
+
+# Run default pipeline tests (all 5 examples)
+echo "=== Default Pipeline Benchmarks ==="
+pytest tesseract_nanobind/tests/benchmarks \
+    -k "TestExampleBenchmarks" \
     --benchmark-enable \
     --benchmark-min-rounds=2 \
+    --benchmark-json="$JSON_DEFAULTS" \
+    -v "$@"
+
+# Run scaling tests grouped by num_planners (generates histogram)
+echo ""
+echo "=== OMPL CPU Scaling Benchmarks ==="
+pytest tesseract_nanobind/tests/benchmarks \
+    -k "TestOMPLScaling" \
+    --benchmark-enable \
+    --benchmark-min-rounds=2 \
+    --benchmark-json="$JSON_SCALING" \
     --benchmark-group-by=param:num_planners \
-    --benchmark-sort=fullname \
     --benchmark-histogram=bench \
     -v "$@"
+
+# Generate summary report
+python3 - "$JSON_DEFAULTS" "$JSON_SCALING" << 'PYTHON'
+import json
+import sys
+from collections import defaultdict
+
+defaults = {}
+scaling = defaultdict(dict)
+
+# Parse defaults
+with open(sys.argv[1]) as f:
+    for bench in json.load(f).get("benchmarks", []):
+        example = bench.get("params", {}).get("example_name", bench["name"])
+        defaults[example] = bench["stats"]["mean"]
+
+# Parse scaling
+with open(sys.argv[2]) as f:
+    for bench in json.load(f).get("benchmarks", []):
+        params = bench.get("params", {})
+        example = params.get("example_name", bench["name"])
+        if "num_planners" in params:
+            scaling[example][params["num_planners"]] = bench["stats"]["mean"]
+
+def fmt(t):
+    return f"{t:.2f}s" if t and t < 60 else (f"{t/60:.1f}m" if t else "-")
+
+print()
+print("╔══════════════════════════════════════════════════════════════════════════════╗")
+print("║                          BENCHMARK RESULTS                                   ║")
+print("╠══════════════════════════════════════════════════════════════════════════════╣")
+
+if defaults:
+    print()
+    print("  Default Pipeline:")
+    print("  " + "─" * 45)
+    for ex in sorted(defaults.keys()):
+        print(f"  {ex:<35} {fmt(defaults[ex]):>8}")
+
+if scaling:
+    print()
+    print("  OMPL CPU Scaling:")
+    print(f"  {'Example':<20} │ {'1 CPU':>8} │ {'2 CPU':>8} │ {'4 CPU':>8} │ {'8 CPU':>8} │ {'Speedup':>8}")
+    print("  " + "─" * 20 + "─┼─" + "─" * 8 + "─┼─" + "─" * 8 + "─┼─" + "─" * 8 + "─┼─" + "─" * 8 + "─┼─" + "─" * 8)
+    for ex in sorted(scaling.keys()):
+        t = scaling[ex]
+        t1, t2, t4, t8 = t.get(1, 0), t.get(2, 0), t.get(4, 0), t.get(8, 0)
+        best = min(v for v in [t1, t2, t4, t8] if v > 0) if any([t1, t2, t4, t8]) else 0
+        speedup = f"{t1/best:.2f}x" if t1 and best else "-"
+        print(f"  {ex:<20} │ {fmt(t1):>8} │ {fmt(t2):>8} │ {fmt(t4):>8} │ {fmt(t8):>8} │ {speedup:>8}")
+    print()
+    print("  Speedup = time(1 CPU) / time(best)")
+
+print()
+print("╚══════════════════════════════════════════════════════════════════════════════╝")
+print()
+print("  Histogram: bench.svg (grouped by num_planners)")
+PYTHON
+
+rm "$JSON_DEFAULTS" "$JSON_SCALING"

--- a/tesseract_nanobind/src/tesseract_robotics/planning/__init__.py
+++ b/tesseract_nanobind/src/tesseract_robotics/planning/__init__.py
@@ -90,9 +90,12 @@ from tesseract_robotics.planning.profiles import (
     STANDARD_PROFILE_NAMES,
     create_trajopt_default_profiles,
     create_ompl_default_profiles,
+    create_ompl_planner_configurators,
     create_descartes_default_profiles,
     create_freespace_pipeline_profiles,
     create_cartesian_pipeline_profiles,
+    create_time_optimal_parameterization,
+    create_iterative_spline_parameterization,
 )
 
 __all__ = [
@@ -136,7 +139,11 @@ __all__ = [
     "STANDARD_PROFILE_NAMES",
     "create_trajopt_default_profiles",
     "create_ompl_default_profiles",
+    "create_ompl_planner_configurators",
     "create_descartes_default_profiles",
     "create_freespace_pipeline_profiles",
     "create_cartesian_pipeline_profiles",
+    # Time Parameterization
+    "create_time_optimal_parameterization",
+    "create_iterative_spline_parameterization",
 ]

--- a/tesseract_nanobind/src/tesseract_robotics/planning/profiles.py
+++ b/tesseract_nanobind/src/tesseract_robotics/planning/profiles.py
@@ -3,11 +3,15 @@ Motion planner profile creation helpers.
 
 These helpers create ProfileDictionary objects with planner profiles
 matching C++ example defaults (collision margins, cost coefficients, etc.).
+
+Also provides helpers for:
+- OMPL planner configurators (RRTConnect, RRTstar, SBL)
+- Time parameterization (TOTG, ISP)
 """
 from __future__ import annotations
 
 import os
-from typing import List, Optional
+from typing import List, Optional, Union
 
 from tesseract_robotics.tesseract_command_language import ProfileDictionary
 
@@ -39,11 +43,40 @@ def create_trajopt_default_profiles(
     This creates profiles with collision and cost/constraint settings that
     match the tesseract_examples C++ code (car_seat_example.cpp, etc.).
 
+    TrajOpt uses Sequential Convex Optimization (SCO) to optimize trajectories
+    by minimizing costs (smoothness, collision distance) while satisfying
+    constraints (joint limits, collision avoidance, waypoint targets).
+
+    Profile Configuration:
+        Composite Profile (applies to entire trajectory):
+        - collision_constraint: safety_margin=0.00, buffer=0.005, coeff=10
+        - collision_cost: safety_margin=0.005, buffer=0.01, coeff=50
+
+        Plan Profile (applies per waypoint):
+        - cartesian_constraint: enabled (enforce Cartesian targets exactly)
+        - joint_constraint: enabled (enforce joint targets exactly)
+        - cartesian_cost: disabled (no soft Cartesian costs)
+        - joint_cost: disabled (no soft joint costs)
+
     Args:
-        profile_names: Profile names to register. Default: TRAJOPT_PROFILE_NAMES
+        profile_names: Profile names to register (default: TRAJOPT_PROFILE_NAMES)
+            Standard names: ["DEFAULT", "FREESPACE", "CARTESIAN", "RASTER", "UPRIGHT"]
 
     Returns:
         ProfileDictionary with configured TrajOpt profiles
+
+    Usage:
+        from tesseract_robotics.planning.profiles import (
+            create_trajopt_default_profiles
+        )
+
+        # Create profiles with standard names
+        profiles = create_trajopt_default_profiles()
+
+        # Or specify custom profile names
+        profiles = create_trajopt_default_profiles(
+            profile_names=["MY_PROFILE"]
+        )
     """
     from tesseract_robotics.tesseract_motion_planners_trajopt import (
         TrajOptDefaultCompositeProfile,
@@ -97,16 +130,56 @@ def create_ompl_default_profiles(
 ) -> ProfileDictionary:
     """Create OMPL profiles with sensible defaults.
 
+    OMPL (Open Motion Planning Library) provides sampling-based motion planners
+    that search the configuration space for collision-free paths. This function
+    creates profiles configured with parallel RRTConnect planners.
+
+    Profile Configuration:
+        - Parallel RRTConnect planners (one per CPU by default)
+        - Planning runs until timeout OR max_solutions found
+        - Optimization enabled to improve solution quality
+        - Simplification disabled (preserves waypoints)
+
     Args:
-        profile_names: Profile names to register. Default: OMPL_PROFILE_NAMES
+        profile_names: Profile names to register (default: OMPL_PROFILE_NAMES)
+            Relevant names: ["DEFAULT", "FREESPACE"]
+            (OMPL doesn't apply to Cartesian/Raster/Upright tasks)
         planning_time: Max planning time in seconds (default: 5.0)
+            Total time budget for all parallel planners
         max_solutions: Max solutions to find before exiting (default: 10)
+            Stops early if this many solutions found
         optimize: Use all planning time to optimize trajectory (default: True)
+            If True, continues improving solution until timeout
+            If False, stops at first solution
         simplify: Simplify trajectory after planning (default: False)
-        num_planners: Number of parallel RRTConnect planners (default: all CPUs)
+            If True, removes waypoints (may violate constraints)
+            If False, preserves all waypoints
+        num_planners: Number of parallel RRTConnect planners (default: CPU count)
+            More planners = higher chance of finding solution quickly
 
     Returns:
         ProfileDictionary with configured OMPL profiles
+
+    Usage:
+        from tesseract_robotics.planning.profiles import (
+            create_ompl_default_profiles
+        )
+
+        # Quick planning with defaults
+        profiles = create_ompl_default_profiles()
+
+        # Custom planning time and parallelism
+        profiles = create_ompl_default_profiles(
+            planning_time=10.0,
+            num_planners=8
+        )
+
+        # Fast first-solution mode
+        profiles = create_ompl_default_profiles(
+            planning_time=2.0,
+            optimize=False,
+            max_solutions=1
+        )
     """
     from tesseract_robotics.tesseract_motion_planners_ompl import (
         OMPLRealVectorPlanProfile,
@@ -143,6 +216,97 @@ def create_ompl_default_profiles(
     return profiles
 
 
+def create_ompl_planner_configurators(
+    planners: Optional[List[str]] = None,
+    num_planners: Optional[int] = None,
+    **kwargs
+) -> List:
+    """Create OMPL planner configurators with custom parameters.
+
+    Supports multiple planner types with their specific parameters:
+    - RRTConnect: range (default: 0.0 = auto)
+    - RRTstar: range, goal_bias (0.05), delay_collision_checking (True)
+    - SBL: range (default: 0.0 = auto)
+
+    Args:
+        planners: List of planner names (default: ["RRTConnect"])
+            Supported: "RRTConnect", "RRTstar", "SBL"
+        num_planners: Number of instances per planner type (default: 1)
+            Use multiple instances for parallel planning
+        **kwargs: Planner-specific parameters:
+            range: Step size for tree extension (0.0 = auto)
+            goal_bias: Probability of sampling goal (RRTstar only)
+            delay_collision_checking: Delay collision checks (RRTstar only)
+
+    Returns:
+        List of configured OMPLPlannerConfigurator instances
+
+    Example:
+        # Single RRTConnect with default settings
+        planners = create_ompl_planner_configurators()
+
+        # Multiple parallel RRTConnect planners
+        planners = create_ompl_planner_configurators(
+            planners=["RRTConnect"],
+            num_planners=4
+        )
+
+        # Mix of planner types with custom parameters
+        planners = create_ompl_planner_configurators(
+            planners=["RRTConnect", "RRTstar"],
+            num_planners=2,
+            range=0.1,
+            goal_bias=0.1,
+            delay_collision_checking=False
+        )
+    """
+    from tesseract_robotics.tesseract_motion_planners_ompl import (
+        RRTConnectConfigurator,
+        RRTstarConfigurator,
+        SBLConfigurator,
+    )
+
+    if planners is None:
+        planners = ["RRTConnect"]
+
+    if num_planners is None:
+        num_planners = 1
+
+    configurators = []
+
+    for planner_name in planners:
+        for _ in range(num_planners):
+            if planner_name == "RRTConnect":
+                cfg = RRTConnectConfigurator()
+                if "range" in kwargs:
+                    cfg.range = kwargs["range"]
+                configurators.append(cfg)
+
+            elif planner_name == "RRTstar":
+                cfg = RRTstarConfigurator()
+                if "range" in kwargs:
+                    cfg.range = kwargs["range"]
+                if "goal_bias" in kwargs:
+                    cfg.goal_bias = kwargs["goal_bias"]
+                if "delay_collision_checking" in kwargs:
+                    cfg.delay_collision_checking = kwargs["delay_collision_checking"]
+                configurators.append(cfg)
+
+            elif planner_name == "SBL":
+                cfg = SBLConfigurator()
+                if "range" in kwargs:
+                    cfg.range = kwargs["range"]
+                configurators.append(cfg)
+
+            else:
+                raise ValueError(
+                    f"Unknown planner: {planner_name}. "
+                    f"Supported: RRTConnect, RRTstar, SBL"
+                )
+
+    return configurators
+
+
 DESCARTES_DEFAULT_NAMESPACE = "DescartesMotionPlannerTask"
 
 
@@ -154,17 +318,53 @@ def create_descartes_default_profiles(
 ) -> ProfileDictionary:
     """Create Descartes profiles with sensible defaults.
 
+    Descartes is a Cartesian path planner that uses a ladder graph approach
+    to find joint configurations for Cartesian waypoints. It samples IK solutions
+    at each waypoint and finds the minimum-cost path through the graph.
+
     Creates both plan profiles (waypoint sampling) and solver profiles
     (ladder graph solver configuration).
 
+    Profile Configuration:
+        Plan Profile:
+        - enable_collision: Check vertex (waypoint) collisions
+        - enable_edge_collision: Check edge (transition) collisions
+
+        Solver Profile:
+        - num_threads: Parallel graph solver threads (default: all CPUs)
+
     Args:
-        profile_names: Profile names to register. Default: DESCARTES_PROFILE_NAMES
+        profile_names: Profile names to register (default: DESCARTES_PROFILE_NAMES)
+            Relevant names: ["DEFAULT", "CARTESIAN", "RASTER"]
+            (Descartes doesn't apply to freespace tasks)
         enable_collision: Enable vertex collision checking (default: True)
+            Checks each waypoint configuration for collisions
         enable_edge_collision: Enable edge collision checking (default: False)
-        num_threads: Number of threads for solver (default: all CPUs)
+            Checks transitions between waypoints for collisions
+            Warning: Significantly slower, use only if needed
+        num_threads: Number of threads for solver (default: CPU count)
+            More threads = faster graph search
 
     Returns:
         ProfileDictionary with configured Descartes profiles
+
+    Usage:
+        from tesseract_robotics.planning.profiles import (
+            create_descartes_default_profiles
+        )
+
+        # Standard configuration
+        profiles = create_descartes_default_profiles()
+
+        # With edge collision checking (slower but safer)
+        profiles = create_descartes_default_profiles(
+            enable_edge_collision=True
+        )
+
+        # Custom thread count
+        profiles = create_descartes_default_profiles(
+            num_threads=4
+        )
     """
     from tesseract_robotics.tesseract_motion_planners_descartes import (
         DescartesDefaultPlanProfileD,
@@ -256,17 +456,43 @@ def create_freespace_pipeline_profiles(
 ) -> ProfileDictionary:
     """Create profiles for FreespacePipeline (OMPL + TrajOpt).
 
-    FreespacePipeline uses:
-    1. OMPL for global path planning (parallel RRTConnect)
-    2. TrajOpt for trajectory optimization/smoothing
+    The FreespacePipeline is a two-stage approach for collision-free motion:
+    1. OMPL finds a feasible collision-free path (fast, approximate)
+    2. TrajOpt optimizes the path for smoothness and exact collision margins
+
+    This combines the strengths of sampling-based planning (global search)
+    and optimization-based planning (solution quality).
+
+    Pipeline Flow:
+        Input: Start/goal joint states
+        -> OMPL: Parallel RRTConnect planners find collision-free path
+        -> TrajOpt: Optimize path for smoothness + collision margins
+        -> Output: Smooth, collision-free trajectory
 
     Args:
-        profile_names: Profile names to register. Default: STANDARD_PROFILE_NAMES
-        num_planners: Number of parallel OMPL planners (default: all CPUs)
+        profile_names: Profile names to register (default: STANDARD_PROFILE_NAMES)
+            Standard names: ["DEFAULT", "FREESPACE", "CARTESIAN", "RASTER", "UPRIGHT"]
+        num_planners: Number of parallel OMPL planners (default: CPU count)
+            More planners = higher success rate for difficult problems
         planning_time: OMPL planning time in seconds (default: 5.0)
+            TrajOpt has no timeout (runs until convergence)
 
     Returns:
         ProfileDictionary with both OMPL and TrajOpt profiles
+
+    Usage:
+        from tesseract_robotics.planning.profiles import (
+            create_freespace_pipeline_profiles
+        )
+
+        # Standard freespace planning
+        profiles = create_freespace_pipeline_profiles()
+
+        # Difficult environments: more time + parallelism
+        profiles = create_freespace_pipeline_profiles(
+            planning_time=10.0,
+            num_planners=16
+        )
     """
     if profile_names is None:
         profile_names = STANDARD_PROFILE_NAMES
@@ -290,16 +516,41 @@ def create_cartesian_pipeline_profiles(
 ) -> ProfileDictionary:
     """Create profiles for CartesianPipeline (Descartes + TrajOpt).
 
-    CartesianPipeline uses:
-    1. Descartes for Cartesian path sampling (ladder graph)
-    2. TrajOpt for trajectory optimization
+    The CartesianPipeline handles motion with Cartesian (tool pose) constraints:
+    1. Descartes samples IK solutions and finds minimum-cost joint path
+    2. TrajOpt optimizes the path for smoothness and collision margins
+
+    This is ideal for tasks with tool orientation constraints (welding, painting,
+    milling, etc.) where the tool must follow a specific Cartesian path.
+
+    Pipeline Flow:
+        Input: Cartesian waypoints (tool poses)
+        -> Descartes: Sample IK solutions at each waypoint
+        -> Descartes: Find minimum-cost path through ladder graph
+        -> TrajOpt: Optimize path for smoothness + collision margins
+        -> Output: Smooth trajectory following Cartesian path
 
     Args:
-        profile_names: Profile names to register. Default: STANDARD_PROFILE_NAMES
-        num_threads: Number of Descartes solver threads (default: all CPUs)
+        profile_names: Profile names to register (default: STANDARD_PROFILE_NAMES)
+            Standard names: ["DEFAULT", "FREESPACE", "CARTESIAN", "RASTER", "UPRIGHT"]
+        num_threads: Number of Descartes solver threads (default: CPU count)
+            More threads = faster graph search for long paths
 
     Returns:
         ProfileDictionary with both Descartes and TrajOpt profiles
+
+    Usage:
+        from tesseract_robotics.planning.profiles import (
+            create_cartesian_pipeline_profiles
+        )
+
+        # Standard Cartesian planning
+        profiles = create_cartesian_pipeline_profiles()
+
+        # Custom thread count for large raster paths
+        profiles = create_cartesian_pipeline_profiles(
+            num_threads=8
+        )
     """
     if profile_names is None:
         profile_names = STANDARD_PROFILE_NAMES
@@ -314,3 +565,111 @@ def create_cartesian_pipeline_profiles(
     _add_trajopt_to_profiles(profiles, profile_names)
 
     return profiles
+
+
+# =============================================================================
+# Time Parameterization Helpers
+# =============================================================================
+
+
+def create_time_optimal_parameterization(
+    path_tolerance: float = 0.1,
+    min_angle_change: float = 0.001,
+):
+    """Create Time-Optimal Trajectory Generation (TOTG) parameterization.
+
+    TOTG finds the time-optimal trajectory that respects velocity, acceleration,
+    and jerk limits. It uses a numerical integration approach to find the fastest
+    trajectory along a given geometric path.
+
+    Args:
+        path_tolerance: Path deviation tolerance in radians (default: 0.1)
+            Controls how closely the time-parameterized trajectory follows
+            the original path. Smaller values = closer following but slower.
+        min_angle_change: Minimum angle change in radians (default: 0.001)
+            Used to detect linear segments vs curves. Smaller values = more
+            sensitive curve detection.
+
+    Returns:
+        TimeOptimalTrajectoryGeneration instance
+
+    Usage:
+        from tesseract_robotics.planning.profiles import (
+            create_time_optimal_parameterization
+        )
+        from tesseract_robotics.tesseract_time_parameterization import (
+            InstructionsTrajectory
+        )
+
+        # Create time parameterization
+        totg = create_time_optimal_parameterization(path_tolerance=0.05)
+
+        # Apply to trajectory
+        trajectory = InstructionsTrajectory(program)
+        success = totg.compute(
+            trajectory,
+            velocity_limits,
+            acceleration_limits,
+            jerk_limits
+        )
+
+    Reference:
+        Kunz & Stilman, "Time-Optimal Trajectory Generation for Path Following
+        with Bounded Acceleration and Velocity", RSS 2012
+    """
+    from tesseract_robotics.tesseract_time_parameterization import (
+        TimeOptimalTrajectoryGeneration,
+    )
+
+    return TimeOptimalTrajectoryGeneration(
+        path_tolerance=path_tolerance,
+        min_angle_change=min_angle_change
+    )
+
+
+def create_iterative_spline_parameterization(add_points: bool = True):
+    """Create Iterative Spline Parameterization (ISP).
+
+    ISP iteratively fits a spline to the trajectory while respecting velocity,
+    acceleration, and jerk limits. Generally faster than TOTG but may produce
+    slower trajectories.
+
+    Args:
+        add_points: Whether to add intermediate points (default: True)
+            If True, adds waypoints between existing ones to better satisfy
+            constraints. If False, only uses existing waypoints (faster but
+            may violate limits).
+
+    Returns:
+        IterativeSplineParameterization instance
+
+    Usage:
+        from tesseract_robotics.planning.profiles import (
+            create_iterative_spline_parameterization
+        )
+        from tesseract_robotics.tesseract_time_parameterization import (
+            InstructionsTrajectory
+        )
+
+        # Create time parameterization
+        isp = create_iterative_spline_parameterization(add_points=True)
+
+        # Apply to trajectory
+        trajectory = InstructionsTrajectory(program)
+        success = isp.compute(
+            trajectory,
+            velocity_limits,
+            acceleration_limits,
+            jerk_limits
+        )
+
+    Note:
+        ISP is typically faster to compute than TOTG, but TOTG produces
+        time-optimal trajectories. Use ISP when computation speed matters
+        more than trajectory time.
+    """
+    from tesseract_robotics.tesseract_time_parameterization import (
+        IterativeSplineParameterization,
+    )
+
+    return IterativeSplineParameterization(add_points=add_points)


### PR DESCRIPTION
## Summary
- Add `create_ompl_planner_configurators()` for RRTConnect, RRTstar, SBL
- Add `create_time_optimal_parameterization()` and `create_iterative_spline_parameterization()`
- Comprehensive docstrings for all profile helpers

## New Functions
```python
# OMPL planners
create_ompl_planner_configurators(planners=["RRTConnect"], num_each=1, **kwargs)

# Time parameterization
create_time_optimal_parameterization(path_tolerance=0.1, min_angle_change=0.001)
create_iterative_spline_parameterization(add_points=True)
```

## Test plan
- [x] 228 tests pass
- [x] Imports work correctly