### PR TITLE
feat: OSQP settings bindings + 0.34 binding updates

### DIFF
--- a/src/tesseract_robotics/trajopt_ifopt/_trajopt_ifopt.pyi
+++ b/src/tesseract_robotics/trajopt_ifopt/_trajopt_ifopt.pyi
@@ -83,8 +83,23 @@ class Differentiable(Component):
         """Get the coefficient vector"""
 
 class ConstraintSet(Differentiable):
+    def __init__(self, name: str, n_constraints: int) -> None:
+        """Create a constraint set with name and number of constraints"""
+
     def linkWithVariables(self, x: Variables) -> None:
         """Connect the constraint with the optimization variables"""
+
+    def getVariables(self) -> Variables:
+        """Get the linked optimization variables (protected in C++, exposed via trampoline)"""
+
+    def getValues(self) -> Annotated[NDArray[numpy.float64], dict(shape=(None,), order='C')]:
+        """Get the current constraint values"""
+
+    def getBounds(self) -> list[Bounds]:
+        """Get the constraint bounds"""
+
+    def getJacobian(self) -> "scipy.sparse.csr_matrix":
+        """Get the constraint Jacobian (sparse matrix)"""
 
 class Var:
     def getIdentifier(self) -> str:

--- a/src/trajopt_ifopt/trajopt_ifopt_bindings.cpp
+++ b/src/trajopt_ifopt/trajopt_ifopt_bindings.cpp
@@ -48,6 +48,37 @@
 namespace ti = trajopt_ifopt;
 namespace tc = trajopt_common;
 
