### PR TITLE
feat(command_language): make push_back polymorphic to accept CompositeInstruction

### DIFF
--- a/src/tesseract_command_language/tesseract_command_language_bindings.cpp
+++ b/src/tesseract_command_language/tesseract_command_language_bindings.cpp
@@ -205,6 +205,8 @@ NB_MODULE(_tesseract_command_language, m) {
     // ========== InstructionPoly ==========
     nb::class_<tp::InstructionPoly>(m, "InstructionPoly")
         .def(nb::init<>())
+        .def(nb::init<const tp::MoveInstructionPoly&>(), "instruction"_a)
+        .def(nb::init<const tp::CompositeInstruction&>(), "instruction"_a)
         .def("getDescription", &tp::InstructionPoly::getDescription)
         .def("setDescription", &tp::InstructionPoly::setDescription, "description"_a)
         .def("print", &tp::InstructionPoly::print, "prefix"_a = "")
@@ -216,7 +218,12 @@ NB_MODULE(_tesseract_command_language, m) {
             if (!self.isMoveInstruction())
                 throw std::runtime_error("InstructionPoly is not a MoveInstruction");
             return self.as<tp::MoveInstructionPoly>();
-        }, "Cast to MoveInstructionPoly. Raises RuntimeError if not a move instruction.");
+        }, "Cast to MoveInstructionPoly. Raises RuntimeError if not a move instruction.")
+        .def("asCompositeInstruction", [](tp::InstructionPoly& self) -> tp::CompositeInstruction {
+            if (!self.isCompositeInstruction())
+                throw std::runtime_error("InstructionPoly is not a CompositeInstruction");
+            return self.as<tp::CompositeInstruction>();
+        }, "Cast to CompositeInstruction. Raises RuntimeError if not a composite instruction.");
 
     // ========== MoveInstructionPoly ==========
     // Note: Not binding as subclass due to nanobind cross-module limitations
