### PR TITLE
feat(task_composer): add planning profiles bindings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -351,8 +351,8 @@ add_tesseract_nanobind_extension(
   tesseract::tesseract_common
 )
 
-# Find and add tesseract_task_composer (core and taskflow components only, planning requires trajopt)
-find_package(tesseract_task_composer REQUIRED COMPONENTS core taskflow)
+# Find and add tesseract_task_composer
+find_package(tesseract_task_composer REQUIRED COMPONENTS core taskflow planning)
 
 add_tesseract_nanobind_extension(
   tesseract_task_composer
@@ -360,6 +360,17 @@ add_tesseract_nanobind_extension(
   tesseract::tesseract_task_composer
   tesseract::tesseract_task_composer_taskflow
   tesseract::tesseract_environment
+  tesseract::tesseract_command_language
+  tesseract::tesseract_common
+)
+
+add_tesseract_nanobind_extension(
+  tesseract_task_composer_planning
+  src/tesseract_task_composer_planning/tesseract_task_composer_planning_bindings.cpp
+  tesseract::tesseract_task_composer_planning_nodes
+  tesseract::tesseract_task_composer
+  tesseract::tesseract_motion_planners_trajopt
+  tesseract::tesseract_collision_core
   tesseract::tesseract_command_language
   tesseract::tesseract_common
 )

--- a/scripts/generate_stubs.sh
+++ b/scripts/generate_stubs.sh
@@ -30,6 +30,7 @@ MODULES=(
     "tesseract_robotics.tesseract_srdf._tesseract_srdf:tesseract_srdf"
     "tesseract_robotics.tesseract_state_solver._tesseract_state_solver:tesseract_state_solver"
     "tesseract_robotics.tesseract_task_composer._tesseract_task_composer:tesseract_task_composer"
+    "tesseract_robotics.tesseract_task_composer_planning._tesseract_task_composer_planning:tesseract_task_composer_planning"
     "tesseract_robotics.tesseract_time_parameterization._tesseract_time_parameterization:tesseract_time_parameterization"
     "tesseract_robotics.tesseract_urdf._tesseract_urdf:tesseract_urdf"
     "tesseract_robotics.trajopt_ifopt._trajopt_ifopt:trajopt_ifopt"

--- a/src/tesseract_robotics/tesseract_task_composer_planning/__init__.py
+++ b/src/tesseract_robotics/tesseract_task_composer_planning/__init__.py
@@ -1,0 +1,11 @@
+from tesseract_robotics.tesseract_task_composer_planning._tesseract_task_composer_planning import *  # noqa: F403
+
+__all__ = [
+    "ContactCheckProfile",
+    "FixStateBoundsProfile",
+    "FixStateCollisionProfile",
+    "KinematicLimitsCheckProfile",
+    "MinLengthProfile",
+    "ProfileSwitchProfile",
+    "UpsampleTrajectoryProfile",
+]

--- a/src/tesseract_robotics/tesseract_task_composer_planning/_tesseract_task_composer_planning.pyi
+++ b/src/tesseract_robotics/tesseract_task_composer_planning/_tesseract_task_composer_planning.pyi
@@ -1,0 +1,187 @@
+"""tesseract_task_composer planning-node profile Python bindings"""
+
+from collections.abc import Sequence
+import enum
+from typing import overload
+
+import tesseract_robotics.tesseract_collision._tesseract_collision
+import tesseract_robotics.tesseract_command_language._tesseract_command_language
+
+
+class ContactCheckProfile(tesseract_robotics.tesseract_command_language._tesseract_command_language.Profile):
+    @overload
+    def __init__(self) -> None: ...
+
+    @overload
+    def __init__(self, longest_valid_segment_length: float, contact_distance: float) -> None: ...
+
+    @property
+    def contact_manager_config(self) -> tesseract_robotics.tesseract_collision._tesseract_collision.ContactManagerConfig: ...
+
+    @contact_manager_config.setter
+    def contact_manager_config(self, arg: tesseract_robotics.tesseract_collision._tesseract_collision.ContactManagerConfig, /) -> None: ...
+
+    @property
+    def collision_check_config(self) -> tesseract_robotics.tesseract_collision._tesseract_collision.CollisionCheckConfig: ...
+
+    @collision_check_config.setter
+    def collision_check_config(self, arg: tesseract_robotics.tesseract_collision._tesseract_collision.CollisionCheckConfig, /) -> None: ...
+
+class FixStateBoundsProfile(tesseract_robotics.tesseract_command_language._tesseract_command_language.Profile):
+    def __init__(self, mode: FixStateBoundsProfile.Settings = FixStateBoundsProfile.Settings.ALL) -> None: ...
+
+    class Settings(enum.Enum):
+        START_ONLY = 0
+
+        END_ONLY = 1
+
+        ALL = 2
+
+        DISABLED = 3
+
+    @property
+    def mode(self) -> FixStateBoundsProfile.Settings: ...
+
+    @mode.setter
+    def mode(self, arg: FixStateBoundsProfile.Settings, /) -> None: ...
+
+    @property
+    def max_deviation_global(self) -> float: ...
+
+    @max_deviation_global.setter
+    def max_deviation_global(self, arg: float, /) -> None: ...
+
+    @property
+    def upper_bounds_reduction(self) -> float: ...
+
+    @upper_bounds_reduction.setter
+    def upper_bounds_reduction(self, arg: float, /) -> None: ...
+
+    @property
+    def lower_bounds_reduction(self) -> float: ...
+
+    @lower_bounds_reduction.setter
+    def lower_bounds_reduction(self, arg: float, /) -> None: ...
+
+class FixStateCollisionProfile(tesseract_robotics.tesseract_command_language._tesseract_command_language.Profile):
+    def __init__(self, mode: FixStateCollisionProfile.Settings = FixStateCollisionProfile.Settings.ALL) -> None: ...
+
+    class Settings(enum.Enum):
+        START_ONLY = 0
+
+        END_ONLY = 1
+
+        INTERMEDIATE_ONLY = 2
+
+        ALL = 3
+
+        ALL_EXCEPT_START = 4
+
+        ALL_EXCEPT_END = 5
+
+        DISABLED = 6
+
+    class CorrectionMethod(enum.Enum):
+        NONE = 0
+
+        TRAJOPT = 1
+
+        RANDOM_SAMPLER = 2
+
+    @property
+    def mode(self) -> FixStateCollisionProfile.Settings: ...
+
+    @mode.setter
+    def mode(self, arg: FixStateCollisionProfile.Settings, /) -> None: ...
+
+    @property
+    def correction_workflow(self) -> list[FixStateCollisionProfile.CorrectionMethod]: ...
+
+    @correction_workflow.setter
+    def correction_workflow(self, arg: Sequence[FixStateCollisionProfile.CorrectionMethod], /) -> None: ...
+
+    @property
+    def jiggle_factor(self) -> float: ...
+
+    @jiggle_factor.setter
+    def jiggle_factor(self, arg: float, /) -> None: ...
+
+    @property
+    def contact_manager_config(self) -> tesseract_robotics.tesseract_collision._tesseract_collision.ContactManagerConfig: ...
+
+    @contact_manager_config.setter
+    def contact_manager_config(self, arg: tesseract_robotics.tesseract_collision._tesseract_collision.ContactManagerConfig, /) -> None: ...
+
+    @property
+    def collision_check_config(self) -> tesseract_robotics.tesseract_collision._tesseract_collision.CollisionCheckConfig: ...
+
+    @collision_check_config.setter
+    def collision_check_config(self, arg: tesseract_robotics.tesseract_collision._tesseract_collision.CollisionCheckConfig, /) -> None: ...
+
+    @property
+    def sampling_attempts(self) -> int: ...
+
+    @sampling_attempts.setter
+    def sampling_attempts(self, arg: int, /) -> None: ...
+
+    @property
+    def update_workspace(self) -> bool: ...
+
+    @update_workspace.setter
+    def update_workspace(self, arg: bool, /) -> None: ...
+
+class KinematicLimitsCheckProfile(tesseract_robotics.tesseract_command_language._tesseract_command_language.Profile):
+    def __init__(self, check_position: bool = True, check_velocity: bool = True, check_acceleration: bool = True) -> None: ...
+
+    @property
+    def check_position(self) -> bool: ...
+
+    @check_position.setter
+    def check_position(self, arg: bool, /) -> None: ...
+
+    @property
+    def check_velocity(self) -> bool: ...
+
+    @check_velocity.setter
+    def check_velocity(self, arg: bool, /) -> None: ...
+
+    @property
+    def check_acceleration(self) -> bool: ...
+
+    @check_acceleration.setter
+    def check_acceleration(self, arg: bool, /) -> None: ...
+
+class MinLengthProfile(tesseract_robotics.tesseract_command_language._tesseract_command_language.Profile):
+    @overload
+    def __init__(self) -> None: ...
+
+    @overload
+    def __init__(self, min_length: int) -> None: ...
+
+    @property
+    def min_length(self) -> int: ...
+
+    @min_length.setter
+    def min_length(self, arg: int, /) -> None: ...
+
+class ProfileSwitchProfile(tesseract_robotics.tesseract_command_language._tesseract_command_language.Profile):
+    def __init__(self, return_value: int = 1) -> None: ...
+
+    @property
+    def return_value(self) -> int: ...
+
+    @return_value.setter
+    def return_value(self, arg: int, /) -> None: ...
+
+class UpsampleTrajectoryProfile(tesseract_robotics.tesseract_command_language._tesseract_command_language.Profile):
+    @overload
+    def __init__(self) -> None: ...
+
+    @overload
+    def __init__(self, longest_valid_segment_length: float) -> None: ...
+
+    @property
+    def longest_valid_segment_length(self) -> float: ...
+
+    @longest_valid_segment_length.setter
+    def longest_valid_segment_length(self, arg: float, /) -> None: ...

--- a/src/tesseract_task_composer_planning/tesseract_task_composer_planning_bindings.cpp
+++ b/src/tesseract_task_composer_planning/tesseract_task_composer_planning_bindings.cpp
@@ -1,0 +1,116 @@
+/**
+ * @file tesseract_task_composer_planning_bindings.cpp
+ * @brief nanobind bindings for tesseract_task_composer planning-node profiles.
+ *
+ * The task classes themselves are constructed via YAML + TaskComposerPluginFactory;
+ * only their *profiles* need to be tunable from Python, so just the profiles
+ * are bound here.
+ *
+ * FixStateCollisionProfile has members of type OSQPSettings,
+ * sco::BasicTrustRegionSQPParameters, trajopt_common::CollisionCoeffData, and
+ * TrajOptJointWaypointConfig that are not currently exposed to Python. Those
+ * members are skipped; users who need to tune them should build the profile
+ * in C++ or configure via YAML. Simple scalar / enum fields are exposed.
+ */
+
+#include "tesseract_nb.h"
+#include <nanobind/stl/vector.h>
+
+#include <tesseract_common/profile.h>
+
+#include <tesseract_task_composer/planning/profiles/contact_check_profile.h>
+#include <tesseract_task_composer/planning/profiles/fix_state_bounds_profile.h>
+#include <tesseract_task_composer/planning/profiles/fix_state_collision_profile.h>
+#include <tesseract_task_composer/planning/profiles/kinematic_limits_check_profile.h>
+#include <tesseract_task_composer/planning/profiles/min_length_profile.h>
+#include <tesseract_task_composer/planning/profiles/profile_switch_profile.h>
+#include <tesseract_task_composer/planning/profiles/upsample_trajectory_profile.h>
+
+namespace tp = tesseract_planning;
+namespace tc = tesseract_common;
+
+NB_MODULE(_tesseract_task_composer_planning, m) {
+    m.doc() = "tesseract_task_composer planning-node profile Python bindings";
+
+    // Import Profile from tesseract_command_language for cross-module inheritance
+    nb::module_::import_("tesseract_robotics.tesseract_command_language._tesseract_command_language");
+    // Import tesseract_collision for ContactManagerConfig / CollisionCheckConfig
+    nb::module_::import_("tesseract_robotics.tesseract_collision._tesseract_collision");
+
+    // ===== ContactCheckProfile =====
+    nb::class_<tp::ContactCheckProfile, tc::Profile>(m, "ContactCheckProfile")
+        .def(nb::init<>())
+        .def(nb::init<double, double>(),
+             "longest_valid_segment_length"_a, "contact_distance"_a)
+        .def_rw("contact_manager_config", &tp::ContactCheckProfile::contact_manager_config)
+        .def_rw("collision_check_config", &tp::ContactCheckProfile::collision_check_config);
+
+    // ===== FixStateBoundsProfile =====
+    nb::class_<tp::FixStateBoundsProfile, tc::Profile> fix_state_bounds(m, "FixStateBoundsProfile");
+    nb::enum_<tp::FixStateBoundsProfile::Settings>(fix_state_bounds, "Settings")
+        .value("START_ONLY", tp::FixStateBoundsProfile::Settings::START_ONLY)
+        .value("END_ONLY", tp::FixStateBoundsProfile::Settings::END_ONLY)
+        .value("ALL", tp::FixStateBoundsProfile::Settings::ALL)
+        .value("DISABLED", tp::FixStateBoundsProfile::Settings::DISABLED);
+    fix_state_bounds
+        .def(nb::init<tp::FixStateBoundsProfile::Settings>(),
+             "mode"_a = tp::FixStateBoundsProfile::Settings::ALL)
+        .def_rw("mode", &tp::FixStateBoundsProfile::mode)
+        .def_rw("max_deviation_global", &tp::FixStateBoundsProfile::max_deviation_global)
+        .def_rw("upper_bounds_reduction", &tp::FixStateBoundsProfile::upper_bounds_reduction)
+        .def_rw("lower_bounds_reduction", &tp::FixStateBoundsProfile::lower_bounds_reduction);
+
+    // ===== FixStateCollisionProfile =====
+    // Heavy trajopt-typed members (opt_params, osqp_settings, coeff data,
+    // trajopt waypoint configs) are not bound — build those in C++ or YAML.
+    nb::class_<tp::FixStateCollisionProfile, tc::Profile> fix_state_collision(m, "FixStateCollisionProfile");
+    nb::enum_<tp::FixStateCollisionProfile::Settings>(fix_state_collision, "Settings")
+        .value("START_ONLY", tp::FixStateCollisionProfile::Settings::START_ONLY)
+        .value("END_ONLY", tp::FixStateCollisionProfile::Settings::END_ONLY)
+        .value("INTERMEDIATE_ONLY", tp::FixStateCollisionProfile::Settings::INTERMEDIATE_ONLY)
+        .value("ALL", tp::FixStateCollisionProfile::Settings::ALL)
+        .value("ALL_EXCEPT_START", tp::FixStateCollisionProfile::Settings::ALL_EXCEPT_START)
+        .value("ALL_EXCEPT_END", tp::FixStateCollisionProfile::Settings::ALL_EXCEPT_END)
+        .value("DISABLED", tp::FixStateCollisionProfile::Settings::DISABLED);
+    nb::enum_<tp::FixStateCollisionProfile::CorrectionMethod>(fix_state_collision, "CorrectionMethod")
+        .value("NONE", tp::FixStateCollisionProfile::CorrectionMethod::NONE)
+        .value("TRAJOPT", tp::FixStateCollisionProfile::CorrectionMethod::TRAJOPT)
+        .value("RANDOM_SAMPLER", tp::FixStateCollisionProfile::CorrectionMethod::RANDOM_SAMPLER);
+    fix_state_collision
+        .def(nb::init<tp::FixStateCollisionProfile::Settings>(),
+             "mode"_a = tp::FixStateCollisionProfile::Settings::ALL)
+        .def_rw("mode", &tp::FixStateCollisionProfile::mode)
+        .def_rw("correction_workflow", &tp::FixStateCollisionProfile::correction_workflow)
+        .def_rw("jiggle_factor", &tp::FixStateCollisionProfile::jiggle_factor)
+        .def_rw("contact_manager_config", &tp::FixStateCollisionProfile::contact_manager_config)
+        .def_rw("collision_check_config", &tp::FixStateCollisionProfile::collision_check_config)
+        .def_rw("sampling_attempts", &tp::FixStateCollisionProfile::sampling_attempts)
+        .def_rw("update_workspace", &tp::FixStateCollisionProfile::update_workspace);
+
+    // ===== KinematicLimitsCheckProfile =====
+    nb::class_<tp::KinematicLimitsCheckProfile, tc::Profile>(m, "KinematicLimitsCheckProfile")
+        .def(nb::init<bool, bool, bool>(),
+             "check_position"_a = true,
+             "check_velocity"_a = true,
+             "check_acceleration"_a = true)
+        .def_rw("check_position", &tp::KinematicLimitsCheckProfile::check_position)
+        .def_rw("check_velocity", &tp::KinematicLimitsCheckProfile::check_velocity)
+        .def_rw("check_acceleration", &tp::KinematicLimitsCheckProfile::check_acceleration);
+
+    // ===== MinLengthProfile =====
+    nb::class_<tp::MinLengthProfile, tc::Profile>(m, "MinLengthProfile")
+        .def(nb::init<>())
+        .def(nb::init<long>(), "min_length"_a)
+        .def_rw("min_length", &tp::MinLengthProfile::min_length);
+
+    // ===== ProfileSwitchProfile =====
+    nb::class_<tp::ProfileSwitchProfile, tc::Profile>(m, "ProfileSwitchProfile")
+        .def(nb::init<int>(), "return_value"_a = 1)
+        .def_rw("return_value", &tp::ProfileSwitchProfile::return_value);
+
+    // ===== UpsampleTrajectoryProfile =====
+    nb::class_<tp::UpsampleTrajectoryProfile, tc::Profile>(m, "UpsampleTrajectoryProfile")
+        .def(nb::init<>())
+        .def(nb::init<double>(), "longest_valid_segment_length"_a)
+        .def_rw("longest_valid_segment_length", &tp::UpsampleTrajectoryProfile::longest_valid_segment_length);
+}

--- a/tests/tesseract_task_composer_planning/test_planning_profiles.py
+++ b/tests/tesseract_task_composer_planning/test_planning_profiles.py
@@ -1,0 +1,188 @@
+"""Tests for tesseract_task_composer planning-node profile bindings."""
+
+import pytest
+
+from tesseract_robotics.tesseract_task_composer_planning import (
+    ContactCheckProfile,
+    FixStateBoundsProfile,
+    FixStateCollisionProfile,
+    KinematicLimitsCheckProfile,
+    MinLengthProfile,
+    ProfileSwitchProfile,
+    UpsampleTrajectoryProfile,
+)
+
+
+# ---- MinLengthProfile ------------------------------------------------------
+
+class TestMinLengthProfile:
+    def test_default(self):
+        p = MinLengthProfile()
+        assert p.min_length == 10
+
+    def test_custom(self):
+        p = MinLengthProfile(42)
+        assert p.min_length == 42
+
+    def test_assignment(self):
+        p = MinLengthProfile()
+        p.min_length = 5
+        assert p.min_length == 5
+
+
+# ---- UpsampleTrajectoryProfile --------------------------------------------
+
+class TestUpsampleTrajectoryProfile:
+    def test_default(self):
+        p = UpsampleTrajectoryProfile()
+        assert p.longest_valid_segment_length == pytest.approx(0.1)
+
+    def test_custom(self):
+        p = UpsampleTrajectoryProfile(0.05)
+        assert p.longest_valid_segment_length == pytest.approx(0.05)
+
+    def test_assignment(self):
+        p = UpsampleTrajectoryProfile()
+        p.longest_valid_segment_length = 0.25
+        assert p.longest_valid_segment_length == pytest.approx(0.25)
+
+
+# ---- ProfileSwitchProfile --------------------------------------------------
+
+class TestProfileSwitchProfile:
+    def test_default(self):
+        p = ProfileSwitchProfile()
+        assert p.return_value == 1
+
+    def test_custom(self):
+        p = ProfileSwitchProfile(7)
+        assert p.return_value == 7
+
+    def test_assignment(self):
+        p = ProfileSwitchProfile()
+        p.return_value = -1
+        assert p.return_value == -1
+
+
+# ---- KinematicLimitsCheckProfile ------------------------------------------
+
+class TestKinematicLimitsCheckProfile:
+    def test_default(self):
+        p = KinematicLimitsCheckProfile()
+        assert p.check_position is True
+        assert p.check_velocity is True
+        assert p.check_acceleration is True
+
+    def test_custom(self):
+        p = KinematicLimitsCheckProfile(
+            check_position=False, check_velocity=True, check_acceleration=False
+        )
+        assert p.check_position is False
+        assert p.check_velocity is True
+        assert p.check_acceleration is False
+
+    def test_assignment(self):
+        p = KinematicLimitsCheckProfile()
+        p.check_position = False
+        assert p.check_position is False
+
+
+# ---- FixStateBoundsProfile -------------------------------------------------
+
+class TestFixStateBoundsProfile:
+    def test_default(self):
+        p = FixStateBoundsProfile()
+        assert p.mode == FixStateBoundsProfile.Settings.ALL
+
+    def test_settings_enum_values(self):
+        # All enum values exposed
+        assert FixStateBoundsProfile.Settings.START_ONLY is not None
+        assert FixStateBoundsProfile.Settings.END_ONLY is not None
+        assert FixStateBoundsProfile.Settings.ALL is not None
+        assert FixStateBoundsProfile.Settings.DISABLED is not None
+
+    def test_construct_with_mode(self):
+        p = FixStateBoundsProfile(FixStateBoundsProfile.Settings.START_ONLY)
+        assert p.mode == FixStateBoundsProfile.Settings.START_ONLY
+
+    def test_mutable_fields(self):
+        p = FixStateBoundsProfile()
+        p.max_deviation_global = 0.25
+        p.upper_bounds_reduction = 0.01
+        p.lower_bounds_reduction = 0.01
+        assert p.max_deviation_global == pytest.approx(0.25)
+        assert p.upper_bounds_reduction == pytest.approx(0.01)
+        assert p.lower_bounds_reduction == pytest.approx(0.01)
+
+
+# ---- FixStateCollisionProfile ---------------------------------------------
+
+class TestFixStateCollisionProfile:
+    def test_default(self):
+        p = FixStateCollisionProfile()
+        assert p.mode == FixStateCollisionProfile.Settings.ALL
+        assert p.jiggle_factor == pytest.approx(0.02)
+        assert p.sampling_attempts == 100
+        assert p.update_workspace is False
+
+    def test_settings_enum_values(self):
+        s = FixStateCollisionProfile.Settings
+        assert s.START_ONLY is not None
+        assert s.END_ONLY is not None
+        assert s.INTERMEDIATE_ONLY is not None
+        assert s.ALL is not None
+        assert s.ALL_EXCEPT_START is not None
+        assert s.ALL_EXCEPT_END is not None
+        assert s.DISABLED is not None
+
+    def test_correction_method_enum_values(self):
+        cm = FixStateCollisionProfile.CorrectionMethod
+        assert cm.NONE is not None
+        assert cm.TRAJOPT is not None
+        assert cm.RANDOM_SAMPLER is not None
+
+    def test_default_correction_workflow(self):
+        p = FixStateCollisionProfile()
+        workflow = list(p.correction_workflow)
+        assert len(workflow) == 2
+        assert workflow[0] == FixStateCollisionProfile.CorrectionMethod.TRAJOPT
+        assert workflow[1] == FixStateCollisionProfile.CorrectionMethod.RANDOM_SAMPLER
+
+    def test_set_correction_workflow(self):
+        p = FixStateCollisionProfile()
+        p.correction_workflow = [FixStateCollisionProfile.CorrectionMethod.RANDOM_SAMPLER]
+        workflow = list(p.correction_workflow)
+        assert len(workflow) == 1
+        assert workflow[0] == FixStateCollisionProfile.CorrectionMethod.RANDOM_SAMPLER
+
+    def test_construct_with_mode(self):
+        p = FixStateCollisionProfile(FixStateCollisionProfile.Settings.START_ONLY)
+        assert p.mode == FixStateCollisionProfile.Settings.START_ONLY
+
+    def test_mutable_scalar_fields(self):
+        p = FixStateCollisionProfile()
+        p.jiggle_factor = 0.05
+        p.sampling_attempts = 200
+        p.update_workspace = True
+        assert p.jiggle_factor == pytest.approx(0.05)
+        assert p.sampling_attempts == 200
+        assert p.update_workspace is True
+
+
+# ---- ContactCheckProfile ---------------------------------------------------
+
+class TestContactCheckProfile:
+    def test_default(self):
+        p = ContactCheckProfile()
+        assert p is not None
+
+    def test_custom_constructor(self):
+        # Second ctor signature: (longest_valid_segment_length, contact_distance)
+        p = ContactCheckProfile(0.05, 0.01)
+        assert p is not None
+
+    def test_has_config_members(self):
+        p = ContactCheckProfile()
+        # Verify the bound struct members are accessible
+        assert p.contact_manager_config is not None
+        assert p.collision_check_config is not None


### PR DESCRIPTION
This one im less sure about because of that one comment about how planning requires trajopt -- i see that in the makelist the trajopt nanobind_extension is also optional for the trajopt bindings.

These profiles don't actually relate to trajopt, but perhaps simply loading the planning module causes a cascade of dependencies that I'm not resolving correctly?