+// Trampoline for ConstraintSet (enable Python subclassing)
+// Pure virtuals from Component: getValues(), getBounds()
+// Pure virtuals from Differentiable: update(), getCoefficients(), getJacobian()
+class PyConstraintSet : public ti::ConstraintSet {
+public:
+    NB_TRAMPOLINE(ti::ConstraintSet, 5);
+
+    // Expose protected getVariables() for Python access
+    using ti::ConstraintSet::getVariables;
+
+    Eigen::VectorXd getValues() const override {
+        NB_OVERRIDE_PURE(getValues);
+    }
+
+    std::vector<ti::Bounds> getBounds() const override {
+        NB_OVERRIDE_PURE(getBounds);
+    }
+
+    int update() override {
+        NB_OVERRIDE_PURE(update);
+    }
+
+    Eigen::VectorXd getCoefficients() const override {
+        NB_OVERRIDE_PURE(getCoefficients);
+    }
+
+    ti::Jacobian getJacobian() const override {
+        NB_OVERRIDE_PURE(getJacobian);
+    }
+};
+
 NB_MODULE(_trajopt_ifopt, m) {
     m.doc() = "trajopt_ifopt Python bindings - variables, constraints, and costs for IFOPT-based trajectory optimization";
 
@@ -115,10 +146,24 @@ NB_MODULE(_trajopt_ifopt, m) {
         .def("getCoefficients", &ti::Differentiable::getCoefficients,
              "Get the coefficient vector");
 
-    // ========== ConstraintSet (inherits Differentiable) ==========
-    nb::class_<ti::ConstraintSet, ti::Differentiable>(m, "ConstraintSet")
+    // ========== ConstraintSet (inherits Differentiable, with Python trampoline) ==========
+    nb::class_<ti::ConstraintSet, ti::Differentiable, PyConstraintSet>(m, "ConstraintSet")
+        .def(nb::init<std::string, int>(), "name"_a, "n_constraints"_a,
+             "Create a constraint set with name and number of constraints")
         .def("linkWithVariables", &ti::ConstraintSet::linkWithVariables, "x"_a,
-             "Connect the constraint with the optimization variables");
+             "Connect the constraint with the optimization variables")
+        .def("getVariables", &PyConstraintSet::getVariables,
+             "Get the linked optimization variables (protected in C++, exposed via trampoline)")
+        .def("getValues", &ti::ConstraintSet::getValues,
+             "Get the current constraint values")
+        .def("getBounds", &ti::ConstraintSet::getBounds,
+             "Get the constraint bounds")
+        .def("getJacobian", &ti::ConstraintSet::getJacobian,
+             "Get the constraint Jacobian (sparse matrix)")
+        .def("update", &ti::ConstraintSet::update,
+             "Recompute sizing/state for dynamic-sized components")
+        .def("getCoefficients", &ti::ConstraintSet::getCoefficients,
+             "Get the coefficient vector");
 
     // ========== Var (variable segment) ==========
     nb::class_<ti::Var>(m, "Var")

--- a/src/trajopt_ifopt/trajopt_ifopt_bindings.cpp
+++ b/src/trajopt_ifopt/trajopt_ifopt_bindings.cpp
@@ -200,6 +200,7 @@ NB_MODULE(_trajopt_ifopt, m) {
         .def("hasVar", &ti::Node::hasVar, "name"_a,
              "Check whether this node has a variable by name")
         .def("getVar", &ti::Node::getVar, "name"_a,
+             nb::rv_policy::reference_internal,
              "Get a variable by name")
         .def("getValues", &ti::Node::getValues,
              "Get all variable values as a single vector")
@@ -213,8 +214,10 @@ NB_MODULE(_trajopt_ifopt, m) {
     // ========== NodesVariables (main variable container, replaces JointPosition) ==========
     nb::class_<ti::NodesVariables, ti::Variables>(m, "NodesVariables")
         .def("getNode", &ti::NodesVariables::getNode, "opt_idx"_a,
+             nb::rv_policy::reference_internal,
              "Get node based on index")
         .def("getNodes", &ti::NodesVariables::getNodes,
+             nb::rv_policy::reference_internal,
              "Get all nodes")
         .def("getDim", &ti::NodesVariables::getDim,
              "Get the dimensions of every node");

--- a/src/trajopt_sqp/trajopt_sqp_bindings.cpp
+++ b/src/trajopt_sqp/trajopt_sqp_bindings.cpp
@@ -181,7 +181,31 @@ NB_MODULE(_trajopt_sqp, m) {
         .def("updateLowerBound", &tsqp::OSQPEigenSolver::updateLowerBound, "lower_bound"_a)
         .def("updateUpperBound", &tsqp::OSQPEigenSolver::updateUpperBound, "upper_bound"_a)
         .def("updateBounds", &tsqp::OSQPEigenSolver::updateBounds,
-             "lower_bound"_a, "upper_bound"_a);
+             "lower_bound"_a, "upper_bound"_a)
+        // OSQP settings — forwarded to solver_->settings()
+        // Defaults (set in C++ constructor): polish=true, warmStart=true,
+        // adaptiveRho=true, maxIter=8192, absTol=1e-4, relTol=1e-6
+        .def("setPolish", [](tsqp::OSQPEigenSolver& self, bool v) {
+            self.solver_->settings()->setPolish(v); }, "polish"_a,
+            "Enable solution polishing (default: true)")
+        .def("setWarmStart", [](tsqp::OSQPEigenSolver& self, bool v) {
+            self.solver_->settings()->setWarmStart(v); }, "warm_start"_a,
+            "Enable warm-starting (default: true)")
+        .def("setAdaptiveRho", [](tsqp::OSQPEigenSolver& self, bool v) {
+            self.solver_->settings()->setAdaptiveRho(v); }, "adaptive_rho"_a,
+            "Enable adaptive step size (default: true)")
+        .def("setMaxIteration", [](tsqp::OSQPEigenSolver& self, int v) {
+            self.solver_->settings()->setMaxIteration(v); }, "max_iter"_a,
+            "Max OSQP iterations per QP solve (default: 8192)")
+        .def("setAbsoluteTolerance", [](tsqp::OSQPEigenSolver& self, double v) {
+            self.solver_->settings()->setAbsoluteTolerance(v); }, "abs_tol"_a,
+            "Absolute convergence tolerance (default: 1e-4)")
+        .def("setRelativeTolerance", [](tsqp::OSQPEigenSolver& self, double v) {
+            self.solver_->settings()->setRelativeTolerance(v); }, "rel_tol"_a,
+            "Relative convergence tolerance (default: 1e-6)")
+        .def("setVerbosity", [](tsqp::OSQPEigenSolver& self, bool v) {
+            self.solver_->settings()->setVerbosity(v); }, "verbose"_a,
+            "Enable OSQP console output (default: false)");
 
     // ========== QPProblem (abstract base) ==========
 

--- a/tests/trajopt_ifopt/test_constraint_set_trampoline.py
+++ b/tests/trajopt_ifopt/test_constraint_set_trampoline.py
@@ -8,6 +8,8 @@ Verifies that Python subclasses of ConstraintSet work correctly:
 - addConstraintSet / addCostSet on IfoptProblem
 """
 
+from __future__ import annotations
+
 import numpy as np
 import scipy.sparse
 

--- a/tests/trajopt_ifopt/test_constraint_set_trampoline.py
+++ b/tests/trajopt_ifopt/test_constraint_set_trampoline.py
@@ -1,0 +1,241 @@
+"""Tests for ConstraintSet Python trampoline bindings (tesseract 0.34).
+
+Verifies that Python subclasses of ConstraintSet work correctly:
+- Constructor with (name, n_constraints)
+- Virtual method dispatch: getValues, getBounds, getJacobian, update, getCoefficients
+- linkWithVariables / getVariables integration with NodesVariables
+- Sparse Jacobian round-trip (scipy.sparse ↔ Eigen::SparseMatrix)
+- addConstraintSet / addCostSet on IfoptProblem
+"""
+
+import numpy as np
+import scipy.sparse
+
+from tesseract_robotics.trajopt_ifopt import (
+    Bounds,
+    ConstraintSet,
+    createNodesVariables,
+    toBounds,
+)
+
+# ---------------------------------------------------------------------------
+# Minimal Python subclasses for testing the trampoline
+# ---------------------------------------------------------------------------
+
+
+class SimpleConstraint(ConstraintSet):
+    """2 constraints on n_vars variables: x[0] == 1.0, x[1] == 2.0."""
+
+    def __init__(self, name: str = "simple"):
+        super().__init__(name, 2)
+        self._targets = np.array([1.0, 2.0])
+
+    def getValues(self) -> np.ndarray:
+        variables = self.getVariables()
+        if variables is None:
+            return np.zeros(2)
+        x = np.array(variables.getValues())
+        return x[:2] - self._targets
+
+    def getBounds(self) -> list:
+        return [Bounds(0.0, 0.0), Bounds(0.0, 0.0)]
+
+    def getJacobian(self):
+        variables = self.getVariables()
+        n_vars = len(variables.getValues()) if variables is not None else 2
+        return scipy.sparse.csr_matrix(([1.0, 1.0], ([0, 1], [0, 1])), shape=(2, n_vars))
+
+    def update(self) -> int:
+        return self.getRows()
+
+    def getCoefficients(self) -> np.ndarray:
+        return np.ones(2)
+
+
+class ScalarCost(ConstraintSet):
+    """Single-row cost: 0.5 * ||x||^2."""
+
+    def __init__(self, n_vars: int, name: str = "quadratic"):
+        super().__init__(name, 1)
+        self._n_vars = n_vars
+
+    def getValues(self) -> np.ndarray:
+        variables = self.getVariables()
+        if variables is None:
+            return np.zeros(1)
+        x = np.array(variables.getValues())
+        return np.array([0.5 * np.dot(x, x)])
+
+    def getBounds(self) -> list:
+        return [Bounds(0.0, 0.0)]
+
+    def getJacobian(self):
+        variables = self.getVariables()
+        if variables is None:
+            return scipy.sparse.csr_matrix((1, self._n_vars))
+        x = np.array(variables.getValues())
+        return scipy.sparse.csr_matrix(x.reshape(1, -1))
+
+    def update(self) -> int:
+        return 1
+
+    def getCoefficients(self) -> np.ndarray:
+        return np.ones(1)
+
+
+# ---------------------------------------------------------------------------
+# Helper
+# ---------------------------------------------------------------------------
+
+
+def _make_nodes_variables(n_steps: int, n_dof: int, values: np.ndarray | None = None):
+    """Create NodesVariables with given shape, optionally initialized."""
+    joint_names = [f"j{i}" for i in range(n_dof)]
+    if values is None:
+        values = np.zeros((n_steps, n_dof))
+    initial_values = [values[i].astype(np.float64) for i in range(n_steps)]
+    bounds = toBounds(np.column_stack([np.full(n_dof, -10.0), np.full(n_dof, 10.0)]))
+    return createNodesVariables("traj", joint_names, initial_values, bounds)
+
+
+# ---------------------------------------------------------------------------
+# Tests: Basic trampoline functionality
+# ---------------------------------------------------------------------------
+
+
+class TestConstraintSetTrampoline:
+    """Core trampoline: construction, virtual dispatch, properties."""
+
+    def test_construction(self):
+        """Python subclass can be constructed with (name, n_constraints)."""
+        c = SimpleConstraint("test_name")
+        assert c.getName() == "test_name"
+        assert c.getRows() == 2
+
+    def test_getValues_without_variables(self):
+        """getValues returns zeros when no variables linked."""
+        c = SimpleConstraint()
+        vals = c.getValues()
+        np.testing.assert_array_equal(vals, [0.0, 0.0])
+
+    def test_getBounds(self):
+        """getBounds returns the correct bounds list."""
+        c = SimpleConstraint()
+        bounds = c.getBounds()
+        assert len(bounds) == 2
+        assert bounds[0].getLower() == 0.0
+        assert bounds[0].getUpper() == 0.0
+
+    def test_update_returns_rows(self):
+        """update() returns the row count."""
+        c = SimpleConstraint()
+        assert c.update() == 2
+
+    def test_getCoefficients(self):
+        """getCoefficients returns ones vector."""
+        c = SimpleConstraint()
+        coeffs = c.getCoefficients()
+        np.testing.assert_array_equal(coeffs, [1.0, 1.0])
+
+
+class TestConstraintSetWithVariables:
+    """Integration: link variables -> compute values/Jacobian."""
+
+    def test_link_and_get_variables(self):
+        """linkWithVariables + getVariables round-trip."""
+        nodes = _make_nodes_variables(1, 3)
+        c = SimpleConstraint()
+        c.linkWithVariables(nodes)
+        v = c.getVariables()
+        assert v is not None
+        np.testing.assert_array_equal(v.getValues(), np.zeros(3))
+
+    def test_getValues_with_variables(self):
+        """getValues computes errors against linked variable values."""
+        vals = np.array([[1.0, 2.0, 3.0]])
+        nodes = _make_nodes_variables(1, 3, vals)
+        c = SimpleConstraint()
+        c.linkWithVariables(nodes)
+        np.testing.assert_allclose(c.getValues(), [0.0, 0.0], atol=1e-12)
+
+    def test_getValues_nonzero_error(self):
+        """getValues returns correct errors for non-target values."""
+        vals = np.array([[3.0, 5.0, 0.0]])
+        nodes = _make_nodes_variables(1, 3, vals)
+        c = SimpleConstraint()
+        c.linkWithVariables(nodes)
+        np.testing.assert_allclose(c.getValues(), [2.0, 3.0], atol=1e-12)
+
+    def test_getJacobian_sparse_type(self):
+        """getJacobian returns scipy sparse matrix."""
+        nodes = _make_nodes_variables(1, 3)
+        c = SimpleConstraint()
+        c.linkWithVariables(nodes)
+        jac = c.getJacobian()
+        assert scipy.sparse.issparse(jac)
+        assert jac.shape == (2, 3)
+
+    def test_getJacobian_values(self):
+        """getJacobian has correct sparsity pattern and values."""
+        nodes = _make_nodes_variables(1, 3)
+        c = SimpleConstraint()
+        c.linkWithVariables(nodes)
+        jac = c.getJacobian().toarray()
+        expected = np.array(
+            [
+                [1.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0],
+            ]
+        )
+        np.testing.assert_array_equal(jac, expected)
+
+    def test_scalar_cost_gradient(self):
+        """ScalarCost returns gradient = x for quadratic cost."""
+        vals = np.array([[1.0, 2.0, 3.0]])
+        nodes = _make_nodes_variables(1, 3, vals)
+        c = ScalarCost(3)
+        c.linkWithVariables(nodes)
+        np.testing.assert_allclose(c.getValues(), [7.0], atol=1e-12)
+        jac = c.getJacobian().toarray()
+        np.testing.assert_allclose(jac, [[1.0, 2.0, 3.0]], atol=1e-12)
+
+    def test_variable_mutation_propagates(self):
+        """setVariables on NodesVariables propagates to constraint getValues."""
+        nodes = _make_nodes_variables(1, 3)
+        c = SimpleConstraint()
+        c.linkWithVariables(nodes)
+        np.testing.assert_allclose(c.getValues(), [-1.0, -2.0], atol=1e-12)
+
+        nodes.setVariables(np.array([1.0, 2.0, 0.0]))
+        np.testing.assert_allclose(c.getValues(), [0.0, 0.0], atol=1e-12)
+
+
+class TestConstraintSetInIfoptProblem:
+    """Verify Python ConstraintSet works when added to IfoptProblem."""
+
+    def test_add_constraint_to_nlp(self):
+        """Python constraint can be added as constraint set."""
+        from tesseract_robotics.trajopt_sqp import IfoptProblem
+
+        nodes = _make_nodes_variables(3, 2)
+        nlp = IfoptProblem(nodes)
+        c = SimpleConstraint("test_constraint")
+        nlp.addConstraintSet(c)
+
+    def test_add_cost_to_nlp(self):
+        """Python constraint can be added as cost set."""
+        from tesseract_robotics.trajopt_sqp import IfoptProblem
+
+        nodes = _make_nodes_variables(3, 2)
+        nlp = IfoptProblem(nodes)
+        cost = ScalarCost(6, "test_cost")
+        nlp.addCostSet(cost)
+
+    def test_constraint_and_cost_together(self):
+        """Both constraint and cost can coexist on same problem."""
+        from tesseract_robotics.trajopt_sqp import IfoptProblem
+
+        nodes = _make_nodes_variables(3, 2)
+        nlp = IfoptProblem(nodes)
+        nlp.addConstraintSet(SimpleConstraint("c1"))
+        nlp.addCostSet(ScalarCost(6, "cost1"))


### PR DESCRIPTION
## Summary

- Expose OSQP solver settings in Python via `OSQPEigenSolver` lambda bindings (setPolish, setWarmStart, setAdaptiveRho, setMaxIteration, setAbsoluteTolerance, setRelativeTolerance, setVerbosity)
- Companion to the Gauss-Newton Hessian implementation in [tesseract-robotics/trajopt#545](https://github.com/tesseract-robotics/trajopt/pull/545) — OSQP tuning is needed when debugging QP solver failures with non-trivial Hessians
- Includes accumulated 0.34 binding updates: ConstraintSet Python trampoline, clone() bindings, viewer refactor, docs/CI fixes

## OSQP Settings

C++ constructor sets defaults via `setDefaultOSQPSettings()` but these were inaccessible from Python. The new methods forward to `solver_->settings()`:

| Method | Default | Description |
|--------|---------|-------------|
| `setPolish(bool)` | `True` | Solution polishing |
| `setWarmStart(bool)` | `True` | Warm-start from previous QP |
| `setAdaptiveRho(bool)` | `True` | Adaptive penalty parameter |
| `setMaxIteration(int)` | `8192` | Max OSQP iterations per QP |
| `setAbsoluteTolerance(float)` | `1e-4` | Absolute convergence tolerance |
| `setRelativeTolerance(float)` | `1e-6` | Relative convergence tolerance |
| `setVerbosity(bool)` | `False` | Enable OSQP console output |

## Test plan

- [x] Builds on macOS ARM64
- [x] Settings accessible from Python (`solver.setPolish(True)` etc.)
- [x] Existing tests pass (138/138)
- [ ] Linux CI