@@ -271,6 +278,12 @@ NB_MODULE(_tesseract_command_language, m) {
         if (!ip.isMoveInstruction())
             throw std::runtime_error("InstructionPoly is not a MoveInstruction");
         return ip.as<tp::MoveInstructionPoly>();
+    }, "instruction"_a);
+
+    m.def("InstructionPoly_as_CompositeInstruction", [](tp::InstructionPoly& ip) -> tp::CompositeInstruction {
+        if (!ip.isCompositeInstruction())
+            throw std::runtime_error("InstructionPoly is not a CompositeInstruction");
+        return ip.as<tp::CompositeInstruction>();
     }, "instruction"_a);
 
     m.def("WaypointPoly_as_StateWaypointPoly", [](tp::WaypointPoly& wp) -> tp::StateWaypointPoly {
@@ -361,9 +374,14 @@ NB_MODULE(_tesseract_command_language, m) {
             return self.getInstructions();
         }, nb::rv_policy::reference_internal)
         .def("setInstructions", &tp::CompositeInstruction::setInstructions, "instructions"_a)
-        // Note: 0.33 removed appendMoveInstruction - use push_back instead
+        .def("push_back", [](tp::CompositeInstruction& self, const tp::InstructionPoly& ip) {
+            self.push_back(ip);
+        }, "instruction"_a)
         .def("push_back", [](tp::CompositeInstruction& self, const tp::MoveInstructionPoly& mi) {
             self.push_back(mi);
+        }, "instruction"_a)
+        .def("push_back", [](tp::CompositeInstruction& self, const tp::CompositeInstruction& ci) {
+            self.push_back(ci);
         }, "instruction"_a)
         // SWIG-compatible alias
         .def("appendMoveInstruction", [](tp::CompositeInstruction& self, const tp::MoveInstructionPoly& mi) {
@@ -413,4 +431,12 @@ NB_MODULE(_tesseract_command_language, m) {
         dict.addProfile(ns, profile_name, profile);
     }, "dict"_a, "ns"_a, "profile_name"_a, "profile"_a,
     "Add a profile to the dictionary (cross-module helper)");
+
+    // Python-side convertibility: lets any API accepting an InstructionPoly
+    // (push_back, setInstructions, function parameters) be called with a
+    // MoveInstructionPoly or a CompositeInstruction directly. Pairs with
+    // the InstructionPoly(nb::init<const SubType&>()) constructors bound
+    // above. Must come after all three class bindings.
+    nb::implicitly_convertible<tp::MoveInstructionPoly, tp::InstructionPoly>();
+    nb::implicitly_convertible<tp::CompositeInstruction, tp::InstructionPoly>();
 }

--- a/src/tesseract_robotics/tesseract_command_language/_tesseract_command_language.pyi
+++ b/src/tesseract_robotics/tesseract_command_language/_tesseract_command_language.pyi
@@ -1,3 +1,5 @@
+"""tesseract_command_language Python bindings"""
+
 from collections.abc import Iterator, Sequence
 import enum
 from typing import Annotated, overload
@@ -244,7 +246,14 @@ def JointWaypointPoly_wrap_JointWaypoint(waypoint: JointWaypoint) -> JointWaypoi
 def StateWaypointPoly_wrap_StateWaypoint(waypoint: StateWaypoint) -> StateWaypointPoly: ...
 
 class InstructionPoly:
+    @overload
     def __init__(self) -> None: ...
+
+    @overload
+    def __init__(self, instruction: MoveInstructionPoly) -> None: ...
+
+    @overload
+    def __init__(self, instruction: CompositeInstruction) -> None: ...
 
     def getDescription(self) -> str: ...
 
@@ -261,6 +270,11 @@ class InstructionPoly:
     def asMoveInstruction(self) -> MoveInstructionPoly:
         """
         Cast to MoveInstructionPoly. Raises RuntimeError if not a move instruction.
+        """
+
+    def asCompositeInstruction(self) -> CompositeInstruction:
+        """
+        Cast to CompositeInstruction. Raises RuntimeError if not a composite instruction.
         """
 
 class MoveInstructionPoly:
@@ -313,6 +327,8 @@ class MoveInstructionPoly:
 def MoveInstructionPoly_wrap_MoveInstruction(instruction: MoveInstruction) -> MoveInstructionPoly: ...
 
 def InstructionPoly_as_MoveInstructionPoly(instruction: InstructionPoly) -> MoveInstructionPoly: ...
+
+def InstructionPoly_as_CompositeInstruction(instruction: InstructionPoly) -> CompositeInstruction: ...
 
 def WaypointPoly_as_StateWaypointPoly(waypoint: WaypointPoly) -> StateWaypointPoly: ...
 
@@ -405,7 +421,14 @@ class CompositeInstruction:
 
     def setInstructions(self, instructions: Sequence[InstructionPoly]) -> None: ...
 
+    @overload
+    def push_back(self, instruction: InstructionPoly) -> None: ...
+
+    @overload
     def push_back(self, instruction: MoveInstructionPoly) -> None: ...
+
+    @overload
+    def push_back(self, instruction: CompositeInstruction) -> None: ...
 
     def appendMoveInstruction(self, mi: MoveInstructionPoly) -> None: ...
 

--- a/tests/tesseract_command_language/test_command_language.py
+++ b/tests/tesseract_command_language/test_command_language.py
@@ -16,6 +16,7 @@ from tesseract_robotics.tesseract_command_language import (
     JointWaypointPoly_wrap_JointWaypoint,
     # Instructions
     MoveInstruction,
+    MoveInstructionPoly,
     MoveInstructionPoly_wrap_MoveInstruction,
     # Enums
     MoveInstructionType,
@@ -220,6 +221,106 @@ class TestCompositeInstruction:
 
         assert len(program) == 2
         assert not program.empty()
+
+
+class TestNestedCompositeInstruction:
+    """Test nesting one CompositeInstruction inside another."""
+
+    @staticmethod
+    def _make_move_instr(x: float) -> MoveInstructionPoly:
+        wp = CartesianWaypoint(Isometry3d.Identity() * Translation3d(x, 0.0, 1.0))
+        mi = MoveInstruction(
+            CartesianWaypointPoly_wrap_CartesianWaypoint(wp),
+            MoveInstructionType_FREESPACE,
+            "DEFAULT",
+        )
+        return MoveInstructionPoly_wrap_MoveInstruction(mi)
+
+    def test_push_back_composite(self):
+        """push_back accepts a CompositeInstruction as a nested child."""
+        outer = CompositeInstruction("DEFAULT")
+        inner = CompositeInstruction("DEFAULT")
+        inner.setDescription("approach")
+        inner.push_back(self._make_move_instr(0.1))
+
+        outer.push_back(inner)
+
+        assert len(outer) == 1
+        child = outer[0]
+        assert child.isCompositeInstruction()
+        assert not child.isMoveInstruction()
+
+    def test_mixed_children(self):
+        """push_back can interleave move instructions and nested composites."""
+        outer = CompositeInstruction("DEFAULT")
+        inner = CompositeInstruction("DEFAULT")
+        inner.setDescription("approach")
+
+        outer.push_back(inner)
+        outer.push_back(self._make_move_instr(0.5))
+
+        assert len(outer) == 2
+        assert outer[0].isCompositeInstruction()
+        assert outer[1].isMoveInstruction()
+
+    def test_as_composite_instruction_round_trip(self):
+        """asCompositeInstruction extracts the composite payload with its
+        description + children intact."""
+        outer = CompositeInstruction("DEFAULT")
+        inner = CompositeInstruction("DEFAULT")
+        inner.setDescription("to_end")
+        inner.push_back(self._make_move_instr(1.0))
+
+        outer.push_back(inner)
+        recovered = outer[0].asCompositeInstruction()
+
+        assert recovered.getDescription() == "to_end"
+        assert len(recovered) == 1
+
+    def test_as_composite_instruction_wrong_type_raises(self):
+        """Calling asCompositeInstruction on a move-instruction payload
+        raises RuntimeError, matching asMoveInstruction's error style."""
+        import pytest
+
+        outer = CompositeInstruction("DEFAULT")
+        outer.push_back(self._make_move_instr(0.0))
+
+        move_ip = outer[0]
+        assert move_ip.isMoveInstruction()
+
+        with pytest.raises(RuntimeError):
+            move_ip.asCompositeInstruction()
+
+    def test_raster_like_dispatch_structure(self):
+        """Full RasterMotionTask-style structure: outer composite whose
+        children are description-tagged sub-composites that a dispatcher
+        routes to different sub-pipelines."""
+        outer = CompositeInstruction("DEFAULT")
+
+        approach = CompositeInstruction("DEFAULT")
+        approach.setDescription("approach")
+        approach.push_back(self._make_move_instr(0.0))
+
+        raster = CompositeInstruction("DEFAULT")
+        raster.setDescription("Raster Index 0")
+        raster.push_back(self._make_move_instr(0.1))
+        raster.push_back(self._make_move_instr(0.2))
+
+        to_end = CompositeInstruction("DEFAULT")
+        to_end.setDescription("to_end")
+        to_end.push_back(self._make_move_instr(0.3))
+
+        outer.push_back(approach)
+        outer.push_back(raster)
+        outer.push_back(to_end)
+
+        assert len(outer) == 3
+        descriptions = []
+        for i in range(len(outer)):
+            child_ip = outer[i]
+            assert child_ip.isCompositeInstruction()
+            descriptions.append(child_ip.asCompositeInstruction().getDescription())
+        assert descriptions == ["approach", "Raster Index 0", "to_end"]
 
 
 class TestProfileDictionary:


### PR DESCRIPTION
Tesseract [supports](https://github.com/tesseract-robotics/tesseract_planning/blob/fdb9774e45ea2affb77d953baf10c4d9ad60df50/task_composer/core/include/tesseract/task_composer/test_suite/test_programs.hpp#L263-L266) adding `CompositeInstruction`s into programs as in the raster program example, so we should support it too