### PR TITLE
Windows x64 wheels for PyPI (issue #40)

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -394,6 +394,9 @@ jobs:
           - os: linux
             arch: x64
             runner: ubuntu-24.04  # needs glibc 2.39 to match build env
+          - os: macos
+            arch: arm64
+            runner: macos-14
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -31,10 +31,9 @@ jobs:
         - os: linux
           arch: x64
           runner: ubuntu-22.04
-        # macOS disabled: wheels exceed PyPI size limit
-        # - os: macos
-        #   arch: arm64
-        #   runner: macos-14
+        - os: macos
+          arch: arm64
+          runner: macos-14
     defaults:
       run:
         shell: bash -el {0}

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -20,6 +20,10 @@ on:
       - 'LICENSE'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ${{ matrix.config.runner }}
@@ -381,6 +385,212 @@ jobs:
         path: "**/*.log"
         retention-days: 2
 
+  build-win:
+    runs-on: windows-2022
+    strategy:
+      fail-fast: false
+      matrix:
+        python: ['3.9', '3.10', '3.11', '3.12']
+    defaults:
+      run:
+        shell: cmd
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        path: ws/src/tesseract_nanobind
+
+    - name: enable long paths
+      shell: pwsh
+      run: git config --global core.longpaths true
+
+    - uses: actions/setup-python@v5
+      id: setup-python
+      with:
+        python-version: ${{ matrix.python }}
+        architecture: x64
+
+    - uses: conda-incubator/setup-miniconda@v3
+      with:
+        auto-update-conda: false
+        miniforge-version: latest
+        activate-environment: osqp-env
+        channels: conda-forge
+        channel-priority: strict
+
+    - name: conda install osqp
+      shell: bash -el {0}
+      run: conda install -y osqp
+
+    - name: choco install ninja
+      run: choco install ninja -r --no-progress
+
+    - uses: johnwason/vcpkg-action@v7
+      with:
+        pkgs: >-
+          boost-dll boost-program-options boost-serialization boost-filesystem
+          boost-stacktrace boost-algorithm boost-format
+          tinyxml2 console-bridge assimp urdfdom octomap orocos-kdl pcl
+          flann jsoncpp yaml-cpp eigen3 openblas
+          fcl ompl taskflow
+          bullet3[multithreading,double-precision,rtti]
+          ccd[double-precision] gperftools
+        triplet: x64-windows-release
+        extra-args: --clean-after-build
+        token: ${{ github.token }}
+        cache-key: win-x64-python-${{ matrix.python }}
+        github-binarycache: true
+
+    - name: pip build tools
+      run: python -m pip install --upgrade pip delvewheel setuptools-scm vcstool colcon-common-extensions
+
+    - name: cache vcs repos
+      uses: actions/cache@v4
+      with:
+        path: |
+          ws/src/tesseract
+          ws/src/tesseract_planning
+          ws/src/trajopt
+          ws/src/descartes_light
+          ws/src/opw_kinematics
+          ws/src/ifopt
+          ws/src/ruckig
+          ws/src/boost_plugin_loader
+          ws/src/ros_industrial_cmake_boilerplate
+        key: vcs-win-${{ hashFiles('ws/src/tesseract_nanobind/dependencies.rosinstall') }}
+
+    - name: vcs import
+      working-directory: ws/src
+      run: vcs import --input tesseract_nanobind\dependencies.rosinstall --skip-existing
+
+    - name: patch upstream missing includes
+      shell: bash
+      working-directory: ws/src
+      run: |
+        # Same patch as Linux — tesseract_planning 0.34.0 std::runtime_error fix
+        find tesseract_planning -name '*.h' -path '*/poly/*' | xargs grep -l 'std::runtime_error' 2>/dev/null | while read f; do
+          if ! grep -q '#include <stdexcept>' "$f"; then
+            sed -i '/#include <string>/a #include <stdexcept>' "$f"
+            echo "  patched: $f"
+          fi
+        done
+
+    - name: cache colcon build
+      uses: actions/cache@v4
+      id: colcon-cache
+      with:
+        path: ws/install
+        key: colcon-v1-win-py${{ matrix.python }}-${{ hashFiles('ws/src/tesseract_nanobind/dependencies.rosinstall', 'ws/src/tesseract_nanobind/pyproject.toml') }}
+
+    - name: colcon build C++ deps
+      if: steps.colcon-cache.outputs.cache-hit != 'true'
+      working-directory: ws
+      run: |
+        call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\VsDevCmd.bat" -arch=amd64 -host_arch=amd64
+        set CXXFLAGS=%CXXFLAGS% -DEIGEN_DONT_ALIGN=1 -DEIGEN_DONT_VECTORIZE=1
+        set CONDA_ENV_DIR=%CONDA%\envs\osqp-env
+        set CMAKE_PREFIX_PATH=%CONDA_ENV_DIR%\Library;%GITHUB_WORKSPACE%\vcpkg\installed\x64-windows-release
+        set PATH=%CONDA_ENV_DIR%\Library\bin;%GITHUB_WORKSPACE%\vcpkg\installed\x64-windows-release\bin;%PATH%
+        set CC=cl
+        set CXX=cl
+        colcon build --merge-install ^
+            --packages-ignore tesseract_python tesseract_examples vhacd qpoases tesseract_nanobind tesseract_viewer_python twc_application twc_motion_planning twc_msgs twc_support ^
+            --event-handlers console_cohesion+ ^
+            --cmake-force-configure ^
+            --cmake-args -GNinja -DCMAKE_BUILD_TYPE=Release ^
+            -DCMAKE_CXX_VISIBILITY_PRESET=default -DCMAKE_VISIBILITY_INLINES_HIDDEN=OFF ^
+            -DINSTALL_OMPL=OFF -DBUILD_CLOUD_CLIENT=OFF -DBUILD_IPOPT=OFF -DBUILD_SNOPT=OFF ^
+            -DBUILD_SHARED_LIBS=ON -DTESSERACT_ENABLE_EXAMPLES=OFF -DTESSERACT_BUILD_TRAJOPT_IFOPT=ON ^
+            -DTESSERACT_ENABLE_TESTING=OFF ^
+            -DCMAKE_POLICY_VERSION_MINIMUM=3.5 ^
+            -DVCPKG_APPLOCAL_DEPS=OFF
+        if %ERRORLEVEL% GEQ 1 exit 1
+
+    - name: build nanobind wheel
+      working-directory: ws/src/tesseract_nanobind
+      run: |
+        call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\VsDevCmd.bat" -arch=amd64 -host_arch=amd64
+        set CONDA_ENV_DIR=%CONDA%\envs\osqp-env
+        set CMAKE_PREFIX_PATH=%GITHUB_WORKSPACE%\ws\install;%CONDA_ENV_DIR%\Library;%GITHUB_WORKSPACE%\vcpkg\installed\x64-windows-release
+        set PATH=%GITHUB_WORKSPACE%\ws\install\bin;%CONDA_ENV_DIR%\Library\bin;%GITHUB_WORKSPACE%\vcpkg\installed\x64-windows-release\bin;%PATH%
+        set CMAKE_ARGS=-DCMAKE_POLICY_VERSION_MINIMUM=3.5
+        pip wheel . -w dist\ --no-build-isolation
+        if %ERRORLEVEL% GEQ 1 exit 1
+
+    - name: bundle plugins then delvewheel repair
+      shell: bash
+      working-directory: ws/src/tesseract_nanobind
+      run: |
+        set -e
+        WHEEL_FILE=$(ls dist/tesseract*.whl)
+        WHEEL_DIR=$(mktemp -d)
+        unzip -q "$WHEEL_FILE" -d "$WHEEL_DIR"
+        PKG_DIR="$WHEEL_DIR/tesseract_robotics"
+
+        echo "=== Bundling plugin factory DLLs into package dir ==="
+        for plugin in \
+          tesseract_collision_bullet_factories \
+          tesseract_collision_fcl_factories \
+          tesseract_kinematics_core_factories \
+          tesseract_kinematics_kdl_factories \
+          tesseract_kinematics_opw_factory \
+          tesseract_kinematics_ur_factory \
+          tesseract_task_composer_factories \
+          tesseract_task_composer_planning_factories \
+          tesseract_task_composer_taskflow_factories; do
+          src="$GITHUB_WORKSPACE/ws/install/bin/${plugin}.dll"
+          if [[ -f "$src" ]]; then
+            cp "$src" "$PKG_DIR/"
+            echo "  Added: ${plugin}.dll"
+          else
+            echo "  MISSING: ${plugin}.dll (expected at $src)"
+          fi
+        done
+
+        echo "=== Patching task_composer_config YAMLs ==="
+        for yaml_file in "$PKG_DIR/data/task_composer_config"/*.yaml; do
+          if [[ -f "$yaml_file" ]] && grep -q '/usr/local/lib' "$yaml_file"; then
+            sed -i 's|/usr/local/lib|"@PLUGIN_PATH@"|g' "$yaml_file"
+            echo "  Patched: $(basename "$yaml_file")"
+          fi
+        done
+
+        echo "=== Stripping search_paths from tesseract_support YAMLs ==="
+        find "$PKG_DIR/data/tesseract_support" -name "*.yaml" -type f 2>/dev/null | while read yaml_file; do
+          if grep -q 'search_paths:' "$yaml_file"; then
+            sed -i '/search_paths:/d; /^[[:space:]]*- \/.*$/d' "$yaml_file"
+            echo "  Stripped: $(basename "$yaml_file")"
+          fi
+        done
+
+        # Repack (RECORD will be regenerated by delvewheel in the next step)
+        rm "$WHEEL_FILE"
+        (cd "$WHEEL_DIR" && zip -rq "$GITHUB_WORKSPACE/ws/src/tesseract_nanobind/$WHEEL_FILE" .)
+        rm -rf "$WHEEL_DIR"
+
+        echo "=== delvewheel repair ==="
+        mkdir -p wheelhouse
+        VCPKG_BIN="$GITHUB_WORKSPACE/vcpkg/installed/x64-windows-release/bin"
+        CONDA_BIN="$CONDA/envs/osqp-env/Library/bin"
+        INSTALL_BIN="$GITHUB_WORKSPACE/ws/install/bin"
+        delvewheel repair -v \
+          --add-path "$INSTALL_BIN;$VCPKG_BIN;$CONDA_BIN" \
+          -w wheelhouse "$WHEEL_FILE"
+
+        echo "=== Wheel contents ==="
+        ls -la wheelhouse/
+
+    - uses: actions/upload-artifact@v4
+      with:
+        name: python-${{ matrix.python }}-windows-x64
+        path: ws/src/tesseract_nanobind/wheelhouse/tesseract*.whl
+
+    - if: failure()
+      uses: actions/upload-artifact@v4
+      with:
+        name: build-logs-windows-x64-py${{ matrix.python }}
+        path: "**/*.log"
+        retention-days: 2
+
   test-wheel:
     needs: build
     runs-on: ${{ matrix.config.runner }}
@@ -464,8 +674,74 @@ jobs:
             --ignore=tests/benchmarks \
             -v --tb=short
 
+  test-wheel-win:
+    needs: build-win
+    runs-on: windows-2022
+    # py3.9 has intermittent GC segfaults with pytest-xdist; don't block CI (matches Linux/macOS policy)
+    continue-on-error: ${{ matrix.python == '3.9' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        python: ['3.9', '3.12']
+    defaults:
+      run:
+        shell: cmd
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        path: tesseract_nanobind
+
+    - uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python }}
+        architecture: x64
+
+    - uses: actions/download-artifact@v4
+      with:
+        name: python-${{ matrix.python }}-windows-x64
+        path: wheelhouse
+
+    - name: install wheel in clean venv
+      run: |
+        python -m venv test_env
+        call test_env\Scripts\activate.bat
+        python -m pip install --upgrade pip
+        for %%W in (wheelhouse\tesseract*.whl) do python -m pip install %%W
+        python -m pip install pytest pytest-xdist scipy
+
+    - name: smoke test
+      run: |
+        call test_env\Scripts\activate.bat
+        python -c "import tesseract_robotics; print('Version:', tesseract_robotics.__version__)"
+        python -c "from tesseract_robotics import tesseract_common, tesseract_geometry, tesseract_scene_graph"
+        python -c "from tesseract_robotics import trajopt_ifopt; print('trajopt_ifopt OK')"
+
+    - name: debug DLLs on failure
+      if: failure()
+      shell: bash
+      run: |
+        source test_env/Scripts/activate
+        PKG_DIR=$(python -c "import tesseract_robotics, pathlib; print(pathlib.Path(tesseract_robotics.__file__).parent)")
+        echo "=== Package dir ==="
+        ls "$PKG_DIR" 2>/dev/null || true
+        echo "=== Sibling .libs dir ==="
+        ls "$PKG_DIR/../tesseract_robotics.libs" 2>/dev/null || echo "none"
+        echo "=== DLLs under site-packages ==="
+        find "$PKG_DIR" -name "*.dll" 2>/dev/null | head -30
+
+    - name: run tests
+      run: |
+        call test_env\Scripts\activate.bat
+        cd tesseract_nanobind
+        python -m pytest tests -n auto ^
+          --ignore=tests\tesseract_time_parameterization ^
+          --ignore=tests\examples ^
+          --ignore=tests\tesseract_kinematics ^
+          --ignore=tests\benchmarks ^
+          -v --tb=short
+
   publish:
-    needs: [build, test-wheel]
+    needs: [build, build-win, test-wheel, test-wheel-win]
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     environment: pypi

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -474,7 +474,7 @@ jobs:
     steps:
     - uses: actions/download-artifact@v4
       with:
-        pattern: python-*-linux-*  # TODO: change back to python-* after PyPI size limit increase
+        pattern: python-*
         merge-multiple: true
         path: dist/
     - name: List wheels

--- a/docs/superpowers/plans/2026-04-22-macos-wheels-to-pypi.md
+++ b/docs/superpowers/plans/2026-04-22-macos-wheels-to-pypi.md
@@ -1,0 +1,540 @@
+# macOS wheels to PyPI Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Publish macOS arm64 wheels to PyPI on tagged releases alongside the existing Linux x64 wheels.
+
+**Architecture:** Three surgical edits to `.github/workflows/wheels.yml` — re-enable macOS in the `build` matrix, add macOS to the `test-wheel` matrix, and open the `publish` job's artifact download filter to all platforms. All supporting macOS steps (brew, colcon, delocate, plugin-bundle, YAML patch) already exist in the workflow and are guarded by `if: matrix.config.os == 'macos'`. No application code changes.
+
+**Tech Stack:** GitHub Actions, pixi, colcon, pip, delocate, `pypa/gh-action-pypi-publish` (Trusted Publishing via OIDC).
+
+**Related spec:** `docs/superpowers/specs/2026-04-22-macos-wheels-to-pypi-design.md` (commit `aeb684e`).
+
+**Branch:** `jf/macos-wheels-to-pypi` (already created from main at `aeb684e`).
+
+---
+
+## File Structure
+
+Only one file is modified: `.github/workflows/wheels.yml`. Three distinct edits at different locations:
+
+- Lines 28–37 — `build.strategy.matrix.config` (re-enable macOS entry)
+- Lines 390–397 — `test-wheel.strategy.matrix.config` (add macOS entry)
+- Lines 473–477 — `publish.steps[download-artifact].with.pattern` (drop `-linux-*` suffix, remove TODO)
+
+Each edit becomes its own commit so the PR history shows intent cleanly and any edit can be reverted independently.
+
+---
+
+## Task 1: Pre-flight — verify clean starting state
+
+**Files:**
+- Read: `.github/workflows/wheels.yml`
+
+- [ ] **Step 1: Confirm branch and working tree**
+
+Run:
+```bash
+git branch --show-current
+git status
+```
+Expected:
+```
+jf/macos-wheels-to-pypi
+On branch jf/macos-wheels-to-pypi
+...
+nothing added to commit but untracked files present (use "git add" to track)
+```
+(The one untracked file `docs/plans/2026-02-18-viewer-submodule.md` is unrelated and stays untracked.)
+
+- [ ] **Step 2: Confirm current HEAD matches the spec commit**
+
+Run:
+```bash
+git log --oneline -1
+```
+Expected: `aeb684e docs: spec for macos wheels to pypi`
+
+- [ ] **Step 3: Verify the workflow YAML parses**
+
+Run:
+```bash
+python -c "import yaml; yaml.safe_load(open('.github/workflows/wheels.yml'))"
+```
+Expected: no output, exit 0. This confirms the file is currently well-formed before editing.
+
+---
+
+## Task 2: Re-enable macOS in the `build` matrix
+
+**Files:**
+- Modify: `.github/workflows/wheels.yml` (lines 34–37)
+
+- [ ] **Step 1: Apply the edit**
+
+Replace this block (lines 34–37):
+```yaml
+        # macOS disabled: wheels exceed PyPI size limit
+        # - os: macos
+        #   arch: arm64
+        #   runner: macos-14
+```
+with:
+```yaml
+        - os: macos
+          arch: arm64
+          runner: macos-14
+```
+
+No other changes in the `build` job. All macOS-conditional steps (lines 46–49 brew, 93–120 colcon, 142–150 pip wheel, 160–166 delocate, 167–213 plugin-bundle + YAML patch) are already present and guarded.
+
+- [ ] **Step 2: Verify YAML still parses**
+
+Run:
+```bash
+python -c "import yaml; d = yaml.safe_load(open('.github/workflows/wheels.yml')); print([c for c in d['jobs']['build']['strategy']['matrix']['config']])"
+```
+Expected output (one line, four entries after product with Python versions is not relevant — we just want both os entries):
+```
+[{'os': 'linux', 'arch': 'x64', 'runner': 'ubuntu-22.04'}, {'os': 'macos', 'arch': 'arm64', 'runner': 'macos-14'}]
+```
+
+- [ ] **Step 3: Commit**
+
+Run:
+```bash
+git add .github/workflows/wheels.yml
+git -c user.name="Jelle Feringa" -c user.email="jelleferinga@gmail.com" \
+  commit --author="Jelle Feringa <jelleferinga@gmail.com>" \
+  -m "ci: re-enable macos arm64 in build matrix"
+```
+
+Expected: single-file commit, pre-commit hooks pass (ruff skipped — not a Python file).
+
+---
+
+## Task 3: Add macOS to the `test-wheel` matrix
+
+**Files:**
+- Modify: `.github/workflows/wheels.yml` (lines 392–397)
+
+- [ ] **Step 1: Apply the edit**
+
+Replace this block (lines 392–397):
+```yaml
+      matrix:
+        python: ['3.9', '3.12']
+        config:
+          - os: linux
+            arch: x64
+            runner: ubuntu-24.04  # needs glibc 2.39 to match build env
+```
+with:
+```yaml
+      matrix:
+        python: ['3.9', '3.12']
+        config:
+          - os: linux
+            arch: x64
+            runner: ubuntu-24.04  # needs glibc 2.39 to match build env
+          - os: macos
+            arch: arm64
+            runner: macos-14
+```
+
+No other changes in `test-wheel`. The existing steps (checkout, setup-python, download-artifact, install wheel in venv, smoke test, full pytest) are shell-portable and run on macOS without modification. The artifact name `python-${{ matrix.python }}-${{ matrix.config.os }}-${{ matrix.config.arch }}` already resolves correctly for macOS because Task 2 produced a `python-3.12-macos-arm64` artifact (and likewise for 3.9).
+
+- [ ] **Step 2: Verify YAML still parses**
+
+Run:
+```bash
+python -c "import yaml; d = yaml.safe_load(open('.github/workflows/wheels.yml')); print([c for c in d['jobs']['test-wheel']['strategy']['matrix']['config']])"
+```
+Expected:
+```
+[{'os': 'linux', 'arch': 'x64', 'runner': 'ubuntu-24.04'}, {'os': 'macos', 'arch': 'arm64', 'runner': 'macos-14'}]
+```
+
+- [ ] **Step 3: Commit**
+
+Run:
+```bash
+git add .github/workflows/wheels.yml
+git -c user.name="Jelle Feringa" -c user.email="jelleferinga@gmail.com" \
+  commit --author="Jelle Feringa <jelleferinga@gmail.com>" \
+  -m "ci: add macos arm64 to test-wheel matrix"
+```
+
+---
+
+## Task 4: Open `publish` download filter to all platforms
+
+**Files:**
+- Modify: `.github/workflows/wheels.yml` (line 475)
+
+- [ ] **Step 1: Apply the edit**
+
+Replace line 475:
+```yaml
+        pattern: python-*-linux-*  # TODO: change back to python-* after PyPI size limit increase
+```
+with:
+```yaml
+        pattern: python-*
+```
+
+This drops the linux-only restriction and the now-obsolete TODO.
+
+- [ ] **Step 2: Verify YAML still parses and the pattern updated**
+
+Run:
+```bash
+python -c "import yaml; d = yaml.safe_load(open('.github/workflows/wheels.yml')); print(d['jobs']['publish']['steps'][0]['with']['pattern'])"
+```
+Expected:
+```
+python-*
+```
+
+- [ ] **Step 3: Confirm no stale TODO references remain**
+
+Run:
+```bash
+grep -n "python-\*-linux-\*\|TODO.*size limit" .github/workflows/wheels.yml || echo "clean"
+```
+Expected: `clean`
+
+- [ ] **Step 4: Commit**
+
+Run:
+```bash
+git add .github/workflows/wheels.yml
+git -c user.name="Jelle Feringa" -c user.email="jelleferinga@gmail.com" \
+  commit --author="Jelle Feringa <jelleferinga@gmail.com>" \
+  -m "ci: publish macos wheels to pypi (drop linux-only filter)"
+```
+
+---
+
+## Task 5: Push branch + open PR
+
+**Files:**
+- None (git + gh operations)
+
+- [ ] **Step 1: Push branch**
+
+Run:
+```bash
+git push -u origin jf/macos-wheels-to-pypi
+```
+Expected: remote branch created, tracking set up.
+
+- [ ] **Step 2: Verify recent commits on the branch**
+
+Run:
+```bash
+git log --oneline origin/main..HEAD
+```
+Expected (order newest first):
+```
+<sha> ci: publish macos wheels to pypi (drop linux-only filter)
+<sha> ci: add macos arm64 to test-wheel matrix
+<sha> ci: re-enable macos arm64 in build matrix
+aeb684e docs: spec for macos wheels to pypi
+```
+
+- [ ] **Step 3: Open PR**
+
+Run (explicit `--repo` per project convention):
+```bash
+gh pr create --repo tesseract-robotics/tesseract_nanobind \
+  --base main --head jf/macos-wheels-to-pypi \
+  --title "ci: publish macos arm64 wheels to pypi" \
+  --body "$(cat <<'EOF'
+## Summary
+
+- Re-enable macOS arm64 in the `build` matrix (py3.9–3.12)
+- Add macOS arm64 to the `test-wheel` matrix (py3.9, 3.12)
+- Open `publish` download filter from `python-*-linux-*` to `python-*`
+
+Unblocked by PyPI filesize limit increase to 250 MB.
+
+Spec: `docs/superpowers/specs/2026-04-22-macos-wheels-to-pypi-design.md`
+
+## Test plan
+
+- [ ] PR CI green on all `build` jobs (linux + macos, py3.9/3.10/3.11/3.12)
+- [ ] PR CI green on all `test-wheel` jobs (linux + macos, py3.9/3.12)
+- [ ] `python-3.12-macos-arm64` artifact extracts correctly: contains 9 plugin factories in `.dylibs/`, task composer YAMLs contain `@PLUGIN_PATH@`
+- [ ] Artifact size < 250 MB
+EOF
+)"
+```
+
+Expected: PR URL printed. Capture it for the next task.
+
+- [ ] **Step 4: Confirm PR targets the correct repo**
+
+Read the URL printed in the previous step. It MUST start with `https://github.com/tesseract-robotics/tesseract_nanobind/pull/`. If it points to a fork or different repo, close the PR and retry with the correct `--repo` flag.
+
+---
+
+## Task 6: Monitor PR CI and diagnose failures
+
+**Files:**
+- None (observation)
+
+- [ ] **Step 1: Watch build jobs**
+
+Run:
+```bash
+gh pr checks --repo tesseract-robotics/tesseract_nanobind --watch
+```
+This blocks until all checks complete. Build jobs typically take 15–25 min (cold cache) or 5–10 min (warm cache).
+
+- [ ] **Step 2: Classify the outcome**
+
+If all checks are green, skip to Task 7.
+
+If any `build` job fails:
+- macOS colcon build failure: most likely missing brew dep or an upstream cmake change. Check `Logs` → find the first cmake/compiler error. Fix in the `brew install` or `colcon build` step of the workflow. Commit fix with `ci: fix macos <specific issue>`.
+- macOS delocate failure: usually a dylib not found on `delocate-path -L` paths. Add the missing path or copy the dylib explicitly in the plugin-bundle step.
+- macOS plugin-bundle failure: a dylib is missing from `ws/install/lib`. Likely the colcon build didn't produce it — check colcon `--packages-ignore` list vs the `PLUGINS` array.
+
+If any `test-wheel` job fails:
+- Import error: usually rpath or `DYLD_LIBRARY_PATH` issue. Check the `debug libs` step output for missing deps reported by `otool -L` (macOS) or `ldd` (linux).
+- pytest failure specific to macOS: add a platform-conditional `--ignore=` for the failing test directory in `run full tests`. Document *why* in the commit message.
+
+- [ ] **Step 3: Apply any fixes and push**
+
+If fixes are needed, commit with clear messages (`ci: fix macos <thing>`) and push. Re-run this task until green.
+
+---
+
+## Task 7: Inspect the macOS wheel artifact
+
+**Files:**
+- None (artifact inspection)
+
+- [ ] **Step 1: Download the py3.12 macOS artifact from the PR run**
+
+Get the PR run ID:
+```bash
+RUN_ID=$(gh run list --repo tesseract-robotics/tesseract_nanobind \
+  --workflow wheels.yml --branch jf/macos-wheels-to-pypi \
+  --limit 1 --json databaseId --jq '.[0].databaseId')
+echo "Run: $RUN_ID"
+```
+
+Download the artifact:
+```bash
+mkdir -p /tmp/macos-wheel-inspect && cd /tmp/macos-wheel-inspect
+gh run download "$RUN_ID" --repo tesseract-robotics/tesseract_nanobind \
+  --name python-3.12-macos-arm64
+ls -lah
+```
+Expected: one `.whl` file. Note its size.
+
+- [ ] **Step 2: Verify size is under 250 MB**
+
+Run:
+```bash
+WHEEL=$(ls /tmp/macos-wheel-inspect/tesseract*.whl)
+SIZE_MB=$(stat -f '%z' "$WHEEL" | awk '{printf "%.1f", $1/1048576}')
+echo "Wheel size: $SIZE_MB MB"
+[[ $(echo "$SIZE_MB < 250" | bc) -eq 1 ]] && echo "OK (< 250 MB)" || echo "FAIL (>= 250 MB)"
+```
+Expected: `OK (< 250 MB)`. If not, this plan stops and the spec's "shrink the wheel" work becomes necessary.
+
+- [ ] **Step 3: Verify the 9 plugin factories are bundled**
+
+Run:
+```bash
+cd /tmp/macos-wheel-inspect
+mkdir extract && unzip -q tesseract*.whl -d extract
+ls extract/tesseract_robotics/.dylibs/ | grep -E 'factories|factory' | sort
+```
+Expected output (9 files):
+```
+libtesseract_collision_bullet_factories.dylib
+libtesseract_collision_fcl_factories.dylib
+libtesseract_kinematics_core_factories.dylib
+libtesseract_kinematics_kdl_factories.dylib
+libtesseract_kinematics_opw_factory.dylib
+libtesseract_kinematics_ur_factory.dylib
+libtesseract_task_composer_factories.dylib
+libtesseract_task_composer_planning_factories.dylib
+libtesseract_task_composer_taskflow_factories.dylib
+```
+
+- [ ] **Step 4: Verify task composer YAMLs are patched**
+
+Run:
+```bash
+grep -l '@PLUGIN_PATH@' extract/tesseract_robotics/data/task_composer_config/*.yaml | wc -l
+grep -l '/usr/local/lib' extract/tesseract_robotics/data/task_composer_config/*.yaml | wc -l
+```
+Expected: non-zero count for `@PLUGIN_PATH@`, zero count for `/usr/local/lib`.
+
+- [ ] **Step 5: Cleanup inspection artifacts**
+
+Run:
+```bash
+rm -rf /tmp/macos-wheel-inspect
+```
+
+---
+
+## Task 8: Merge PR with linear history
+
+**Files:**
+- None (git + gh operations)
+
+- [ ] **Step 1: Confirm all CI checks green**
+
+Run:
+```bash
+gh pr checks --repo tesseract-robotics/tesseract_nanobind
+```
+Expected: all checks `pass`.
+
+- [ ] **Step 2: Rebase onto latest main (in case main advanced)**
+
+Run:
+```bash
+git fetch origin main
+git rebase origin/main
+```
+If conflicts arise: resolve them — `wheels.yml` is the only file this PR touches, so conflicts would be with other `wheels.yml` edits landed on main. Resolve by keeping both sets of changes. After resolution: `git rebase --continue`, then `git push --force-with-lease` (confirm with user before force-pushing).
+
+- [ ] **Step 3: Merge PR via rebase (linear history)**
+
+Run:
+```bash
+gh pr merge --repo tesseract-robotics/tesseract_nanobind --rebase --delete-branch
+```
+Expected: PR merged, local `jf/macos-wheels-to-pypi` branch auto-deleted on GitHub, no merge commit.
+
+- [ ] **Step 4: Sync local main**
+
+Run:
+```bash
+git checkout main
+git pull --ff-only
+git branch -d jf/macos-wheels-to-pypi
+```
+
+---
+
+## Task 9: Post-merge validation on main
+
+**Files:**
+- None (CI operation)
+
+- [ ] **Step 1: Dispatch the workflow on main**
+
+Run:
+```bash
+gh workflow run wheels.yml --repo tesseract-robotics/tesseract_nanobind --ref main
+```
+Expected: workflow queued.
+
+- [ ] **Step 2: Watch the dispatch run**
+
+Run:
+```bash
+sleep 10
+RUN_ID=$(gh run list --repo tesseract-robotics/tesseract_nanobind \
+  --workflow wheels.yml --event workflow_dispatch \
+  --limit 1 --json databaseId --jq '.[0].databaseId')
+gh run watch "$RUN_ID" --repo tesseract-robotics/tesseract_nanobind
+```
+Expected: all `build` and `test-wheel` jobs green. `publish` does NOT run because it's gated on `refs/tags/`.
+
+- [ ] **Step 3: Confirm no regressions vs PR run**
+
+If the dispatch run passes, we are release-ready. If it fails where the PR run passed, something on main differs from the PR branch — investigate before tagging.
+
+---
+
+## Task 10: Cut release tag and verify PyPI publish
+
+**Files:**
+- None (git + PyPI)
+
+- [ ] **Step 1: Pick the next version**
+
+Run:
+```bash
+git tag --sort=-creatordate | head -3
+```
+Current tag is `0.34.1.0`. The next patch tag consistent with the 4-segment trigger pattern is `0.34.1.1`. Confirm with user before tagging.
+
+- [ ] **Step 2: Create and push the tag**
+
+Run:
+```bash
+git tag -a 0.34.1.1 -m "release: macos arm64 wheels"
+git push origin 0.34.1.1
+```
+Expected: tag pushed; `wheels.yml` tag trigger fires.
+
+- [ ] **Step 3: Watch the tag-triggered run**
+
+Run:
+```bash
+sleep 10
+RUN_ID=$(gh run list --repo tesseract-robotics/tesseract_nanobind \
+  --workflow wheels.yml --event push \
+  --limit 1 --json databaseId --jq '.[0].databaseId')
+gh run watch "$RUN_ID" --repo tesseract-robotics/tesseract_nanobind
+```
+Expected: `build`, `test-wheel`, AND `publish` jobs all green. The `publish` job runs because the ref starts with `refs/tags/`.
+
+- [ ] **Step 4: Verify wheels on PyPI**
+
+Run:
+```bash
+curl -s https://pypi.org/pypi/tesseract-robotics-nanobind/0.34.1.1/json \
+  | python3 -c "import sys, json; d = json.load(sys.stdin); [print(f\"{f['filename']:70s} {f['size']/1e6:7.1f} MB\") for f in d['urls']]"
+```
+Expected: Linux and macOS wheels for each Python version listed (8 total: 4 linux + 4 macos).
+
+- [ ] **Step 5: Smoke test installed wheel on a macOS arm64 machine**
+
+Run in a clean environment:
+```bash
+python3.12 -m venv /tmp/tesseract-pypi-test
+source /tmp/tesseract-pypi-test/bin/activate
+pip install --no-cache-dir tesseract-robotics-nanobind==0.34.1.1
+tesseract_nanobind_selftest
+python -c "from tesseract_robotics import tesseract_common, tesseract_geometry, tesseract_scene_graph; print('OK')"
+deactivate
+rm -rf /tmp/tesseract-pypi-test
+```
+Expected: selftest passes, imports succeed.
+
+---
+
+## Rollback
+
+If anything above fails catastrophically AND a broken wheel reaches PyPI, follow the spec's rollback procedure:
+
+1. Yank the broken release via PyPI web UI (Manage → Release → Yank).
+2. Revert the three CI commits on main (`git revert <sha>` for each of the three `ci:` commits from this plan).
+3. Cut a new patch version to unblock future publishes.
+
+If CI fails before tagging (Tasks 6–9), no rollback needed — just fix forward on the branch or abandon the PR.
+
+---
+
+## Self-review notes
+
+Spec coverage check passes:
+- Spec §"Scope → In scope" bullet 1 (enable macOS arm64 in build matrix) → Task 2
+- Spec §"Scope → In scope" bullet 2 (add macOS to test-wheel) → Task 3
+- Spec §"Scope → In scope" bullet 3 (flip publish filter) → Task 4
+- Spec §"Scope → In scope" bullet 4 (remove TODO) → Task 4 (Step 1 drops the comment along with the filter change; Step 3 grep confirms)
+- Spec §"Validation plan" steps 1–6 → Tasks 5, 6, 7, 8, 9, 10
+
+No placeholders. Each commit-producing task shows exact edits and exact commit commands. Artifact inspection commands are concrete. The only genuinely unknown branch (CI failure diagnosis in Task 6, Step 2) provides three labelled failure modes with targeted fixes rather than hand-waving.

--- a/docs/superpowers/specs/2026-04-22-windows-wheels-to-pypi-design.md
+++ b/docs/superpowers/specs/2026-04-22-windows-wheels-to-pypi-design.md
@@ -1,0 +1,165 @@
+# Windows wheels to PyPI — Design
+
+**Date:** 2026-04-22
+**Status:** Approved for implementation
+**Owner:** Jelle Feringa
+**Issue:** [#40 — Windows build (pypi)](https://github.com/tesseract-robotics/tesseract_nanobind/issues/40)
+**Branch:** `gh-40-windows-build` (stacked on `jf/macos-wheels-to-pypi`)
+
+## Context
+
+`wheels.yml` currently builds Linux x64 and macOS arm64 via a shared `build` job (both driven by pixi), gates on a shared `test-wheel`, and publishes on tag via `pattern: python-*`. The macOS path was re-enabled by PR `jf/macos-wheels-to-pypi`, which also dropped the former `linux-only` artifact filter. No Windows path exists.
+
+This work adds Windows x64 wheels to the same PyPI release alongside Linux and macOS.
+
+**Why this is stacked on the macOS PR:** both PRs modify the `publish` job's `needs:` list. Stacking avoids a merge conflict on that line and lets the Windows PR inherit the already-corrected `pattern: python-*` filter for free. If macOS takes longer than expected, we rebase to `main` and reinstate the filter change in this PR.
+
+## Goal
+
+Publish Windows x64 wheels to PyPI on tagged releases for Python 3.9–3.12, gated by the same build → test-wheel → publish flow as Linux/macOS. Full feature parity with Linux/macOS: `trajopt_ifopt` and `trajopt_sqp` enabled.
+
+## Scope
+
+**In scope:**
+- New `build-win` job on `windows-2022`, Python 3.9–3.12 matrix, x64.
+- New `test-wheel-win` job on `windows-2022`, Python 3.9 + 3.12 (bookends, matching Linux/macOS test coverage).
+- Extend `publish.needs` from `[build, test-wheel]` to `[build, build-win, test-wheel, test-wheel-win]`.
+- Windows branch in `src/tesseract_robotics/__init__.py` for runtime DLL resolution.
+
+**Out of scope:**
+- **Local Windows developer experience** (pixi-on-Windows, Windows build scripts, IDE setup). Separate follow-up effort. A Windows contributor cloning the repo today gets the same "build via CI or on Linux/macOS" expectation — unchanged by this PR.
+- **Windows ARM64 / Windows-on-ARM wheels.** Hosted ARM Windows runners are in preview; demand is low.
+- **Python 3.13 support.** Requires cross-platform bump; separate PR across all three platforms.
+- **Matrix-based Windows integration** (adding Windows as a matrix entry on the existing `build` job). Rejected: Windows toolchain is fundamentally different from Linux/macOS (vcpkg + conda-forge + MSVC + VsDevCmd.bat + cmd/bash shell mix vs. pixi-everywhere on Linux/macOS). A matrix split would require `if: matrix.config.os == 'windows'` guards on every step and a mixed-shell setup that's harder to read than two parallel jobs.
+- **Documentation updates.** Deferred to a follow-up PR after Windows CI has been green on `main` for a stable period — premature docs create broken promises.
+
+## Design
+
+### Architecture after this PR
+
+```
+.github/workflows/wheels.yml
+├── build              (existing, Linux + macOS matrix, pixi-driven)
+├── build-win          (NEW, Windows x64, vcpkg + conda-forge hybrid)
+├── test-wheel         (existing, Linux + macOS matrix)
+├── test-wheel-win     (NEW, Windows bookend matrix)
+└── publish            (existing — only `needs:` list extended)
+```
+
+### Hybrid C++ dependency sourcing on Windows
+
+Two package managers, each chosen for what it handles best on win-64:
+
+- **vcpkg** (via `johnwason/vcpkg-action@v7`, triplet `x64-windows-release`) supplies the bulk: `boost-*`, `eigen3`, `tinyxml2`, `console-bridge`, `assimp`, `urdfdom`, `octomap`, `orocos-kdl`, `pcl`, `flann`, `jsoncpp`, `yaml-cpp`, `openblas`, `fcl`, `ompl`, `taskflow`, `bullet3[multithreading,double-precision,rtti]`, `ccd[double-precision]`, `gperftools`. Exact mirror of upstream `tesseract_python`'s Windows build — proven and well-tuned.
+- **conda-forge** (via `conda-incubator/setup-miniconda@v3`) supplies `osqp` only. OSQP is the solver backend for both `trajopt_sqp` (direct dep) and `ifopt` (built from source via our rosinstall, same as Linux/macOS). conda-forge's `osqp` is a clean C-API binary with small ABI surface; vcpkg's port has known CMake-config friction we avoid by sourcing elsewhere.
+
+`CMAKE_PREFIX_PATH` includes both `${VCPKG}/installed/x64-windows-release` and `%CONDA_PREFIX%\Library` — the `\Library` suffix is non-negotiable on conda-for-Windows (CMake configs are under `Library/lib/cmake`, not the env root).
+
+`ifopt` builds from source via `dependencies.rosinstall` — consistent with Linux/macOS, no change to the rosinstall.
+
+### Toolchain
+
+- **Runner:** `windows-2022` (VS 2022 Enterprise pre-installed).
+- **Compiler:** `cl` from VS 2022, activated via `VsDevCmd.bat -arch=amd64 -host_arch=amd64` in each `cmd` step that invokes the compiler.
+- **Generator:** `Ninja` (installed via `choco install ninja`).
+- **Mandatory flags:** `-DEIGEN_DONT_ALIGN=1 -DEIGEN_DONT_VECTORIZE=1` in `CXXFLAGS`. Without these, Eigen alignment assumptions cross MSVC ABI boundaries and segfault at runtime. Non-negotiable Windows landmine.
+- **Other flags matching Linux/macOS:** `-DCMAKE_CXX_VISIBILITY_PRESET=default`, `-DCMAKE_VISIBILITY_INLINES_HIDDEN=OFF` (RTTI typeinfo across DLL boundaries), `-DCMAKE_BUILD_TYPE=Release`, `-DBUILD_SHARED_LIBS=ON`, `-DCMAKE_POLICY_VERSION_MINIMUM=3.5`, `-DTESSERACT_BUILD_TRAJOPT_IFOPT=ON`, `-DVCPKG_APPLOCAL_DEPS=OFF`, `-DBUILD_IPOPT=OFF`, `-DBUILD_SNOPT=OFF`, `-DINSTALL_OMPL=OFF`, `-DTESSERACT_ENABLE_TESTING=OFF`, `-DTESSERACT_ENABLE_EXAMPLES=OFF`.
+- **Shell mix:** `cmd` for any step that invokes `VsDevCmd.bat` or the colcon/cmake build (so the VS env stays active); `bash` (Git-for-Windows, pre-installed) for sed/zip/mv-style wheel-repack steps where POSIX utilities are cleaner.
+
+### Wheel packaging
+
+1. `pip wheel . -w dist\ --no-build-isolation` with `CMAKE_PREFIX_PATH` pointing at `ws/install`, vcpkg, and the conda env (in that order of precedence).
+2. **Bundle plugin-factory DLLs before `delvewheel`**, not after. Plugin factories are `dlopen`-loaded at runtime, invisible to `delvewheel`'s static dep scan. Dropping them into the wheel's package dir first lets `delvewheel` resolve their transitive DLL deps in the same repair pass. Mirrors the Linux "bundle plugins → auditwheel" order.
+3. `delvewheel repair --add-path "<ws/install/bin>;<vcpkg/bin>;<conda/Library/bin>" -w wheelhouse dist\*.whl` — pulls transitive DLL deps into `tesseract_robotics.libs/` (sibling dir to the package) and injects the `_delvewheel_init_patch.py` hook that Python needs for `os.add_dll_directory()`.
+4. Patch `data/task_composer_config/*.yaml` — replace `/usr/local/lib` with `@PLUGIN_PATH@` so `__init__.py` can resolve at runtime. Same sed expression as Linux/macOS.
+5. Strip `search_paths:` from `data/tesseract_support/*.yaml` — forces env-var-driven plugin search so bundled plugins are discovered correctly at runtime.
+
+### Plugin-factory DLL naming
+
+On Windows, CMake emits `foo.dll` (no `lib` prefix) for `MODULE`/`SHARED` libraries — unlike `libfoo.so` on Linux or `libfoo.dylib` on macOS. The plugin-bundling loop references bare names: `tesseract_collision_bullet_factories.dll`, `tesseract_kinematics_kdl_factories.dll`, etc.
+
+### Runtime DLL loading (`__init__.py` Windows branch)
+
+Python 3.8+ on Windows requires `os.add_dll_directory()` for DLL resolution outside `sys.prefix\Library\bin` — the old `PATH`-based mechanism was removed for security. `src/tesseract_robotics/__init__.py` gets a new `sys.platform == 'win32'` branch that:
+
+1. Resolves `@PLUGIN_PATH@` in the runtime YAML rewrite to `<package_parent>\tesseract_robotics.libs` (delvewheel's output dir), NOT `.libs` or `.dylibs`.
+2. Calls `os.add_dll_directory()` on both:
+   - `<package_parent>\tesseract_robotics.libs` — for delvewheel-bundled deps.
+   - The package dir itself — for plugin-factory DLLs bundled alongside the Python extensions.
+3. **Runs BEFORE any extension import.** The current `__init__.py` imports `_tesseract_common` early; the Windows branch must come first.
+4. Uses `os.pathsep` for any `TESSERACT_*_PLUGIN_DIRECTORIES` env var assembly (Windows uses `;`, POSIX uses `:`).
+
+### Publish job change
+
+```yaml
+publish:
+  needs: [build, build-win, test-wheel, test-wheel-win]   # was: [build, test-wheel]
+  # pattern: python-* stays unchanged (already set by macOS PR)
+  # everything else unchanged
+```
+
+One-line change. The artifact filter is already correct.
+
+## Files changed
+
+| File | Change | Approx. size |
+|------|--------|--------------|
+| `.github/workflows/wheels.yml` | Add `build-win` job (4-version matrix). Add `test-wheel-win` job (bookend 2-version matrix: 3.9, 3.12). Extend `publish.needs` to include `build-win` and `test-wheel-win`. | ~180 added lines |
+| `src/tesseract_robotics/__init__.py` | Add `sys.platform == 'win32'` branch per above. | ~15 added lines |
+
+### Files deliberately NOT changed
+
+- **`pyproject.toml`** — `[tool.pixi.workspace].platforms` stays `["osx-arm64", "linux-64"]`. Adding `win-64` would half-enable local Windows dev (pixi install succeeds but bash build scripts fail), which is out of scope.
+- **`scripts/build_tesseract_cpp.sh`**, **`scripts/build_wheel.sh`** — bash-only, no `.bat` / `.ps1` equivalent for this PR.
+- **`dependencies.rosinstall`** — no Windows-specific branches; same sources everywhere.
+- **`docs/`, `README.md`** — deferred to follow-up PR.
+
+## Validation plan
+
+No local Windows machine required. All verification via CI iteration on `gh-40-windows-build`.
+
+1. **Build iteration** — push branch, watch `build-win`, fix forward. Expected early failures (ranked by likelihood):
+   - CMake can't find OSQP → fix `CMAKE_PREFIX_PATH` to include `%CONDA_PREFIX%\Library`.
+   - vcpkg cold-cache 20–30 min build; warm (cached) seconds.
+   - Eigen alignment SIGSEGV → verify `EIGEN_DONT_ALIGN=1` is propagated (inspect compile log).
+   - Plugin factory DLL naming mismatch → adjust loop if CMake emits unexpected names.
+2. **Wheel inspection** — on first successful build, unzip artifact. Confirm `tesseract_robotics.libs/` contains OSQP, ifopt, bullet, fcl, ompl DLLs; confirm `_delvewheel_init_patch.py` is present; confirm plugin factory DLLs are in the package dir.
+3. **`test-wheel-win` gate** — clean `windows-2022` runner, fresh venv, wheel-only install. This is the packaging-bug surface; build-env DLL leakage does not reach here. Same pytest exclusions as Linux/macOS: `tesseract_time_parameterization`, `examples`, `tesseract_kinematics`, `benchmarks`.
+4. **`trajopt_ifopt` import smoke test** — explicitly added to `test-wheel-win`. This is the canary for the hybrid vcpkg+conda-forge integration. If this import works end-to-end, the OSQP-from-conda-forge sourcing succeeded.
+5. **`workflow_dispatch`** — already present in the workflow, supports re-runs without dummy commits during iteration.
+6. **Publish gate (human discipline)** — do not push a release tag until Windows CI has had 5+ consecutive green runs on `main`. No YAML enforces this; it's a release-process norm.
+
+## Risks
+
+| # | Risk | Severity | Mitigation |
+|---|------|---------|------------|
+| 1 | Plugin-factory DLL naming differs from Linux/macOS (`foo.dll` vs `libfoo.so`/`.dylib`). | Low | Bundling loop uses bare names. Verify at first build with `dir ws\install\bin\*_factories.dll`. |
+| 2 | `__init__.py` has no Windows path today; delvewheel output lives in sibling `tesseract_robotics.libs/`; Python 3.8+ needs explicit `os.add_dll_directory()`. | Medium | New `sys.platform == 'win32'` branch runs **before** any extension import. |
+| 3 | Repacking the wheel after delvewheel breaks its init-patch hook. | Medium | Bundle plugin DLLs **before** delvewheel, not after — mirrors Linux's "bundle → auditwheel" order. |
+| 4 | MSVC ABI / CRT mismatch between vcpkg Release and conda-forge win-64. | Low | Both use Release + MD runtime. conda-forge's `osqp` is a small C API with no `std::` on the boundary. Escalation: pass `/D_ITERATOR_DEBUG_LEVEL=0`. |
+| 5 | Path separator for `TESSERACT_*_PLUGIN_DIRECTORIES` env vars. | Low | Use `os.pathsep` in the Windows branch of `__init__.py`. |
+| 6 | IfOpt CMake config can't find OSQP from conda-forge. | Medium | `CMAKE_PREFIX_PATH` includes `%CONDA_PREFIX%\Library` (not `%CONDA_PREFIX%` alone). |
+| 7 | Long-path limit (260 chars) hit by `ws/src/tesseract_planning/...`. | Low | `git config --system core.longpaths true` as early step; `actions/checkout@v4` handles this on recent versions. |
+| 8 | `boost-stacktrace` linking `dbghelp` on Windows. | Very low | vcpkg port handles transitively. Fallback: explicit `dbghelp.lib` link. |
+| 9 | delvewheel can't trace plugins' transitive DLL deps. | Addressed | Plugins are present during delvewheel's graph walk (see risk #3 mitigation). |
+| 10 | Unicode in CI prints crashes `cmd` with cp1252. | Low | Keep all CI prints ASCII. |
+| 11 | First-build flakiness on a release tag. | Medium | Merge to `main` early; observe CI stability for ≥1 week before the next release. Never publish relying on first-green Windows CI. |
+| 12 | macOS PR doesn't merge and we rebase onto `main` — need to also restore the `python-*` artifact filter change. | Low | On rebase, pick up the artifact filter change from the macOS PR into this one. Trivial one-line. |
+
+## Rollback
+
+Single-commit revert restores pre-Windows behavior (Linux + macOS publish only). If a broken Windows wheel reaches PyPI:
+
+1. Yank the broken release on PyPI (Manage → Release → Yank). Yanking hides the version from `pip install` resolution without deleting it.
+2. Remove `build-win` and `test-wheel-win` from `publish.needs` (or revert the commit).
+3. Cut a new patch version.
+
+No database migrations, no external system state. Pure CI change.
+
+## Success criteria
+
+- `build-win` green on all 4 Python versions (3.9, 3.10, 3.11, 3.12).
+- `test-wheel-win` green on 3.12 (3.9 runs with `continue-on-error`, matching Linux/macOS policy).
+- `from tesseract_robotics import trajopt_ifopt` succeeds from the wheel in a clean venv — proves full feature parity.
+- `publish` uploads 4 `*-win_amd64.whl` wheels alongside Linux and macOS wheels on the next tagged release.
+- No regression in Linux / macOS `build` / `test-wheel` / `publish` jobs.

--- a/src/tesseract_robotics/__init__.py
+++ b/src/tesseract_robotics/__init__.py
@@ -25,6 +25,21 @@ from pathlib import Path
 
 from loguru import logger
 
+# Windows DLL directory registration — must run before any C extension import.
+# Python 3.8+ on Windows removed PATH-based DLL search; os.add_dll_directory is the
+# replacement. Attribute only exists on Windows, so getattr-probe avoids pyright
+# platform-narrowing while being purely feature-detection.
+_add_dll_dir = getattr(os, "add_dll_directory", None)
+if _add_dll_dir is not None:
+    _pkg_dir = Path(__file__).parent.resolve()
+    _libs_dir = _pkg_dir.parent / "tesseract_robotics.libs"
+    if _libs_dir.is_dir():
+        _add_dll_dir(str(_libs_dir))
+    _add_dll_dir(str(_pkg_dir))
+    del _pkg_dir, _libs_dir
+del _add_dll_dir
+
+
 try:
     __version__ = version("tesseract-robotics-nanobind")
 except PackageNotFoundError:
@@ -124,15 +139,21 @@ def _configure_environment():
     editable = _is_editable_install()
 
     if not plugin_path:
-        # Check for bundled plugins (Linux wheel - plugins in package root)
+        # Check for bundled plugins — layout differs per platform:
+        #   Linux   : plugins in package root (libfoo.so)
+        #   macOS   : plugins in .dylibs subdir (delocate-repaired)
+        #   Windows : plugins in package root (foo.dll, no lib prefix)
         bundled_plugin = pkg_dir / "libtesseract_collision_bullet_factories.so"
-        dylibs_dir = pkg_dir / ".dylibs"  # macOS bundled (delocate-repaired)
+        dylibs_dir = pkg_dir / ".dylibs"
+        bundled_plugin_win = pkg_dir / "tesseract_collision_bullet_factories.dll"
         ws_install_lib = project_root / "ws" / "install" / "lib"
 
         if bundled_plugin.exists():
             plugin_path = str(pkg_dir)
         elif dylibs_dir.is_dir():
             plugin_path = str(dylibs_dir)
+        elif bundled_plugin_win.exists():
+            plugin_path = str(pkg_dir)
         elif editable and ws_install_lib.is_dir():
             plugin_path = str(ws_install_lib)
 


### PR DESCRIPTION
Issue #40. Stacked on `jf/macos-wheels-to-pypi`.

Design: `docs/superpowers/specs/2026-04-22-windows-wheels-to-pypi-design.md`

- vcpkg for bulk C++ deps (mirrors upstream `tesseract_python`)
- conda-forge for `osqp` (trajopt_sqp + ifopt solver backend)
- delvewheel for DLL bundling
- Full parity: `TESSERACT_BUILD_TRAJOPT_IFOPT=ON`
- `concurrency: cancel-in-progress` added (satisfies CLAUDE.md zombie-runs rule)

First-time Windows CI — expect iteration before green.