### PR TITLE
docs: api-truth sweep + CHANGELOG wiring + strict CI

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,13 +1,21 @@
 name: Docs
 
 on:
+  pull_request:
+    paths:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - 'CHANGELOG.md'
+      - '.github/workflows/docs.yml'
+      - 'src/tesseract_robotics/**/*.pyi'
   push:
     branches: [main]
     paths:
       - 'docs/**'
       - 'mkdocs.yml'
+      - 'CHANGELOG.md'
       - '.github/workflows/docs.yml'
-      - 'src/tesseract_robotics/**/*.pyi'  # stub files for API docs
+      - 'src/tesseract_robotics/**/*.pyi'
   workflow_dispatch:
 
 permissions:
@@ -16,7 +24,7 @@ permissions:
   id-token: write
 
 concurrency:
-  group: pages
+  group: docs-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -33,15 +41,17 @@ jobs:
     - name: Install dependencies
       run: pip install -r docs/requirements.txt
 
-    - name: Build docs
-      run: PYTHONPATH=src mkdocs build
+    - name: Build docs (strict)
+      run: PYTHONPATH=src mkdocs build --strict
 
     - name: Upload artifact
+      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
       uses: actions/upload-pages-artifact@v3
       with:
         path: site
 
   deploy:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     needs: build
     runs-on: ubuntu-latest
     environment:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - `CompositeInstruction.push_back` now accepts a `CompositeInstruction` in addition to a plain `Instruction`, enabling nested composites (e.g. raster programs) to be built from Python the same way they are in C++ ([#51], [6d17314]).
   - contributed by [@Joelkang]
+- **SimplePlanner profiles** configurable from Python — `SimplePlannerCompositeProfile` plus seven concrete move profiles (`FixedSize`, `FixedSizeAssign`, `FixedSizeAssignNoIK`, `LVS`, `LVSNoIK`, `LVSAssign`, `LVSAssignNoIK`), with `ProfileDictionary_addSimplePlannerMoveProfile` / `…CompositeProfile` helpers for registration ([#54], [e2bf837]).
+  - contributed by [@Joelkang]
+- **task_composer planning-node profiles** exposed through a new `tesseract_task_composer_planning` module: `ContactCheckProfile`, `FixStateBoundsProfile`, `FixStateCollisionProfile`, `KinematicLimitsCheckProfile`, `MinLengthProfile`, `ProfileSwitchProfile`, and `UpsampleTrajectoryProfile`. Heavy TrajOpt-typed members on `FixStateCollisionProfile` (OSQP settings, SQP params, coeff data) are intentionally skipped — configure those via YAML or C++ ([#56], [62cd2cd]).
+  - contributed by [@Joelkang]
+- **`ConstantTCPSpeedParameterization`** (KDL-based, constant TCP-speed time parameterization) bound alongside its `ConstantTCPSpeedCompositeProfile` ([#55], [f4f981d]).
+  - contributed by [@Joelkang]
 
 ### In progress
 
@@ -58,15 +64,21 @@ First PyPI-published macOS arm64 wheels, shipping via a dedicated `wheels-macos.
 [#49]: https://github.com/tesseract-robotics/tesseract_nanobind/issues/49
 [#50]: https://github.com/tesseract-robotics/tesseract_nanobind/pull/50
 [#51]: https://github.com/tesseract-robotics/tesseract_nanobind/pull/51
+[#54]: https://github.com/tesseract-robotics/tesseract_nanobind/pull/54
+[#55]: https://github.com/tesseract-robotics/tesseract_nanobind/pull/55
+[#56]: https://github.com/tesseract-robotics/tesseract_nanobind/pull/56
 [07f8f9c]: https://github.com/tesseract-robotics/tesseract_nanobind/commit/07f8f9c8c54ab13c3d10ceca00181091d0126336
 [2c62952]: https://github.com/tesseract-robotics/tesseract_nanobind/commit/2c62952fded6cb1253cb45441d7cd6f9b0423593
 [361c60e]: https://github.com/tesseract-robotics/tesseract_nanobind/commit/361c60e263f0768e1b23d3a9919f700d06b15993
 [590343f]: https://github.com/tesseract-robotics/tesseract_nanobind/commit/590343f93dc4b82fae92f56d038cdb5ba41a511d
+[62cd2cd]: https://github.com/tesseract-robotics/tesseract_nanobind/commit/62cd2cdd02f9c711d78726d1993d7585a8d54141
 [6d17314]: https://github.com/tesseract-robotics/tesseract_nanobind/commit/6d17314a0b5aa1db45ffb9d9b18a8b3e048d3d06
 [7f53185]: https://github.com/tesseract-robotics/tesseract_nanobind/commit/7f531851ce70a2564251761f560020d768e3e940
 [87ce68e]: https://github.com/tesseract-robotics/tesseract_nanobind/commit/87ce68ed5d015ae596a9047d629ed26f8595e3b0
 [a1d7607]: https://github.com/tesseract-robotics/tesseract_nanobind/commit/a1d7607afa7d03cd27e845059cb455eb74a4d7ec
 [d80e689]: https://github.com/tesseract-robotics/tesseract_nanobind/commit/d80e689f559f560aeb5e5b28cb332e942d15ecef
 [e26df2a]: https://github.com/tesseract-robotics/tesseract_nanobind/commit/e26df2a10d37b9d4ffb689a384e6bad490b2fb7d
+[e2bf837]: https://github.com/tesseract-robotics/tesseract_nanobind/commit/e2bf837c61b307157eb8cc3313e34f772c7d1b27
+[f4f981d]: https://github.com/tesseract-robotics/tesseract_nanobind/commit/f4f981d161a59d7d4367139e5eb79a4c3a6b1eef
 [@Joelkang]: https://github.com/Joelkang
 [@marip8]: https://github.com/marip8

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,0 +1,1 @@
+../CHANGELOG.md

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -2,7 +2,7 @@
 
 ## Installation
 
-**Platform:** Linux x86_64 (Python 3.9-3.12). macOS coming soon.
+**Platforms:** Linux x86_64 and macOS arm64 (Python 3.9-3.12). Windows x64 is in progress (see [#40](https://github.com/tesseract-robotics/tesseract_nanobind/issues/40)).
 
 ```bash
 pip install tesseract-robotics-nanobind

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -8,7 +8,7 @@ Auto-generated API documentation from docstrings.
 
 | Module | Description |
 |--------|-------------|
-| [`tesseract_robotics.planning`](planning.md) | Robot, Planner, Composer classes |
+| [`tesseract_robotics.planning`](planning.md) | `Robot`, `MotionProgram`, `TaskComposer`, `plan_freespace`/`plan_ompl`/`plan_cartesian` |
 
 ### Core Modules
 
@@ -45,10 +45,25 @@ Auto-generated API documentation from docstrings.
 ### High-Level (Recommended)
 
 ```python
-from tesseract_robotics.planning import Robot, Planner, Composer
+from tesseract_robotics.planning import (
+    Robot,
+    MotionProgram,
+    JointTarget,
+    plan_freespace,
+    TaskComposer,
+)
 
 robot = Robot.from_tesseract_support("abb_irb2400")
-planner = Planner(robot)
+program = (
+    MotionProgram("manipulator")
+    .move_to(JointTarget([0, 0, 0, 0, 0, 0]))
+    .move_to(JointTarget([0.5, 0, 0, 0, 0, 0]))
+)
+result = plan_freespace(robot, program)
+
+# Or reuse a composer (amortizes plugin loading):
+composer = TaskComposer.from_config(warmup=True)
+result = composer.plan(robot, program, pipeline="TrajOptPipeline")
 ```
 
 ### Direct Module Access

--- a/docs/api/planning.md
+++ b/docs/api/planning.md
@@ -22,9 +22,9 @@ robot = Robot.from_urdf(
     "package://my_robot/urdf/robot.srdf",
 )
 
-# FK / IK
-pose = robot.fk([0, 0, 0, 0, 0, 0], group="manipulator")
-solutions = robot.ik(target_pose, group="manipulator")
+# FK / IK — group_name is the first positional argument
+pose = robot.fk("manipulator", [0, 0, 0, 0, 0, 0])
+solution = robot.ik("manipulator", target_pose, seed=[0, 0, 0, 0, 0, 0])
 
 # Access the underlying Environment
 env = robot.env

--- a/docs/api/planning.md
+++ b/docs/api/planning.md
@@ -1,193 +1,101 @@
 # tesseract_robotics.planning
 
-High-level planning API for robot motion planning.
+High-level planning API. See the [Planning User Guide](../user-guide/planning.md)
+and [TaskComposer User Guide](../user-guide/task-composer.md) for walkthroughs.
+
+## Classes
+
+### Robot
+
+Entry point for working with a robot — loads URDF/SRDF, exposes FK/IK, state
+management, and access to the underlying `Environment`.
+
+```python
+from tesseract_robotics.planning import Robot
+
+# Bundled test robots
+robot = Robot.from_tesseract_support("abb_irb2400")
+
+# From URDF/SRDF (package:// or file:// URLs)
+robot = Robot.from_urdf(
+    "package://my_robot/urdf/robot.urdf",
+    "package://my_robot/urdf/robot.srdf",
+)
+
+# FK / IK
+pose = robot.fk([0, 0, 0, 0, 0, 0], group="manipulator")
+solutions = robot.ik(target_pose, group="manipulator")
+
+# Access the underlying Environment
+env = robot.env
+```
+
+### MotionProgram
+
+Builder for motion sequences. Chain `.move_to(...)` calls with `JointTarget`,
+`CartesianTarget`, or `StateTarget` waypoints.
+
+```python
+from tesseract_robotics.planning import (
+    MotionProgram,
+    JointTarget,
+    CartesianTarget,
+    Pose,
+)
+
+program = (
+    MotionProgram("manipulator")
+    .move_to(JointTarget([0, 0, 0, 0, 0, 0]))
+    .move_to(CartesianTarget(Pose.from_xyz(0.5, 0.0, 0.5)))
+    .move_to(JointTarget([0.5, 0, 0, 0, 0, 0]))
+)
+```
+
+### TaskComposer
+
+Orchestrates multi-stage planning pipelines.
+See [TaskComposer User Guide](../user-guide/task-composer.md) for the full
+workflow (including pipeline warmup).
+
+```python
+from tesseract_robotics.planning import TaskComposer
+
+composer = TaskComposer.from_config(warmup=True)  # ~10-15s one-time cost
+result = composer.plan(robot, program, pipeline="TrajOptPipeline")
+```
+
+### Pose
+
+Scalar-last (`qx, qy, qz, qw`) quaternion convention — matches scipy's
+`Rotation.as_quat()`.
+
+```python
+from tesseract_robotics.planning import Pose
+
+pose = Pose.from_xyz_quat(0.5, 0.0, 0.5, 0.0, 0.0, 0.0, 1.0)
+print(pose.quaternion)  # [qx, qy, qz, qw]
+```
+
+## Functions
+
+| Function | Pipeline default | Description |
+|---|---|---|
+| `plan_freespace(robot, program)` | `TrajOptPipeline` | Optimization-based freespace motion |
+| `plan_ompl(robot, program)` | `FreespacePipeline` | OMPL sampling + TrajOpt smoothing |
+| `plan_cartesian(robot, program)` | `DescartesPipeline` | Descartes Cartesian path search |
+| `assign_current_state_as_seed(program, robot)` | — | Seed Cartesian waypoints with the current robot state |
+
+All three `plan_*` helpers accept an optional `pipeline=` override and a
+`profiles=` `ProfileDictionary`.
+
+## Module API
 
 ::: tesseract_robotics.planning
     options:
       show_root_heading: true
       show_source: false
       members_order: source
-      heading_level: 2
+      heading_level: 3
       docstring_style: google
       show_signature_annotations: true
       separate_signature: true
-
-## Classes
-
-### Robot
-
-The main entry point for working with a robot.
-
-```python
-from tesseract_robotics.planning import Robot
-
-# Load from bundled models
-robot = Robot.from_tesseract_support("abb_irb2400")
-
-# Load from URDF/SRDF
-robot = Robot.from_urdf("robot.urdf", "robot.srdf")
-
-# Access environment
-env = robot.env
-
-# Forward kinematics
-pose = robot.fk(joints, group="manipulator")
-
-# Inverse kinematics
-solutions = robot.ik(target_pose, group="manipulator")
-
-# Collision checking
-is_safe = robot.check_collision(joints)
-contacts = robot.get_contacts(joints)
-```
-
-#### Methods
-
-| Method | Description |
-|--------|-------------|
-| `from_tesseract_support(name)` | Load bundled robot model |
-| `from_urdf(urdf, srdf)` | Load from URDF/SRDF files |
-| `fk(joints, group)` | Forward kinematics |
-| `ik(pose, group, seed)` | Inverse kinematics |
-| `check_collision(joints)` | Collision check (bool) |
-| `get_contacts(joints)` | Detailed collision info |
-| `get_joint_names(group)` | Joint names for group |
-| `get_joint_limits(group)` | Position/velocity limits |
-
-### Planner
-
-Motion planner wrapper.
-
-```python
-from tesseract_robotics.planning import Planner
-
-planner = Planner(robot)
-
-# Joint-space planning
-trajectory = planner.plan(
-    start=start_joints,
-    goal=goal_joints,
-    planner="ompl"
-)
-
-# Cartesian planning
-trajectory = planner.plan(
-    start=start_joints,
-    goal=goal_pose,  # Isometry3d
-    planner="trajopt"
-)
-
-# Refine existing trajectory
-smooth = planner.refine(trajectory, planner="trajopt")
-```
-
-#### Parameters
-
-| Parameter | Type | Description |
-|-----------|------|-------------|
-| `start` | `np.ndarray` | Start joint configuration |
-| `goal` | `np.ndarray` or `Isometry3d` | Goal (joint or Cartesian) |
-| `planner` | `str` | Planner type: ompl, trajopt, descartes, simple |
-| `profile` | `str` | Profile name (default: "DEFAULT") |
-
-### Composer
-
-Task composition for complex sequences.
-
-```python
-from tesseract_robotics.planning import Composer
-
-composer = Composer(robot)
-
-# Add motion segments
-composer.add_freespace(goal_joints=via_point)
-composer.add_cartesian(goal_pose=target_pose)
-composer.add_linear(goal_joints=final_joints)
-
-# Plan all segments
-result = composer.plan()
-
-if result.success:
-    trajectories = result.get_trajectories()
-```
-
-#### Methods
-
-| Method | Description |
-|--------|-------------|
-| `add_freespace(goal_joints)` | Add freespace motion |
-| `add_cartesian(goal_pose)` | Add Cartesian motion |
-| `add_linear(goal_pose)` | Add linear Cartesian motion |
-| `clear()` | Clear all segments |
-| `plan()` | Execute planning pipeline |
-
-### Trajectory
-
-Planned trajectory result.
-
-```python
-if trajectory:
-    for waypoint in trajectory:
-        print(f"Positions: {waypoint.positions}")
-        print(f"Velocities: {waypoint.velocities}")
-        print(f"Time: {waypoint.time}")
-```
-
-#### Attributes
-
-| Attribute | Type | Description |
-|-----------|------|-------------|
-| `positions` | `np.ndarray` | Joint positions |
-| `velocities` | `np.ndarray` | Joint velocities |
-| `accelerations` | `np.ndarray` | Joint accelerations |
-| `time` | `float` | Time from start (seconds) |
-
-### ComposerResult
-
-Result from Composer.plan().
-
-```python
-result = composer.plan()
-
-if result.success:
-    print(f"Planned {len(result.get_trajectories())} segments")
-else:
-    print(f"Failed: {result.message}")
-```
-
-#### Attributes
-
-| Attribute | Type | Description |
-|-----------|------|-------------|
-| `success` | `bool` | Planning succeeded |
-| `message` | `str` | Error message if failed |
-| `raw_results` | object | Raw TaskComposer output |
-
-#### Methods
-
-| Method | Returns | Description |
-|--------|---------|-------------|
-| `get_trajectories()` | `list[Trajectory]` | Extract trajectories |
-
-## Enums
-
-### PlannerType
-
-```python
-from tesseract_robotics.planning import PlannerType
-
-PlannerType.OMPL       # Sampling-based (OMPL)
-PlannerType.TRAJOPT    # Optimization (TrajOpt)
-PlannerType.DESCARTES  # Graph search (Descartes)
-PlannerType.SIMPLE     # Interpolation
-```
-
-### MotionType
-
-```python
-from tesseract_robotics.planning import MotionType
-
-MotionType.FREESPACE  # Any collision-free path
-MotionType.LINEAR     # Straight Cartesian line
-MotionType.CIRCULAR   # Circular arc
-```

--- a/docs/api/tesseract_collision.md
+++ b/docs/api/tesseract_collision.md
@@ -20,7 +20,8 @@ my_manager = manager.clone()
 # Set collision objects state
 my_manager.setCollisionObjectsTransform(link_transforms)
 
-# Run collision check
+# Run collision check — fills ContactResultMap
+result_map = ContactResultMap()
 my_manager.contactTest(result_map, request)
 ```
 
@@ -44,6 +45,7 @@ my_manager.setCollisionObjectsTransform(
 )
 
 # Run continuous collision check
+result_map = ContactResultMap()
 my_manager.contactTest(result_map, request)
 ```
 
@@ -79,16 +81,19 @@ request.type = ContactTestType.LIMITED  # up to max contacts
 Single contact between two objects.
 
 ```python
-from tesseract_robotics.tesseract_collision import ContactResult
+from tesseract_robotics.tesseract_collision import ContactResult, ContactResultVector
 
-# After contactTest()
-for key, results in result_map.items():
-    for contact in results:
-        print(f"Contact: {contact.link_names[0]} <-> {contact.link_names[1]}")
-        print(f"  Distance: {contact.distance}")
-        print(f"  Point A: {contact.nearest_points[0]}")
-        print(f"  Point B: {contact.nearest_points[1]}")
-        print(f"  Normal: {contact.normal}")
+# ContactResultMap is a nested map (link_a → link_b → list[ContactResult]).
+# Flatten it to iterate individual contacts.
+result_vector = ContactResultVector()
+result_map.flattenMoveResults(result_vector)   # or flattenCopyResults()
+
+for contact in result_vector:
+    print(f"Contact: {contact.link_names[0]} <-> {contact.link_names[1]}")
+    print(f"  Distance: {contact.distance}")
+    print(f"  Point A: {contact.nearest_points[0]}")
+    print(f"  Point B: {contact.nearest_points[1]}")
+    print(f"  Normal: {contact.normal}")
 ```
 
 | Attribute | Type | Description |
@@ -101,7 +106,9 @@ for key, results in result_map.items():
 
 ### ContactResultMap
 
-Dictionary of contacts by link pair.
+Nested map: `link_a → link_b → list[ContactResult]`. Exposes `size()`,
+`empty()`, `count()`, `clear()`, `getSummary()`, and
+`flattenCopyResults()` / `flattenMoveResults()` for iteration.
 
 ```python
 from tesseract_robotics.tesseract_collision import ContactResultMap
@@ -109,22 +116,22 @@ from tesseract_robotics.tesseract_collision import ContactResultMap
 result_map = ContactResultMap()
 manager.contactTest(result_map, request)
 
-# Iterate results
-for pair_key, contacts in result_map.items():
-    print(f"Pair {pair_key}: {len(contacts)} contacts")
+print(f"{result_map.size()} contact pairs")
+print(result_map.getSummary())
 ```
 
 ### ContactResultVector
 
-List of contact results.
+Flat list of `ContactResult`. Use this for iteration.
 
 ```python
 from tesseract_robotics.tesseract_collision import ContactResultVector
 
-# Flatten all contacts
 all_contacts = ContactResultVector()
-for contacts in result_map.values():
-    all_contacts.extend(contacts)
+result_map.flattenMoveResults(all_contacts)   # or flattenCopyResults to keep map data
+
+for contact in all_contacts:
+    print(contact.distance, contact.link_names)
 ```
 
 ## Configuration
@@ -182,7 +189,7 @@ CollisionEvaluatorType.CONTINUOUS         # continuous
 
 ```python
 from tesseract_robotics.tesseract_collision import (
-    ContactRequest, ContactTestType, ContactResultMap
+    ContactRequest, ContactTestType, ContactResultMap, ContactResultVector
 )
 
 # Setup
@@ -191,7 +198,7 @@ request = ContactRequest()
 request.type = ContactTestType.ALL
 
 # Set state
-env.setState(joint_values)
+env.setState({"joint_1": 0.0, "joint_2": 0.0})
 state = env.getState()
 manager.setCollisionObjectsTransform(state.link_transforms)
 
@@ -200,12 +207,12 @@ results = ContactResultMap()
 manager.contactTest(results, request)
 
 # Process results
-is_collision = len(results) > 0
-if is_collision:
-    for contacts in results.values():
-        for c in contacts:
-            if c.distance < 0:
-                print(f"Penetration: {c.link_names} depth={-c.distance:.4f}")
+if not results.empty():
+    contacts = ContactResultVector()
+    results.flattenMoveResults(contacts)
+    for c in contacts:
+        if c.distance < 0:
+            print(f"Penetration: {c.link_names} depth={-c.distance:.4f}")
 ```
 
 ## Auto-generated API Reference

--- a/docs/api/tesseract_command_language.md
+++ b/docs/api/tesseract_command_language.md
@@ -50,10 +50,12 @@ from tesseract_robotics.tesseract_command_language import (
     CartesianWaypoint, CartesianWaypointPoly, CartesianWaypointPoly_wrap_CartesianWaypoint
 )
 from tesseract_robotics.tesseract_common import Isometry3d
+import numpy as np
 
-# Create target pose
-pose = Isometry3d.Identity()
-pose.translate([0.5, 0.2, 0.3])
+# Create target pose (build the 4x4 matrix then wrap)
+mat = np.eye(4)
+mat[:3, 3] = [0.5, 0.2, 0.3]
+pose = Isometry3d(mat)
 
 # Create waypoint
 wp = CartesianWaypoint(pose)
@@ -141,9 +143,13 @@ program.setManipulatorInfo(manip_info)
 program.appendMoveInstruction(move1)
 program.appendMoveInstruction(move2)
 
+# push_back accepts either a single Instruction or a nested CompositeInstruction
+# (0.35+) so raster-style programs can be built the same way they are in C++:
+program.push_back(sub_composite)
+
 # Iterate instructions
-for i in range(len(program)):
-    instr = program[i]
+for instr in program.getInstructions():
+    pass
 ```
 
 ### CompositeInstructionOrder
@@ -216,6 +222,7 @@ from tesseract_robotics.tesseract_command_language import (
     StateWaypoint, StateWaypointPoly_wrap_StateWaypoint,
     CartesianWaypoint, CartesianWaypointPoly_wrap_CartesianWaypoint,
     MoveInstruction, MoveInstructionType,
+    MoveInstructionPoly_wrap_MoveInstruction,
     CompositeInstruction,
 )
 from tesseract_robotics.tesseract_common import ManipulatorInfo, Isometry3d
@@ -224,8 +231,10 @@ import numpy as np
 # Setup
 joint_names = ["j1", "j2", "j3", "j4", "j5", "j6"]
 start_joints = np.zeros(6)
-goal_pose = Isometry3d.Identity()
-goal_pose.translate([0.5, 0.2, 0.3])
+
+goal_mat = np.eye(4)
+goal_mat[:3, 3] = [0.5, 0.2, 0.3]
+goal_pose = Isometry3d(goal_mat)
 
 # Create waypoints
 start_wp = StateWaypointPoly_wrap_StateWaypoint(
@@ -235,9 +244,13 @@ goal_wp = CartesianWaypointPoly_wrap_CartesianWaypoint(
     CartesianWaypoint(goal_pose)
 )
 
-# Create instructions
-start_instr = MoveInstruction(start_wp, MoveInstructionType.FREESPACE, "DEFAULT")
-goal_instr = MoveInstruction(goal_wp, MoveInstructionType.LINEAR, "DEFAULT")
+# Create instructions (wrap in MoveInstructionPoly before appending)
+start_instr = MoveInstructionPoly_wrap_MoveInstruction(
+    MoveInstruction(start_wp, MoveInstructionType.FREESPACE, "DEFAULT")
+)
+goal_instr = MoveInstructionPoly_wrap_MoveInstruction(
+    MoveInstruction(goal_wp, MoveInstructionType.LINEAR, "DEFAULT")
+)
 
 # Create program
 program = CompositeInstruction("DEFAULT")

--- a/docs/api/tesseract_common.md
+++ b/docs/api/tesseract_common.md
@@ -6,7 +6,7 @@ Common types, utilities, and resource handling.
 
 ### Isometry3d
 
-Rigid body transformation (rotation + translation).
+Eigen rigid-body transform (rotation + translation). Raw C++ binding.
 
 ```python
 from tesseract_robotics.tesseract_common import Isometry3d
@@ -15,36 +15,54 @@ import numpy as np
 # Identity transform
 pose = Isometry3d.Identity()
 
-# From 4x4 matrix
+# From a 4x4 matrix
 mat = np.eye(4)
 mat[:3, 3] = [0.5, 0.2, 0.3]
 pose = Isometry3d(mat)
 
-# Access components
+# Access components (translation() / rotation() / matrix() are METHODS)
 position = pose.translation()  # np.array([x, y, z])
 rotation = pose.rotation()     # 3x3 rotation matrix
 matrix = pose.matrix()         # 4x4 homogeneous matrix
 
-# Transform operations
-pose.translate([0.1, 0, 0])    # translate in place
-pose.rotate(rotation_matrix)   # rotate in place
-combined = pose1 * pose2       # compose transforms
+# Compose
+combined = pose1 * pose2
 ```
+
+!!! tip "Prefer `planning.Pose` for authoring"
+    For building/serializing transforms in Python, use
+    `tesseract_robotics.planning.Pose` — it accepts scalar-last quaternions
+    (`qx, qy, qz, qw`, matching scipy's `Rotation.as_quat()`) and offers
+    `from_xyz_quat`, `from_rpy`, etc. Convert to an `Isometry3d` when calling
+    the raw C++ API.
+
+    ```python
+    from tesseract_robotics.planning import Pose
+    pose = Pose.from_xyz_quat(0.5, 0.2, 0.3, 0, 0, 0, 1)
+    iso = Isometry3d(pose.matrix)
+    ```
 
 ### Quaterniond
 
-Quaternion rotation (w, x, y, z).
+Eigen quaternion, **scalar-first** (`w, x, y, z`) — matches Eigen's C++
+convention.
 
 ```python
 from tesseract_robotics.tesseract_common import Quaterniond
 
-q = Quaterniond(w=1.0, x=0.0, y=0.0, z=0.0)  # identity
-q = Quaterniond.Identity()
+q = Quaterniond(1.0, 0.0, 0.0, 0.0)  # identity: w, x, y, z
 
 # Access
 print(f"w={q.w()}, x={q.x()}, y={q.y()}, z={q.z()}")
 rotation_matrix = q.toRotationMatrix()
 ```
+
+!!! warning "Quaternion conventions differ"
+    - `Quaterniond` (raw Eigen) is **scalar-first** (`w, x, y, z`).
+    - `planning.Pose.quaternion` is **scalar-last** (`qx, qy, qz, qw`),
+      matching scipy.
+
+    Reorder components when crossing the boundary.
 
 ### AngleAxisd
 

--- a/docs/api/tesseract_environment.md
+++ b/docs/api/tesseract_environment.md
@@ -12,12 +12,18 @@ from tesseract_robotics.tesseract_environment import Environment
 # Create empty environment
 env = Environment()
 
-# Initialize from URDF/SRDF
-env.init(urdf_string, srdf_string, locator)
+# From URDF + SRDF paths (+ ResourceLocator for mesh resolution)
+env.init(urdf_path, srdf_path, locator)
 
-# Or use Robot helper
+# Or from raw XML strings
+env.initFromUrdfSrdf(urdf_xml, srdf_xml, locator)
+
+# Or use the high-level Robot helper (takes BOTH URDF and SRDF)
 from tesseract_robotics.planning import Robot
-robot = Robot.from_urdf("robot.urdf", "robot.srdf")
+robot = Robot.from_urdf(
+    "package://my_robot/urdf/robot.urdf",
+    "package://my_robot/urdf/robot.srdf",
+)
 env = robot.env
 ```
 
@@ -41,10 +47,9 @@ joint = env.getJoint("joint_1")
 state = env.getState()
 joint_positions = state.joints
 
-# Set joint state
-env.setState(["joint_1", "joint_2"], [0.5, -0.3])
-# Or with dict
-env.setState({"joint_1": 0.5, "joint_2": -0.3})
+# Set joint state — two overloads
+env.setState({"joint_1": 0.5, "joint_2": -0.3})          # dict form
+env.setState(["joint_1", "joint_2"], np.array([0.5, -0.3]))  # names + values
 
 # Get link transform
 tcp = env.getLinkTransform("tool0")
@@ -93,7 +98,7 @@ Add a new link to the scene.
 
 ```python
 from tesseract_robotics.tesseract_environment import AddLinkCommand
-from tesseract_robotics.tesseract_scene_graph import Link, Joint
+from tesseract_robotics.tesseract_scene_graph import Link, Joint, JointType
 
 link = Link("obstacle")
 # ... configure link with visual/collision
@@ -136,9 +141,12 @@ Change a joint's transform.
 
 ```python
 from tesseract_robotics.tesseract_environment import ChangeJointOriginCommand
+from tesseract_robotics.tesseract_common import Isometry3d
+import numpy as np
 
-new_origin = Isometry3d.Identity()
-new_origin.translate([0.1, 0, 0])
+mat = np.eye(4)
+mat[:3, 3] = [0.1, 0, 0]
+new_origin = Isometry3d(mat)
 
 cmd = ChangeJointOriginCommand("obstacle_joint", new_origin)
 env.applyCommand(cmd)
@@ -203,12 +211,18 @@ Update collision margins.
 
 ```python
 from tesseract_robotics.tesseract_environment import ChangeCollisionMarginsCommand
-from tesseract_robotics.tesseract_common import CollisionMarginData
 
-margins = CollisionMarginData()
-margins.setDefaultCollisionMargin(0.05)
+# Simplified 0.34 constructor — just pass the new default margin
+cmd = ChangeCollisionMarginsCommand(0.05)
+env.applyCommand(cmd)
 
-cmd = ChangeCollisionMarginsCommand(margins)
+# Or override per-pair margins via CollisionMarginPairData
+from tesseract_robotics.tesseract_common import (
+    CollisionMarginPairData, CollisionMarginPairOverrideType
+)
+pair_data = CollisionMarginPairData()
+pair_data.setCollisionMargin("link_a", "link_b", 0.1)
+cmd = ChangeCollisionMarginsCommand(pair_data, CollisionMarginPairOverrideType.REPLACE)
 env.applyCommand(cmd)
 ```
 

--- a/docs/api/tesseract_kinematics.md
+++ b/docs/api/tesseract_kinematics.md
@@ -58,49 +58,43 @@ print(f"TCP rotation:\n{tcp_pose.rotation()}")
 
 ## Inverse Kinematics
 
-Compute joint values for target pose.
+Compute joint values for a target pose. `calcInvKin` takes a `KinGroupIKInput`
+(not a raw `Isometry3d`) — it bundles the target pose with the tip link and
+working frame.
 
 ```python
 from tesseract_robotics.tesseract_common import Isometry3d
+from tesseract_robotics.tesseract_kinematics import KinGroupIKInput
+import numpy as np
 
 manip = env.getKinematicGroup("manipulator")
 
-# Target pose
-target = Isometry3d.Identity()
-target.translate([0.5, 0.2, 0.3])
+# Build target
+mat = np.eye(4)
+mat[:3, 3] = [0.5, 0.2, 0.3]
+target_pose = Isometry3d(mat)
 
-# Seed (initial guess)
+ik_input = KinGroupIKInput(target_pose, "base_link", "tool0")
 seed = np.zeros(6)
 
-# Solve IK
-solutions = manip.calcInvKin(target, seed)
+solutions = manip.calcInvKin(ik_input, seed)
 
 if solutions:
     print(f"Found {len(solutions)} solutions")
     best = solutions[0]
-    print(f"Solution: {best}")
 else:
     print("No IK solution found")
 ```
 
-### KinGroupIKInput
-
-Batch IK for multiple targets.
+### Batch IK — KinGroupIKInputs
 
 ```python
-from tesseract_robotics.tesseract_kinematics import KinGroupIKInput, KinGroupIKInputs
+from tesseract_robotics.tesseract_kinematics import KinGroupIKInputs
 
-# Single IK input
-ik_input = KinGroupIKInput()
-ik_input.pose = target_pose
-ik_input.tip_link_name = "tool0"
-ik_input.working_frame = "base_link"
-
-# Multiple inputs
 inputs = KinGroupIKInputs()
 inputs.append(ik_input)
+inputs.append(another_input)
 
-# Solve
 solutions = manip.calcInvKin(inputs, seed)
 ```
 
@@ -114,12 +108,12 @@ from tesseract_robotics.tesseract_kinematics import getRedundantSolutions
 # Initial solution
 solution = solutions[0]
 
-# Get redundant solutions (considering joint limits)
+# Get redundant solutions by adding ±2π to redundancy-capable joints
+# Signature: getRedundantSolutions(sol, limits[:, 0:2], redundancy_capable_joint_indices)
 redundant = getRedundantSolutions(
     solution,
-    limits.joint_limits[:, 0],  # lower
-    limits.joint_limits[:, 1],  # upper
-    np.array([2*np.pi] * 6)     # resolution
+    limits.joint_limits,       # N×2 matrix (lower, upper per joint)
+    [5],                       # redundant joint indices (e.g., last wrist joint)
 )
 ```
 
@@ -158,6 +152,8 @@ from tesseract_robotics.tesseract_kinematics import KinematicsPluginFactory
 
 ```python
 from tesseract_robotics.planning import Robot
+from tesseract_robotics.tesseract_common import Isometry3d
+from tesseract_robotics.tesseract_kinematics import KinGroupIKInput
 import numpy as np
 
 # Load robot
@@ -169,12 +165,13 @@ joints = np.array([0.0, 0.0, 0.0, 0.0, 0.0, 0.0])
 fk = manip.calcFwdKin(joints)
 current_pose = fk["tool0"]
 
-# Move 10cm in X
-target = Isometry3d(current_pose.matrix())
-target.translate([0.1, 0, 0])
+# Move 10cm in X — build a new 4x4 matrix
+mat = current_pose.matrix().copy()
+mat[0, 3] += 0.1
+target_pose = Isometry3d(mat)
 
 # Solve IK
-solutions = manip.calcInvKin(target, joints)
+solutions = manip.calcInvKin(KinGroupIKInput(target_pose, "base_link", "tool0"), joints)
 
 if solutions:
     # Verify solution
@@ -182,7 +179,7 @@ if solutions:
     check_pose = fk_check["tool0"]
 
     error = np.linalg.norm(
-        target.translation() - check_pose.translation()
+        target_pose.translation() - check_pose.translation()
     )
     print(f"Position error: {error:.6f} m")
 ```

--- a/docs/api/tesseract_motion_planners_ompl.md
+++ b/docs/api/tesseract_motion_planners_ompl.md
@@ -38,32 +38,36 @@ response = planner.solve(request)
 
 ### OMPLRealVectorPlanProfile
 
-Configure OMPL planning behavior.
+Configure OMPL planning behavior. The profile has three sub-configs:
+`solver_config`, `collision_check_config`, and `contact_manager_config`.
 
 ```python
-from tesseract_robotics.tesseract_motion_planners_ompl import OMPLRealVectorPlanProfile
+from tesseract_robotics.tesseract_motion_planners_ompl import (
+    OMPLRealVectorPlanProfile, RRTConnectConfigurator,
+)
 
 profile = OMPLRealVectorPlanProfile()
 
-# Planning time
-profile.planning_time = 5.0  # seconds
+# Solver settings
+profile.solver_config.planning_time = 5.0   # seconds
+profile.solver_config.simplify = True       # simplify path after planning
+profile.solver_config.optimize = True       # run path optimization
 
-# Simplification
-profile.simplify = True
+# Add planner configurator(s)
+profile.solver_config.addPlanner(RRTConnectConfigurator())
 
-# State validation resolution
+# State-validation resolution (for collision checking)
 profile.collision_check_config.longest_valid_segment_length = 0.01
-
-# Add planner configurator
-profile.planners = [RRTConnectConfigurator()]
 ```
 
-| Attribute | Type | Default | Description |
-|-----------|------|---------|-------------|
-| `planning_time` | `float` | 5.0 | Max planning time (seconds) |
-| `simplify` | `bool` | True | Simplify path after planning |
-| `optimize` | `bool` | True | Run path optimization |
-| `planners` | `list` | `[RRTConnect]` | Planner configurators |
+| Attribute | Config | Description |
+|---|---|---|
+| `solver_config.planning_time` | solver | Max planning time (seconds) |
+| `solver_config.simplify` | solver | Simplify path after planning |
+| `solver_config.optimize` | solver | Run path optimization |
+| `solver_config.max_solutions` | solver | Cap on returned paths |
+| `collision_check_config.longest_valid_segment_length` | collision | State-validation resolution |
+| `collision_check_config.type` | collision | `CollisionEvaluatorType` (discrete vs continuous) |
 
 ## Planner Configurators
 
@@ -77,7 +81,7 @@ from tesseract_robotics.tesseract_motion_planners_ompl import RRTConnectConfigur
 config = RRTConnectConfigurator()
 config.range = 0.0  # 0 = auto
 
-profile.planners = [config]
+profile.solver_config.addPlanner(config)
 ```
 
 ### RRTstarConfigurator
@@ -91,7 +95,7 @@ config = RRTstarConfigurator()
 config.range = 0.0
 config.goal_bias = 0.05
 
-profile.planners = [config]
+profile.solver_config.addPlanner(config)
 ```
 
 ### SBLConfigurator
@@ -104,7 +108,7 @@ from tesseract_robotics.tesseract_motion_planners_ompl import SBLConfigurator
 config = SBLConfigurator()
 config.range = 0.0
 
-profile.planners = [config]
+profile.solver_config.addPlanner(config)
 ```
 
 ## OMPLPlannerType
@@ -134,12 +138,12 @@ from tesseract_robotics.tesseract_motion_planners_ompl import (
 
 # Create profile
 profile = OMPLRealVectorPlanProfile()
-profile.planning_time = 10.0
-profile.planners = [RRTConnectConfigurator()]
+profile.solver_config.planning_time = 10.0
+profile.solver_config.addPlanner(RRTConnectConfigurator())
 
-# Add to dictionary
+# Add to dictionary (dict, namespace, profile_name, profile)
 profiles = ProfileDictionary()
-ProfileDictionary_addOMPLProfile(profiles, "DEFAULT", profile)
+ProfileDictionary_addOMPLProfile(profiles, "OMPLMotionPlannerTask", "DEFAULT", profile)
 
 # Use with planner request
 request.profiles = profiles
@@ -157,12 +161,12 @@ from tesseract_robotics.tesseract_command_language import ProfileDictionary
 
 # Configure OMPL profile
 profile = OMPLRealVectorPlanProfile()
-profile.planning_time = 5.0
-profile.simplify = True
-profile.planners = [RRTConnectConfigurator()]
+profile.solver_config.planning_time = 5.0
+profile.solver_config.simplify = True
+profile.solver_config.addPlanner(RRTConnectConfigurator())
 
 profiles = ProfileDictionary()
-ProfileDictionary_addOMPLProfile(profiles, "DEFAULT", profile)
+ProfileDictionary_addOMPLProfile(profiles, "OMPLMotionPlannerTask", "DEFAULT", profile)
 
 # Create request
 request = PlannerRequest()

--- a/docs/api/tesseract_motion_planners_trajopt.md
+++ b/docs/api/tesseract_motion_planners_trajopt.md
@@ -59,8 +59,9 @@ profile.cartesian_constraint_config.coeff = np.array([5.0, 5.0, 5.0, 2.0, 2.0, 2
 profile.cartesian_cost_config.enabled = True
 profile.cartesian_cost_config.coeff = np.array([5.0, 5.0, 5.0, 2.0, 2.0, 2.0])
 
-# Joint waypoint config (uses joint_cost_config / joint_*_config too)
-# (availability depends on profile subtype; see source for current attributes)
+# Joint waypoint config
+profile.joint_constraint_config.enabled = True
+profile.joint_constraint_config.coeff = np.ones(6)  # weight per joint
 ```
 
 ### TrajOptDefaultCompositeProfile
@@ -73,10 +74,10 @@ from tesseract_robotics.tesseract_collision import CollisionEvaluatorType
 
 profile = TrajOptDefaultCompositeProfile()
 
-# Collision avoidance (0.33 API: TrajOptCollisionConfig)
+# Collision avoidance — collision_*_config is a TrajOptCollisionConfig
 profile.collision_cost_config.enabled = True
-profile.collision_cost_config.collision_margin_buffer = 0.025  # was safety_margin
-profile.collision_cost_config.collision_coeff_data.setDefaultCollisionCoeff(20.0)  # was .coeff
+profile.collision_cost_config.collision_margin_buffer = 0.025
+profile.collision_cost_config.collision_coeff_data.setDefaultCollisionCoeff(20.0)
 profile.collision_cost_config.collision_check_config.type = CollisionEvaluatorType.DISCRETE
 
 profile.collision_constraint_config.enabled = False  # use cost, not constraint
@@ -90,11 +91,12 @@ profile.velocity_coeff = np.ones(6)
 profile.acceleration_coeff = np.ones(6)
 ```
 
-## Collision Configuration (0.33 API)
+## Collision Configuration
 
 ### TrajOptCollisionConfig
 
-Replaces the old `CollisionCostConfig` and `CollisionConstraintConfig`.
+Replaces the 0.33 `CollisionCostConfig` / `CollisionConstraintConfig`.
+See [changes](../changes.md) for the full migration notes.
 
 ```python
 from tesseract_robotics.tesseract_motion_planners_trajopt import TrajOptCollisionConfig
@@ -111,13 +113,15 @@ config.collision_check_config.longest_valid_segment_length = 0.05  # for LVS mod
 ### CollisionEvaluatorType
 
 !!! note "Module Location"
-    `CollisionEvaluatorType` moved to `tesseract_collision` in 0.33 API.
+    `CollisionEvaluatorType` lives in
+    `tesseract_robotics.tesseract_collision` (re-exported from the TrajOpt
+    module for convenience).
 
 | Type | Description | Speed |
 |------|-------------|-------|
-| `DISCRETE` | Check at waypoints only (was `SINGLE_TIMESTEP`) | Fast |
-| `LVS_DISCRETE` | Interpolate between waypoints | Medium |
-| `LVS_CONTINUOUS` | Swept volume check (was `DISCRETE_CONTINUOUS`) | Slow |
+| `DISCRETE` | Check at waypoints only | Fast |
+| `LVS_DISCRETE` | Interpolate between waypoints, discrete checks | Medium |
+| `LVS_CONTINUOUS` | Swept volume check, LVS interpolation | Slow |
 | `CONTINUOUS` | Full continuous collision | Slowest |
 
 ## Waypoint Configurations
@@ -188,7 +192,7 @@ from tesseract_robotics.tesseract_command_language import ProfileDictionary
 from tesseract_robotics.tesseract_collision import CollisionEvaluatorType
 import numpy as np
 
-# Configure profiles (0.33 API)
+# Configure profiles
 plan_profile = TrajOptDefaultPlanProfile()
 plan_profile.cartesian_constraint_config.enabled = True
 plan_profile.cartesian_constraint_config.coeff = np.array([10, 10, 10, 5, 5, 5])

--- a/docs/api/tesseract_motion_planners_trajopt.md
+++ b/docs/api/tesseract_motion_planners_trajopt.md
@@ -12,12 +12,17 @@ from tesseract_robotics.tesseract_motion_planners_trajopt import (
     TrajOptMotionPlanner,
     TrajOptDefaultPlanProfile, TrajOptDefaultCompositeProfile,
     TrajOptPlanProfile, TrajOptCompositeProfile,
-    TrajOptCollisionConfig,  # 0.33 API
+    TrajOptCollisionConfig,
     ProfileDictionary_addTrajOptPlanProfile,
     ProfileDictionary_addTrajOptCompositeProfile,
 )
 from tesseract_robotics.tesseract_collision import CollisionEvaluatorType
 ```
+
+!!! note "`TrajOptCollisionConfig` lives in `trajopt_ifopt`"
+    It's defined in `tesseract_robotics.trajopt_ifopt` (trajopt_common) and
+    re-exported from `tesseract_motion_planners_trajopt` for convenience. Import
+    from either location.
 
 ## TrajOptMotionPlanner
 
@@ -46,7 +51,7 @@ from tesseract_robotics.tesseract_motion_planners_trajopt import TrajOptDefaultP
 
 profile = TrajOptDefaultPlanProfile()
 
-# Cartesian waypoint config (0.33 API)
+# Cartesian waypoint config
 profile.cartesian_constraint_config.enabled = True
 profile.cartesian_constraint_config.coeff = np.array([5.0, 5.0, 5.0, 2.0, 2.0, 2.0])  # xyz, rpy weights
 
@@ -54,9 +59,8 @@ profile.cartesian_constraint_config.coeff = np.array([5.0, 5.0, 5.0, 2.0, 2.0, 2
 profile.cartesian_cost_config.enabled = True
 profile.cartesian_cost_config.coeff = np.array([5.0, 5.0, 5.0, 2.0, 2.0, 2.0])
 
-# Joint waypoint config
-profile.joint_constraint_config.enabled = True
-profile.joint_constraint_config.coeff = np.ones(6)  # weight per joint
+# Joint waypoint config (uses joint_cost_config / joint_*_config too)
+# (availability depends on profile subtype; see source for current attributes)
 ```
 
 ### TrajOptDefaultCompositeProfile

--- a/docs/api/tesseract_scene_graph.md
+++ b/docs/api/tesseract_scene_graph.md
@@ -26,9 +26,10 @@ link = graph.getLink("base_link")
 joint = graph.getJoint("joint_1")
 
 # Kinematic queries
-children = graph.getChildren("base_link")
-parent = graph.getParent("tool0")
+child_joints = graph.getJointChildrenNames("base_link")
+child_links = graph.getLinkChildrenNames("base_link")
 path = graph.getShortestPath("base_link", "tool0")
+root = graph.getRoot()
 ```
 
 ## Link

--- a/docs/api/tesseract_serialization.md
+++ b/docs/api/tesseract_serialization.md
@@ -1,9 +1,27 @@
 # tesseract_robotics.tesseract_serialization
 
-XML and binary serialization for root types via Boost.Serialization.
+XML and binary serialization for root types. The backend switched from
+Boost.Serialization (0.33) to Cereal (0.34); the Python API is unchanged.
+See the [Serialization User Guide](../user-guide/serialization.md) for a
+walkthrough and the [migration notes](../changes.md) if you have 0.33 archives.
+
+## Free functions
+
+Each supported type exposes paired `to_*` / `from_*` functions for the three
+archive formats:
+
+| Type | XML | Binary | File (auto) |
+|---|---|---|---|
+| `CompositeInstruction` | `composite_instruction_to_xml` / `composite_instruction_from_xml` | `composite_instruction_to_binary` / `composite_instruction_from_binary` | `composite_instruction_to_file` / `composite_instruction_from_file` |
+| `Environment` | `environment_to_xml` / `environment_from_xml` | `environment_to_binary` / `environment_from_binary` | `environment_to_file` / `environment_from_file` |
+| `SceneState` | `scene_state_to_xml` / `scene_state_from_xml` | `scene_state_to_binary` / `scene_state_from_binary` | `scene_state_to_file` / `scene_state_from_file` |
+
+The `*_to_file` / `*_from_file` helpers auto-detect the format from the path
+suffix (`.xml` vs `.bin`).
 
 ::: tesseract_robotics.tesseract_serialization
     options:
       show_root_heading: true
       show_source: false
       members_order: source
+      heading_level: 3

--- a/docs/api/tesseract_task_composer.md
+++ b/docs/api/tesseract_task_composer.md
@@ -264,16 +264,23 @@ else:
 
 ## High-Level Alternative
 
-For simpler usage, use the `tesseract_robotics.planning` module:
+For most users the `tesseract_robotics.planning` module is simpler:
 
 ```python
-from tesseract_robotics.planning import Robot, plan
+from tesseract_robotics.planning import Robot, TaskComposer, plan_freespace
 
 robot = Robot.from_tesseract_support("abb_irb2400")
-result = plan(robot, program, pipeline="FreespaceMotionPipeline")
+
+# One-liner — picks pipeline defaults per entry point
+result = plan_freespace(robot, program)
+
+# Or reuse a composer to amortize plugin loading across calls
+composer = TaskComposer.from_config(warmup=True)
+result = composer.plan(robot, program, pipeline="TrajOptPipeline")
 
 if result.successful:
-    trajectory = result.trajectory
+    for point in result:
+        print(point.positions)
 ```
 
 ## Auto-generated API Reference

--- a/docs/api/trajopt_ifopt.md
+++ b/docs/api/trajopt_ifopt.md
@@ -1,305 +1,103 @@
 # tesseract_robotics.trajopt_ifopt
 
-Robotics-specific constraints and variables for trajectory optimization.
+Constraints, costs, and variables for the low-level SQP solver.
+See the [Low-Level SQP guide](../user-guide/low-level-sqp.md) for the user-guide walkthrough.
 
-## Overview
+## Variables (0.34+)
 
-```python
-from tesseract_robotics.trajopt_ifopt import (
-    # Variables
-    JointPosition,
-    # Joint constraints
-    JointPosConstraint, JointVelConstraint, JointAccelConstraint, JointJerkConstraint,
-    # Cartesian constraints
-    CartPosInfo, CartPosConstraint, CartLineInfo, CartLineConstraint,
-    # Collision constraints
-    TrajOptCollisionConfig, DiscreteCollisionConstraint, ContinuousCollisionConstraint,
-    # IK constraint
-    InverseKinematicsInfo, InverseKinematicsConstraint,
-    # Utilities
-    interpolate, toBounds,
-)
-```
+The `JointPosition` class from 0.33 is removed. Variables now use a three-level hierarchy.
 
-## Variables
+### Var
 
-### JointPosition
+A single variable — typically one joint value at one waypoint.
 
-Optimization variable representing joint configuration at a timestep.
+### Node
+
+Groups multiple `Var`s per waypoint (e.g., joints + velocities at one waypoint).
+
+### NodesVariables
+
+Container of `Node`s. Passed to `IfoptProblem`.
+
+### createNodesVariables
+
+Factory helper. Builds the full hierarchy from a list of initial states.
 
 ```python
-from tesseract_robotics.trajopt_ifopt import JointPosition
-import numpy as np
+from tesseract_robotics.trajopt_ifopt import Bounds, createNodesVariables
 
-joint_names = ["joint_1", "joint_2", "joint_3", "joint_4", "joint_5", "joint_6"]
-initial_values = np.array([0.0, -0.5, 0.5, 0.0, 0.5, 0.0])
-
-# Create variable
-var = JointPosition(initial_values, joint_names, "position_0")
-
-# Access values
-print(f"Values: {var.GetValues()}")
-print(f"Names: {var.GetJointNames()}")
-
-# Set bounds
-from tesseract_robotics.ifopt import Bounds
-bounds = [Bounds(-3.14, 3.14) for _ in range(6)]
-var.SetBounds(bounds)
-```
-
-| Method | Returns | Description |
-|--------|---------|-------------|
-| `GetValues()` | `np.ndarray` | Current joint values |
-| `SetVariables(x)` | `None` | Set joint values |
-| `GetJointNames()` | `list[str]` | Joint names |
-| `GetBounds()` | `list[Bounds]` | Joint limits |
-| `SetBounds(bounds)` | `None` | Set joint limits |
-
-## Joint Constraints
-
-### JointPosConstraint
-
-Constrain joint positions to target values.
-
-```python
-from tesseract_robotics.trajopt_ifopt import JointPosConstraint
-import numpy as np
-
-targets = np.array([0.0, 0.0, 0.0, 0.0, 0.0, 0.0])  # home position
-coeffs = np.ones(6)  # weight per joint
-
-constraint = JointPosConstraint(targets, position_var, coeffs, "joint_pos")
-```
-
-### JointVelConstraint
-
-Constrain joint velocities between consecutive timesteps.
-
-```python
-from tesseract_robotics.trajopt_ifopt import JointVelConstraint
-
-targets = np.zeros(6)  # zero velocity
-coeffs = np.ones(6)
-
-# Requires two consecutive position variables
-constraint = JointVelConstraint(targets, [pos_var_0, pos_var_1], coeffs, "joint_vel")
-```
-
-### JointAccelConstraint
-
-Constrain joint accelerations (requires 3 consecutive positions).
-
-```python
-from tesseract_robotics.trajopt_ifopt import JointAccelConstraint
-
-targets = np.zeros(6)
-coeffs = np.ones(6)
-
-constraint = JointAccelConstraint(
-    targets, [pos_var_0, pos_var_1, pos_var_2], coeffs, "joint_accel"
-)
-```
-
-### JointJerkConstraint
-
-Constrain joint jerk (requires 4 consecutive positions).
-
-```python
-from tesseract_robotics.trajopt_ifopt import JointJerkConstraint
-
-targets = np.zeros(6)
-coeffs = np.ones(6)
-
-constraint = JointJerkConstraint(
-    targets, [pos_var_0, pos_var_1, pos_var_2, pos_var_3], coeffs, "joint_jerk"
-)
-```
-
-## Cartesian Constraints
-
-### CartPosInfo / CartPosConstraint
-
-Constrain TCP to a Cartesian pose.
-
-```python
-from tesseract_robotics.trajopt_ifopt import CartPosInfo, CartPosInfoType, CartPosConstraint
-from tesseract_robotics.tesseract_common import Isometry3d
-
-# Create info struct
-info = CartPosInfo()
-info.manip = kin_group  # KinematicGroup from env.getKinematicGroup()
-info.source_frame = "tool0"
-info.target_frame = "base_link"
-info.target_frame_offset = target_pose  # Isometry3d
-
-# Constraint indices (which DoFs to constrain)
-# CartPosInfoType: FULL (all 6), POSITION_ONLY (xyz), ORIENTATION_ONLY (rpy)
-info.indices = [0, 1, 2, 3, 4, 5]  # all 6 DoF
-
-# Create constraint
-coeffs = np.array([10.0, 10.0, 10.0, 5.0, 5.0, 5.0])  # xyz, rpy weights
-constraint = CartPosConstraint(info, position_var, coeffs, "cart_pos")
-
-# Get current error
-values = constraint.GetValues()
-```
-
-### CartLineInfo / CartLineConstraint
-
-Constrain TCP to lie on a line between two points.
-
-```python
-from tesseract_robotics.trajopt_ifopt import CartLineInfo, CartLineConstraint
-
-info = CartLineInfo()
-info.manip = kin_group
-info.source_frame = "tool0"
-info.target_frame = "base_link"
-info.target_frame_offset1 = line_start  # Isometry3d
-info.target_frame_offset2 = line_end    # Isometry3d
-
-constraint = CartLineConstraint(info, position_var, coeffs, "cart_line")
-```
-
-## Collision Constraints
-
-### TrajOptCollisionConfig
-
-Configuration for collision checking.
-
-```python
-from tesseract_robotics.trajopt_ifopt import TrajOptCollisionConfig
-
-config = TrajOptCollisionConfig()
-config.contact_manager_config.margin_data_override_type = 0
-config.contact_manager_config.margin_data.setDefaultCollisionMargin(0.025)
-config.collision_margin_buffer = 0.01
-config.collision_coeff_data.default_collision_coeff = 20.0
-```
-
-| Attribute | Type | Description |
-|-----------|------|-------------|
-| `contact_manager_config` | object | Contact manager settings |
-| `collision_margin_buffer` | `float` | Safety margin buffer |
-| `collision_coeff_data` | object | Collision cost coefficients |
-
-### DiscreteCollisionConstraint
-
-Collision avoidance at a single configuration.
-
-```python
-from tesseract_robotics.trajopt_ifopt import (
-    DiscreteCollisionConstraint, SingleTimestepCollisionEvaluator, CollisionCache
+bounds = Bounds(-3.14, 3.14)
+nodes_variables = createNodesVariables(
+    "trajectory", joint_names, initial_states, bounds
 )
 
-# Create evaluator
-cache = CollisionCache(100)
-evaluator = SingleTimestepCollisionEvaluator(
-    cache, kin_group, env, config, True  # True = dynamic environment
-)
-
-# Create constraint
-constraint = DiscreteCollisionConstraint(
-    evaluator,
-    position_var,
-    max_num_cnt=3,       # max collision pairs
-    fixed_sparsity=False,
-    name="collision"
-)
+# Iterate waypoints to pull Var refs for constraints
+vars_list = [node.getVar("joints") for node in nodes_variables.getNodes()]
 ```
 
-### ContinuousCollisionConstraint
+## Constraints
 
-Collision avoidance between consecutive configurations (swept volume).
+| Class | Purpose |
+|---|---|
+| `JointPosConstraint` | Target joint values at a waypoint |
+| `JointVelConstraint` | Velocity limits across consecutive waypoints |
+| `JointAccelConstraint` | Acceleration limits |
+| `JointJerkConstraint` | Jerk limits |
+| `CartPosConstraint` | TCP pose at a waypoint |
+| `CartLineConstraint` | TCP on a line segment between two poses |
+| `DiscreteCollisionConstraint` | Collision at a single waypoint |
+| `DiscreteCollisionNumericalConstraint` | Alternative collision jacobian (numerical) |
+| `ContinuousCollisionConstraint` | Collision between two consecutive waypoints |
+| `InverseKinematicsConstraint` | IK-based constraint |
 
-```python
-from tesseract_robotics.trajopt_ifopt import (
-    ContinuousCollisionConstraint, LVSContinuousCollisionEvaluator
-)
+0.34 constraint constructors take `Var` references directly (not
+`JointPosition` lists). See [changes](../changes.md) for the migration details.
 
-# LVS = Longest Valid Segment (interpolates and checks)
-evaluator = LVSContinuousCollisionEvaluator(
-    cache, kin_group, env, config, True
-)
+## Collision Evaluators
 
-# Constraint between two consecutive position variables
-constraint = ContinuousCollisionConstraint(
-    evaluator,
-    position_var_0,
-    position_var_1,
-    max_num_cnt=3,
-    fixed_sparsity=False,
-    name="continuous_collision"
-)
-```
+| Class | Pairs with |
+|---|---|
+| `SingleTimestepCollisionEvaluator` | `DiscreteCollisionConstraint` |
+| `LVSDiscreteCollisionEvaluator` | `ContinuousCollisionConstraint` (LVS discrete mode) |
+| `LVSContinuousCollisionEvaluator` | `ContinuousCollisionConstraint` (LVS continuous mode) |
+| `DiscreteCollisionEvaluator` | Base class |
+| `ContinuousCollisionEvaluator` | Base class |
 
-### Collision Evaluators
+`CollisionCache` was removed in 0.34 — caching is internal to each evaluator.
 
-| Class | Description |
-|-------|-------------|
-| `SingleTimestepCollisionEvaluator` | Discrete check at single config |
-| `LVSDiscreteCollisionEvaluator` | Discrete checks at interpolated points |
-| `LVSContinuousCollisionEvaluator` | Swept volume collision check |
+## Info Structs (for Cartesian / IK constraints)
 
-## IK Constraint
+| Struct | Used by |
+|---|---|
+| `CartLineInfo` | `CartLineConstraint` |
+| `InverseKinematicsInfo` | `InverseKinematicsConstraint` |
 
-### InverseKinematicsInfo / InverseKinematicsConstraint
+`CartPosInfo` from 0.33 is gone — `CartPosConstraint` now takes parameters
+directly (see [changes](../changes.md)).
 
-Constrain variables to match IK solution.
+## Config / Bounds
 
-```python
-from tesseract_robotics.trajopt_ifopt import InverseKinematicsInfo, InverseKinematicsConstraint
-
-info = InverseKinematicsInfo()
-info.manip = kin_group
-info.working_frame = "base_link"
-info.tcp_frame = "tool0"
-info.tcp_offset = Isometry3d.Identity()
-
-constraint = InverseKinematicsConstraint(
-    target_pose,      # Isometry3d
-    info,
-    constraint_var,   # variable to constrain
-    seed_var,         # seed for IK
-    "ik_constraint"
-)
-```
+- `TrajOptCollisionConfig(margin, coeff)` — re-exported here and from
+  `tesseract_motion_planners_trajopt`.
+- `CollisionCoeffData` — per-pair collision coefficient data.
+- `Bounds(lower, upper)` — single-variable bounds.
+- Enums: `BoundsType`, `RangeBoundHandling`.
 
 ## Utilities
 
-### interpolate
+- `interpolate(start, end, steps)` — linear joint interpolation.
+- `toBounds(joint_limits)` — convert a limits matrix into a `Bounds` list.
 
-Linear interpolation between joint configurations.
+## Module API
 
-```python
-from tesseract_robotics.trajopt_ifopt import interpolate
-import numpy as np
-
-start = np.array([0.0, 0.0, 0.0, 0.0, 0.0, 0.0])
-end = np.array([1.0, 1.0, 1.0, 1.0, 1.0, 1.0])
-steps = 10
-
-trajectory = interpolate(start, end, steps)  # (10, 6) array
-```
-
-### toBounds
-
-Convert numpy arrays to ifopt Bounds.
-
-```python
-from tesseract_robotics.trajopt_ifopt import toBounds
-import numpy as np
-
-lower = np.array([-3.14, -3.14, -3.14])
-upper = np.array([3.14, 3.14, 3.14])
-
-bounds = toBounds(lower, upper)  # list[Bounds]
-```
-
-## Auto-generated API Reference
-
-::: tesseract_robotics.trajopt_ifopt._trajopt_ifopt
+::: tesseract_robotics.trajopt_ifopt
     options:
-      show_root_heading: false
+      show_root_heading: true
       show_source: false
       members_order: source
+      heading_level: 3
+
+## See also
+
+- [Low-Level SQP API](../user-guide/low-level-sqp.md) — user-guide walkthrough
+- [0.33 → 0.34 migration](../changes.md) — if you're porting from the old `ifopt` module

--- a/docs/api/trajopt_sqp.md
+++ b/docs/api/trajopt_sqp.md
@@ -63,9 +63,11 @@ on the QP problem (no arguments) — the 0.33
 ## Parameters and Results
 
 - `SQPParameters` — configure iteration limits, trust region, penalty
-  coefficients.
-- `SQPResults` — `status`, `overall_cost`, `best_var_vals`, `cost_names`,
-  `constraint_names`.
+  coefficients. Mutated via `solver.params` before `solve()`.
+- `SQPResults` — the solver's iteration state. Notable attributes:
+  `best_var_vals`, `best_exact_merit`, `best_costs`, `best_constraint_violations`,
+  `cost_names`, `constraint_names`, plus the various iteration counters.
+- Solver status: `solver.getStatus()` returns the `SQPStatus` enum.
 
 ## Enums
 
@@ -85,11 +87,13 @@ The 0.33 `ConstraintType` enum was removed; if you referenced it, drop the usage
 
 ## Callbacks
 
+Override `execute(problem, results)` — return `False` to stop the solver.
+
 ```python
 class MyCallback(tsqp.SQPCallback):
-    def __call__(self, problem, results):
-        print(f"iter {results.best_var_vals}")
-        return True  # False stops the solver
+    def execute(self, problem, results):
+        print(f"iter {results.overall_iteration}: best_merit={results.best_exact_merit}")
+        return True
 
 solver.registerCallback(MyCallback())
 ```

--- a/docs/api/trajopt_sqp.md
+++ b/docs/api/trajopt_sqp.md
@@ -1,304 +1,110 @@
 # tesseract_robotics.trajopt_sqp
 
 Sequential Quadratic Programming (SQP) solver for trajectory optimization.
+See the [Low-Level SQP guide](../user-guide/low-level-sqp.md) for the user-guide walkthrough.
 
-## Overview
+## Problem hierarchy (0.34)
+
+0.34 splits the problem into two layers:
+
+- **`IfoptProblem(nodes_variables)`** — the non-linear program (NLP). Holds
+  the variables and accepts joint/cartesian/cost sets.
+- **`IfoptQPProblem(nlp)`** — the QP wrapper passed to the solver. Accepts
+  collision constraints and must be `setup()` before solving.
 
 ```python
-from tesseract_robotics.trajopt_sqp import (
-    # Solver
-    TrustRegionSQPSolver, OSQPEigenSolver,
-    # Problem types
-    IfoptQPProblem, IfoptProblem, QPProblem, QPSolver,
-    # Configuration
-    SQPParameters, SQPResults, SQPCallback,
-    # Enums
-    SQPStatus, QPSolverStatus, CostPenaltyType, ConstraintType,
-)
+from tesseract_robotics import trajopt_ifopt as ti
+from tesseract_robotics import trajopt_sqp as tsqp
+
+nodes_variables = ti.createNodesVariables("trajectory", joint_names, states, bounds)
+
+nlp = tsqp.IfoptProblem(nodes_variables)
+nlp.addConstraintSet(joint_constraint)   # joint / cartesian constraints on NLP
+nlp.addCostSet(vel_cost)                 # costs on NLP
+
+problem = tsqp.IfoptQPProblem(nlp)
+problem.addConstraintSet(collision_constraint)  # collision constraints on QP
+problem.setup()                                 # must call before solving
 ```
 
-## Quick Start
+`IfoptQPProblem` no longer has a default constructor — see
+[changes](../changes.md) for the full migration.
+
+## Solver
+
+### TrustRegionSQPSolver
+
+Main SQP solver with trust-region globalization.
 
 ```python
-from tesseract_robotics.trajopt_sqp import (
-    TrustRegionSQPSolver, OSQPEigenSolver, IfoptQPProblem, SQPParameters
-)
-from tesseract_robotics.trajopt_ifopt import JointPosition, JointVelConstraint
-from tesseract_robotics.ifopt import Bounds
-import numpy as np
-
-# Create variables
-joint_names = ["j1", "j2", "j3", "j4", "j5", "j6"]
-n_steps = 10
-variables = []
-for i in range(n_steps):
-    var = JointPosition(np.zeros(6), joint_names, f"pos_{i}")
-    var.SetBounds([Bounds(-3.14, 3.14)] * 6)
-    variables.append(var)
-
-# Create problem
-qp_solver = OSQPEigenSolver()
-nlp = IfoptQPProblem(qp_solver)
-
-# Add variables
-for var in variables:
-    nlp.addVariableSet(var)
-
-# Add constraints (e.g., velocity limits)
-for i in range(n_steps - 1):
-    vel_constraint = JointVelConstraint(
-        np.zeros(6), [variables[i], variables[i+1]], np.ones(6), f"vel_{i}"
-    )
-    nlp.addConstraintSet(vel_constraint)
-
-# Configure and solve
-params = SQPParameters()
-params.max_iterations = 50
-
-solver = TrustRegionSQPSolver(qp_solver)
-solver.init(nlp)
-solver.setParameters(params)
-solver.solve()
-
-# Get results
-results = solver.getResults()
-print(f"Status: {results.status}")
-print(f"Final cost: {results.overall_cost}")
-```
-
-## TrustRegionSQPSolver
-
-Main SQP solver with trust region method.
-
-```python
-from tesseract_robotics.trajopt_sqp import TrustRegionSQPSolver, OSQPEigenSolver
-
-qp_solver = OSQPEigenSolver()
-solver = TrustRegionSQPSolver(qp_solver)
-
-# Initialize with problem
-solver.init(nlp)
-
-# Configure
-params = SQPParameters()
-solver.setParameters(params)
-
-# Register callback (optional)
-solver.registerCallback(callback)
+qp_solver = tsqp.OSQPEigenSolver()
+solver = tsqp.TrustRegionSQPSolver(qp_solver)
+solver.verbose = False
+solver.params.initial_trust_box_size = 0.01
 
 # Solve
-solver.solve()
-
-# Get results
-results = solver.getResults()
-```
-
-| Method | Description |
-|--------|-------------|
-| `init(nlp)` | Initialize with problem |
-| `setParameters(params)` | Set solver parameters |
-| `registerCallback(cb)` | Register iteration callback |
-| `solve()` | Run optimization |
-| `stepSQPSolver()` | Single iteration step |
-| `getResults()` | Get optimization results |
-
-## OSQPEigenSolver
-
-QP solver using OSQP (Operator Splitting QP).
-
-```python
-from tesseract_robotics.trajopt_sqp import OSQPEigenSolver
-
-qp_solver = OSQPEigenSolver()
-
-# Used internally by TrustRegionSQPSolver
-# Solves convex QP subproblems at each SQP iteration
-```
-
-## IfoptQPProblem
-
-Problem formulation combining ifopt interface with QP solver.
-
-```python
-from tesseract_robotics.trajopt_sqp import IfoptQPProblem, OSQPEigenSolver
-
-qp_solver = OSQPEigenSolver()
-nlp = IfoptQPProblem(qp_solver)
-
-# Add optimization components
-nlp.addVariableSet(position_var)
-nlp.addConstraintSet(collision_constraint)
-nlp.addCostSet(velocity_cost)
-
-# Setup (called automatically by solver.init())
-nlp.setup()
-```
-
-| Method | Description |
-|--------|-------------|
-| `addVariableSet(var)` | Add optimization variable |
-| `addConstraintSet(constraint)` | Add constraint |
-| `addCostSet(cost)` | Add cost term |
-| `setup()` | Finalize problem structure |
-| `GetNumberOfOptimizationVariables()` | Total variable count |
-| `GetNumberOfConstraints()` | Total constraint count |
-
-## SQPParameters
-
-Solver configuration parameters.
-
-```python
-from tesseract_robotics.trajopt_sqp import SQPParameters
-
-params = SQPParameters()
-
-# Iteration limits
-params.max_iterations = 50
-
-# Convergence tolerances
-params.min_approx_improve = 1e-4
-params.min_trust_box_size = 1e-4
-
-# Trust region
-params.initial_trust_box_size = 0.1
-params.trust_shrink_ratio = 0.1
-params.trust_expand_ratio = 1.5
-
-# Constraint handling
-params.initial_constraint_penalty = 10.0
-params.constraint_penalty_increase_factor = 2.0
-
-# Logging
-params.log_results = False
-```
-
-| Parameter | Default | Description |
-|-----------|---------|-------------|
-| `max_iterations` | 50 | Maximum SQP iterations |
-| `min_approx_improve` | 1e-4 | Min improvement to continue |
-| `min_trust_box_size` | 1e-4 | Min trust region size |
-| `initial_trust_box_size` | 0.1 | Initial trust region |
-| `trust_shrink_ratio` | 0.1 | Trust region shrink factor |
-| `trust_expand_ratio` | 1.5 | Trust region expand factor |
-| `initial_constraint_penalty` | 10.0 | Initial penalty coefficient |
-| `constraint_penalty_increase_factor` | 2.0 | Penalty increase rate |
-
-## SQPResults
-
-Optimization results.
-
-```python
+solver.solve(problem)
 results = solver.getResults()
 
-# Status
-print(f"Status: {results.status}")  # SQPStatus enum
-
-# Cost information
-print(f"Overall cost: {results.overall_cost}")
-print(f"Cost names: {results.cost_names}")
-print(f"Constraint names: {results.constraint_names}")
-
-# Solution
-best_values = results.best_var_vals  # np.ndarray of all variables
+# Or single incremental step (for online/replanning)
+solver.init(problem)
+solver.stepSQPSolver()
+solver.setBoxSize(0.01)          # trust region resets don't belong in the solve loop
 ```
 
-| Attribute | Type | Description |
-|-----------|------|-------------|
-| `status` | `SQPStatus` | Solver exit status |
-| `overall_cost` | `float` | Final cost value |
-| `best_var_vals` | `np.ndarray` | Optimal variable values |
-| `cost_names` | `list[str]` | Names of cost terms |
-| `constraint_names` | `list[str]` | Names of constraints |
+Cost/constraint evaluation uses `getTotalExactCost()` / `getExactCosts()`
+on the QP problem (no arguments) — the 0.33
+`evaluate*` methods are gone.
+
+### OSQPEigenSolver
+
+`QPSolver` implementation backed by OSQP. Used by `TrustRegionSQPSolver`.
+
+## Parameters and Results
+
+- `SQPParameters` — configure iteration limits, trust region, penalty
+  coefficients.
+- `SQPResults` — `status`, `overall_cost`, `best_var_vals`, `cost_names`,
+  `constraint_names`.
 
 ## Enums
 
-### SQPStatus
-
 ```python
-from tesseract_robotics.trajopt_sqp import SQPStatus
+from tesseract_robotics.trajopt_sqp import (
+    SQPStatus, QPSolverStatus, CostPenaltyType,
+)
 
-SQPStatus.RUNNING           # Still iterating
-SQPStatus.CONVERGED         # Converged successfully
-SQPStatus.ITERATION_LIMIT   # Hit max iterations
-SQPStatus.TRUST_REGION_CONVERGED  # Trust region too small
-SQPStatus.PENALTY_CONVERGED      # Penalty method converged
-SQPStatus.CALLBACK_STOPPED       # Stopped by callback
+SQPStatus.RUNNING
+SQPStatus.NLP_CONVERGED
+QPSolverStatus.UNITIALIZED
+CostPenaltyType.SQUARED
 ```
 
-### QPSolverStatus
+Python names are unchanged from 0.33 — see [changes](../changes.md).
+The 0.33 `ConstraintType` enum was removed; if you referenced it, drop the usage.
+
+## Callbacks
 
 ```python
-from tesseract_robotics.trajopt_sqp import QPSolverStatus
+class MyCallback(tsqp.SQPCallback):
+    def __call__(self, problem, results):
+        print(f"iter {results.best_var_vals}")
+        return True  # False stops the solver
 
-QPSolverStatus.OPTIMAL      # QP solved optimally
-QPSolverStatus.PRIMAL_INFEASIBLE  # Infeasible
-QPSolverStatus.DUAL_INFEASIBLE    # Dual infeasible
+solver.registerCallback(MyCallback())
 ```
 
-### CostPenaltyType
+## Module API
 
-```python
-from tesseract_robotics.trajopt_sqp import CostPenaltyType
-
-CostPenaltyType.SQUARED  # Quadratic penalty
-CostPenaltyType.HINGE    # Hinge loss
-```
-
-### ConstraintType
-
-```python
-from tesseract_robotics.trajopt_sqp import ConstraintType
-
-ConstraintType.EQ   # Equality constraint
-ConstraintType.INEQ # Inequality constraint
-```
-
-## SQPCallback
-
-Custom callback for monitoring optimization.
-
-```python
-from tesseract_robotics.trajopt_sqp import SQPCallback
-
-class MyCallback(SQPCallback):
-    def __call__(self, nlp, results):
-        print(f"Iteration {results.iteration}: cost = {results.overall_cost}")
-        return True  # Return False to stop optimization
-
-callback = MyCallback()
-solver.registerCallback(callback)
-```
-
-## Performance Tips
-
-1. **Warm starting**: Initialize variables close to expected solution
-2. **Trust region**: Start with smaller `initial_trust_box_size` for difficult problems
-3. **Collision frequency**: Use discrete collision for speed, continuous for safety
-4. **Variable scaling**: Ensure variables have similar magnitudes
-
-```python
-# Warm start example
-from tesseract_robotics.trajopt_ifopt import interpolate
-
-start = current_joints
-goal = target_joints
-initial_traj = interpolate(start, goal, n_steps)
-
-for i, var in enumerate(variables):
-    var.SetVariables(initial_traj[i])
-```
-
-## Auto-generated API Reference
-
-The following is auto-generated from the module's type stubs and docstrings.
-
-::: tesseract_robotics.trajopt_sqp._trajopt_sqp.SQPStatus
+::: tesseract_robotics.trajopt_sqp
     options:
       show_root_heading: true
       show_source: false
+      members_order: source
+      heading_level: 3
 
-::: tesseract_robotics.trajopt_sqp._trajopt_sqp.SQPParameters
-    options:
-      show_root_heading: true
-      show_source: false
-      members: true
+## See also
+
+- [`trajopt_ifopt`](trajopt_ifopt.md) — variables and constraints
+- [Low-Level SQP API](../user-guide/low-level-sqp.md)
+- [0.33 → 0.34 migration](../changes.md)

--- a/docs/developer/index.md
+++ b/docs/developer/index.md
@@ -38,7 +38,9 @@ pixi run python -m pytest tests/trajopt_sqp/test_trajopt_sqp_bindings.py -v
 pixi run python -m pytest --testmon
 
 # Run an example
-pixi run python examples/freespace_ompl_example.py
+pixi run tesseract_freespace_ompl_example
+# or
+pixi run python -m tesseract_robotics.examples.freespace_ompl_example
 
 # Interactive shell (all env vars set)
 pixi shell
@@ -152,7 +154,7 @@ graph TD
 
     subgraph "Python API"
         I[tesseract_robotics.planning]
-        J[Robot, Planner, Composer]
+        J[Robot, MotionProgram, TaskComposer,<br/>plan_freespace / plan_ompl / plan_cartesian]
     end
 
     A --> E

--- a/docs/developer/trajopt_ifopt_missing_constraints.md
+++ b/docs/developer/trajopt_ifopt_missing_constraints.md
@@ -1,8 +1,11 @@
-# TrajOpt IFOPT: Constraint Bindings Reference
+# Constraint Bindings Completion (0.34)
+
+All 4 C++ constraint classes now have Python bindings, completed during the 0.34 upgrade.
+This page remains as a historical record of which constraints landed and their use cases.
+
+Current bindings live in [`src/trajopt_ifopt/trajopt_ifopt_bindings.cpp`](https://github.com/tesseract-robotics/tesseract_nanobind/blob/main/src/trajopt_ifopt/trajopt_ifopt_bindings.cpp).
 
 ## Summary
-
-All 4 C++ constraint classes now have Python bindings.
 
 | Constraint | Status | Complexity | Use Case |
 |-----------|--------|------------|----------|
@@ -24,9 +27,9 @@ All 4 C++ constraint classes now have Python bindings.
 **Constructor:**
 ```cpp
 JointJerkConstraint(
-    const Eigen::VectorXd& targets,                              // jerk targets per DOF
-    const std::vector<std::shared_ptr<const JointPosition>>& position_vars,  // 4+ consecutive waypoints
-    const Eigen::VectorXd& coeffs,                               // weights per DOF
+    const Eigen::VectorXd& targets,                          // jerk targets per DOF
+    const std::vector<std::shared_ptr<const Var>>& position_vars,  // 4+ consecutive waypoints
+    const Eigen::VectorXd& coeffs,                           // weights per DOF
     const std::string& name = "JointJerk"
 );
 ```
@@ -63,7 +66,7 @@ struct CartLineInfo {
 ```cpp
 CartLineConstraint(
     CartLineInfo info,
-    std::shared_ptr<const JointPosition> position_var,
+    std::shared_ptr<const Var> position_var,
     const Eigen::VectorXd& coeffs,
     const std::string& name = "CartLine"
 );
@@ -100,7 +103,7 @@ Eigen::Isometry3d GetLinePoint(
 ```cpp
 DiscreteCollisionNumericalConstraint(
     std::shared_ptr<DiscreteCollisionEvaluator> collision_evaluator,
-    std::shared_ptr<const JointPosition> position_var,
+    std::shared_ptr<const Var> position_var,
     int max_num_cnt = 1,
     bool fixed_sparsity = false,
     const std::string& name = "DiscreteCollisionNumerical"
@@ -139,8 +142,8 @@ struct InverseKinematicsInfo {
 InverseKinematicsConstraint(
     const Eigen::Isometry3d& target_pose,
     InverseKinematicsInfo::ConstPtr kinematic_info,
-    std::shared_ptr<const JointPosition> constraint_var,  // variable being constrained
-    std::shared_ptr<const JointPosition> seed_var,        // seed for IK (usually adjacent waypoint)
+    std::shared_ptr<const Var> constraint_var,  // variable being constrained
+    std::shared_ptr<const Var> seed_var,        // seed for IK (usually adjacent waypoint)
     const std::string& name = "InverseKinematics"
 );
 ```

--- a/docs/examples/basic.md
+++ b/docs/examples/basic.md
@@ -2,139 +2,69 @@
 
 Fundamental examples demonstrating kinematics, collision detection, and scene graph operations.
 
+All examples install as console scripts. Run them with:
+
+```bash
+# Installed console script (preferred)
+tesseract_kinematics_example
+
+# Or via Python module invocation
+pixi run python -m tesseract_robotics.examples.tesseract_kinematics_example
+```
+
 ## Kinematics Example
 
-Forward and inverse kinematics with the ABB IRB2400:
+Forward and inverse kinematics with the KUKA LBR IIWA 14 R820 (7-DOF). The snippet
+below is the core of the example — loaded directly from the shipped source.
 
 ```python title="tesseract_kinematics_example.py"
---8<-- "examples/tesseract_kinematics_example.py"
+--8<-- "src/tesseract_robotics/examples/tesseract_kinematics_example.py:fk_ik"
 ```
+
+Run it:
+
+```bash
+tesseract_kinematics_example
+```
+
+!!! tip "Quaternion convention"
+    The Python API uses **scalar-last** quaternions `[x, y, z, w]` to match
+    scipy. C++ Eigen uses scalar-first `[w, x, y, z]` — reorder when porting
+    C++ examples.
 
 ## Collision Detection Example
 
 Check for collisions in the environment:
 
-```python title="tesseract_collision_example.py"
---8<-- "examples/tesseract_collision_example.py"
+```bash
+tesseract_collision_example
 ```
+
+See the source at
+[`tesseract_collision_example.py`](https://github.com/tesseract-robotics/tesseract_nanobind/blob/main/src/tesseract_robotics/examples/tesseract_collision_example.py).
 
 ## Scene Graph Example
 
 Manipulate the scene graph (add/remove objects):
 
-```python title="scene_graph_example.py"
-from tesseract_robotics.planning import Robot
-from tesseract_robotics.tesseract_geometry import Box, Sphere
-from tesseract_robotics.tesseract_scene_graph import (
-    Link, Joint, JointType, Visual, Collision, Material
-)
-from tesseract_robotics.tesseract_environment import (
-    AddLinkCommand, RemoveLinkCommand
-)
-from tesseract_robotics.tesseract_common import Isometry3d
-import numpy as np
-
-robot = Robot.from_tesseract_support("abb_irb2400")
-env = robot.env
-scene = env.getSceneGraph()
-
-# Print existing links
-print("Existing links:")
-for link in scene.getLinks():
-    print(f"  {link.getName()}")
-
-# Create obstacle link
-obstacle_link = Link("obstacle_box")
-
-# Add visual
-visual = Visual()
-visual.geometry = Box(0.3, 0.3, 0.3)  # 30cm cube
-visual.origin = Isometry3d.Identity()
-material = Material("red")
-material.color = np.array([0.8, 0.2, 0.2, 1.0])
-visual.material = material
-obstacle_link.addVisual(visual)
-
-# Add collision
-collision = Collision()
-collision.geometry = Box(0.3, 0.3, 0.3)
-collision.origin = Isometry3d.Identity()
-obstacle_link.addCollision(collision)
-
-# Create joint (fixed to world)
-obstacle_joint = Joint("obstacle_joint")
-obstacle_joint.type = JointType.FIXED
-obstacle_joint.parent_link_name = "base_link"
-obstacle_joint.child_link_name = "obstacle_box"
-obstacle_joint.parent_to_joint_origin_transform = Isometry3d.Identity()
-obstacle_joint.parent_to_joint_origin_transform.translate([0.8, 0.0, 0.3])
-
-# Add to environment
-cmd = AddLinkCommand(obstacle_link, obstacle_joint)
-env.applyCommand(cmd)
-print("\nAdded obstacle_box to scene")
-
-# Verify obstacle affects collision
-joints = np.array([0.5, 0, 0, 0, 0, 0])  # Reach toward obstacle
-is_safe = robot.check_collision(joints)
-print(f"Collision with obstacle: {not is_safe}")
-
-# Remove obstacle
-env.applyCommand(RemoveLinkCommand("obstacle_box"))
-print("Removed obstacle_box from scene")
-
-# Verify no collision after removal
-is_safe = robot.check_collision(joints)
-print(f"Collision after removal: {not is_safe}")
+```bash
+tesseract_scene_graph_example
 ```
+
+See the source at
+[`scene_graph_example.py`](https://github.com/tesseract-robotics/tesseract_nanobind/blob/main/src/tesseract_robotics/examples/scene_graph_example.py).
 
 ## Geometry Showcase
 
-All available geometry types:
+All available geometry types (Box, Sphere, Cylinder, Capsule, Cone, Mesh,
+ConvexMesh, Plane, Octree):
 
-```python title="geometry_showcase_example.py"
-from tesseract_robotics.tesseract_geometry import (
-    Box, Sphere, Cylinder, Capsule, Cone,
-    Mesh, ConvexMesh, Plane, Octree
-)
-from tesseract_robotics.tesseract_common import VectorVector3d
-import numpy as np
-
-# Primitive shapes
-box = Box(0.5, 0.3, 0.2)  # length, width, height
-sphere = Sphere(0.15)      # radius
-cylinder = Cylinder(0.1, 0.4)  # radius, length
-capsule = Capsule(0.1, 0.3)    # radius, length
-cone = Cone(0.15, 0.3)         # radius, length
-
-print("Primitive shapes:")
-print(f"  Box: {box.getX()} x {box.getY()} x {box.getZ()}")
-print(f"  Sphere radius: {sphere.getRadius()}")
-print(f"  Cylinder: r={cylinder.getRadius()}, l={cylinder.getLength()}")
-print(f"  Capsule: r={capsule.getRadius()}, l={capsule.getLength()}")
-print(f"  Cone: r={cone.getRadius()}, l={cone.getLength()}")
-
-# Mesh from vertices (simple tetrahedron)
-vertices = VectorVector3d()
-vertices.append(np.array([0, 0, 0]))
-vertices.append(np.array([1, 0, 0]))
-vertices.append(np.array([0.5, 1, 0]))
-vertices.append(np.array([0.5, 0.5, 1]))
-
-triangles = np.array([
-    0, 1, 2,  # Base
-    0, 1, 3,  # Side 1
-    1, 2, 3,  # Side 2
-    0, 2, 3   # Side 3
-], dtype=np.int32)
-
-mesh = Mesh(vertices, triangles)
-print(f"\nMesh: {mesh.getVertexCount()} vertices, {mesh.getTriangleCount()} triangles")
-
-# Plane (infinite, used for ground)
-plane = Plane(0, 0, 1, 0)  # Normal (0,0,1), distance 0
-print(f"Plane normal: ({plane.getA()}, {plane.getB()}, {plane.getC()})")
+```bash
+tesseract_geometry_showcase_example
 ```
+
+See the source at
+[`geometry_showcase_example.py`](https://github.com/tesseract-robotics/tesseract_nanobind/blob/main/src/tesseract_robotics/examples/geometry_showcase_example.py).
 
 ??? tip "Loading Mesh Files"
     ```python
@@ -147,77 +77,17 @@ print(f"Plane normal: ({plane.getA()}, {plane.getB()}, {plane.getC()})")
     mesh = Mesh.fromFile("/path/to/model.stl", scale=[0.001, 0.001, 0.001])  # mm to m
     ```
 
-## Transforms and Poses
+## Reeds-Shepp Example
 
-Working with Isometry3d transforms:
+Reeds-Shepp path for a differential-drive vehicle — a 2D motion planning
+demonstration using OMPL:
 
-```python title="transforms_example.py"
-from tesseract_robotics.tesseract_common import Isometry3d
-import numpy as np
-
-# Identity transform
-pose = Isometry3d.Identity()
-
-# Translation
-pose.translate([0.5, 0.2, 0.3])
-print(f"Position: {pose.translation()}")
-
-# Rotation from axis-angle
-from scipy.spatial.transform import Rotation
-R = Rotation.from_euler('z', 45, degrees=True)
-pose.rotate(R.as_matrix())
-
-# Get components
-position = pose.translation()  # np.array([x, y, z])
-rotation = pose.rotation()     # 3x3 rotation matrix
-matrix = pose.matrix()         # 4x4 homogeneous matrix
-
-# Compose transforms
-pose2 = Isometry3d.Identity()
-pose2.translate([0.1, 0, 0])
-combined = pose * pose2  # pose2 in pose's frame
-
-# Inverse
-inverse = pose.inverse()
-
-# From 4x4 matrix
-matrix = np.eye(4)
-matrix[:3, 3] = [1, 2, 3]  # Translation
-pose_from_matrix = Isometry3d(matrix)
+```bash
+tesseract_reeds_shepp_example
 ```
 
-## State Management
-
-Working with environment state:
-
-```python title="state_example.py"
-from tesseract_robotics.planning import Robot
-import numpy as np
-
-robot = Robot.from_tesseract_support("abb_irb2400")
-env = robot.env
-
-# Get current state
-state = env.getState()
-print(f"Joint names: {state.joint_names}")
-print(f"Positions: {state.position}")
-
-# Set state (dict interface)
-env.setState({
-    "joint_1": 0.5,
-    "joint_2": -0.3,
-    "joint_3": 0.2
-})
-
-# Set state (array interface)
-joint_names = ["joint_1", "joint_2", "joint_3", "joint_4", "joint_5", "joint_6"]
-joint_values = np.array([0.5, -0.3, 0.2, 0.0, 0.5, 0.0])
-env.setState(joint_names, joint_values)
-
-# Get link transform in current state
-tcp = env.getLinkTransform("tool0")
-print(f"TCP position: {tcp.translation()}")
-```
+See the source at
+[`reeds_shepp_example.py`](https://github.com/tesseract-robotics/tesseract_nanobind/blob/main/src/tesseract_robotics/examples/reeds_shepp_example.py).
 
 ## Next Steps
 

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -34,55 +34,64 @@ Learn tesseract_robotics through working examples.
 
 ## Running Examples
 
-All examples are in the `examples/` directory:
+Examples install as console scripts via `[project.scripts]` in `pyproject.toml`.
+Once the package is installed (via `pip` or `pixi install`) they are on `PATH`:
 
 ```bash
 # Activate environment
 pixi shell
 
-# Run an example
-python examples/freespace_ompl_example.py
+# Run an example (installed console script)
+tesseract_freespace_ompl_example
+
+# Or via Python module invocation
+pixi run python -m tesseract_robotics.examples.freespace_ompl_example
 ```
+
+Every example module has both `main()` and `run()` entry points — `main()`
+handles optional viewer launch, `run()` returns results for testing / reuse.
 
 ## Example Index
 
 ### Basic
 
-| Example | Description |
-|---------|-------------|
-| `tesseract_kinematics_example.py` | FK/IK with joint groups |
-| `tesseract_collision_example.py` | Discrete collision checking |
-| `scene_graph_example.py` | Scene graph manipulation |
-| `geometry_showcase_example.py` | All geometry types |
+| Example | Console script | Description |
+|---------|----------------|-------------|
+| `tesseract_kinematics_example.py` | `tesseract_kinematics_example` | FK/IK with joint groups |
+| `tesseract_collision_example.py` | `tesseract_collision_example` | Discrete collision checking |
+| `scene_graph_example.py` | `tesseract_scene_graph_example` | Scene graph manipulation |
+| `geometry_showcase_example.py` | `tesseract_geometry_showcase_example` | All geometry types |
+| `reeds_shepp_example.py` | `tesseract_reeds_shepp_example` | Reeds-Shepp path for differential-drive |
 
 ### Planning
 
-| Example | Description |
-|---------|-------------|
-| `freespace_ompl_example.py` | OMPL freespace motion |
-| `basic_cartesian_example.py` | Cartesian path with TrajOpt |
-| `glass_upright_example.py` | Orientation constraints |
-| `pick_and_place_example.py` | Pick, attach, place workflow |
-| `car_seat_example.py` | Complex multi-step planning |
-| `raster_example.py` | Industrial raster patterns |
-| `puzzle_piece_auxillary_axes_example.py` | 9-DOF with external axis |
-| `freespace_hybrid_example.py` | OMPL + TrajOpt hybrid |
-| `chain_example.py` | Descartes + TrajOpt chaining |
+| Example | Console script | Description |
+|---------|----------------|-------------|
+| `freespace_ompl_example.py` | `tesseract_freespace_ompl_example` | OMPL freespace motion |
+| `basic_cartesian_example.py` | `tesseract_basic_cartesian_example` | Cartesian path with TrajOpt |
+| `glass_upright_example.py` | `tesseract_glass_upright_example` | Orientation constraints |
+| `pick_and_place_example.py` | `tesseract_pick_and_place_example` | Pick, attach, place workflow |
+| `car_seat_example.py` | `tesseract_car_seat_example` | Complex multi-step planning |
+| `raster_example.py` | `tesseract_raster_example` | Industrial raster patterns |
+| `puzzle_piece_auxillary_axes_example.py` | `tesseract_puzzle_piece_auxillary_axes_example` | 9-DOF with external axis |
+| `freespace_hybrid_example.py` | `tesseract_freespace_hybrid_example` | OMPL + TrajOpt hybrid |
+| `chain_example.py` | `tesseract_chain_example` | Descartes + TrajOpt chaining |
 
 ### Real-Time
 
-| Example | Description |
-|---------|-------------|
-| `online_planning_example.py` | TaskComposer replanning |
-| `online_planning_sqp_example.py` | Low-level SQP (73 Hz) |
+| Example | Console script | Description |
+|---------|----------------|-------------|
+| `online_planning_example.py` | `tesseract_online_planning_example` | TaskComposer replanning |
+| `online_planning_sqp_example.py` | `tesseract_online_planning_sqp_example` | Low-level SQP (73 Hz) |
 
 ### Visualization
 
-| Example | Description |
-|---------|-------------|
-| `shapes_viewer.py` | Basic shapes in viewer |
-| `tesseract_material_mesh_viewer.py` | Materials and meshes |
-| `abb_irb2400_viewer.py` | Robot visualization |
+| Example | Console script | Description |
+|---------|----------------|-------------|
+| `shapes_viewer.py` | `tesseract_shapes_viewer` | Basic shapes in viewer |
+| `tesseract_material_mesh_viewer.py` | `tesseract_material_mesh_viewer` | Materials and meshes |
+| `abb_irb2400_viewer.py` | `tesseract_abb_irb2400_viewer` | Robot visualization |
+| `twc_workcell_positioner_viewer.py` | `tesseract_twc_workcell_positioner_viewer` | Industrial workcell (positioner, requires submodule) |
 
 ## Prerequisites
 
@@ -96,7 +105,7 @@ import tesseract_robotics
 from tesseract_robotics.viewer import TesseractViewer
 ```
 
-Install the viewer:
+Install the package:
 
 ```bash
 pip install tesseract-robotics-nanobind

--- a/docs/examples/online-planning.md
+++ b/docs/examples/online-planning.md
@@ -25,237 +25,93 @@ sequenceDiagram
 
 | Method | Rate | Use Case |
 |--------|------|----------|
-| Task Composer | 1-5 Hz | Moderate changes |
+| Task Composer | 1-5 Hz | Moderate scene changes |
 | Low-Level SQP (discrete) | 73 Hz | Fast replanning |
 | Low-Level SQP (no collision) | 128 Hz | Safe environments |
 | Low-Level SQP (LVS continuous) | 5-10 Hz | High precision |
 
+Numbers are from the reference
+[`online_planning_sqp_example.py`](https://github.com/tesseract-robotics/tesseract_nanobind/blob/main/src/tesseract_robotics/examples/online_planning_sqp_example.py)
+on an 8-DOF gantry workcell. Run it on your machine to get local numbers.
+
 ## Low-Level SQP Example
 
-Real-time replanning at 73 Hz with discrete collision:
+Real-time replanning at ~73 Hz using discrete collision. The snippets below
+are the real shipped source, split into three regions: `setup`, `problem`,
+`sqp_loop`. For the accompanying conceptual guide see the
+[Low-Level SQP API](../user-guide/low-level-sqp.md) page.
 
-```python title="online_planning_sqp_example.py"
-import numpy as np
-import time
-from tesseract_robotics.planning import Robot
-from tesseract_robotics.ifopt import Bounds
-from tesseract_robotics.trajopt_ifopt import (
-    JointPosition, CartPosConstraint, CartPosInfo, CartPosInfoType,
-    TrajOptCollisionConfig, CollisionCache, SingleTimestepCollisionEvaluator,
-    DiscreteCollisionConstraint, interpolate
-)
-from tesseract_robotics.trajopt_sqp import (
-    TrustRegionSQPSolver, OSQPEigenSolver, IfoptQPProblem, SQPStatus
-)
+### Setup
 
-def setup_robot():
-    """Load robot with human obstacle."""
-    robot = Robot.from_tesseract_support(
-        "abb_irb2400",
-        extra_urdf="abb_irb2400_support/urdf/human_obstacle.urdf"
-    )
-    return robot
-
-def build_problem(env, manip, joint_names, start_joints, target_pose,
-                  n_steps=12, prev_trajectory=None):
-    """Build QP problem for single planning iteration."""
-
-    n_joints = len(joint_names)
-    limits = manip.getLimits()
-    lower = limits.joint_limits[:, 0]
-    upper = limits.joint_limits[:, 1]
-
-    # Create problem
-    qp = IfoptQPProblem()
-
-    # Add variables with warm-start
-    variables = []
-    for i in range(n_steps):
-        if i == 0:
-            init = start_joints
-        elif prev_trajectory is not None and i < len(prev_trajectory):
-            init = prev_trajectory[i]
-        else:
-            # Interpolate to goal
-            t = i / (n_steps - 1)
-            init = interpolate(start_joints, start_joints, t)  # Placeholder
-
-        var = JointPosition(init, joint_names, f"joint_pos_{i}")
-
-        # Fix start position
-        if i == 0:
-            bounds = [Bounds(start_joints[j], start_joints[j])
-                      for j in range(n_joints)]
-        else:
-            bounds = [Bounds(lower[j], upper[j]) for j in range(n_joints)]
-
-        var.SetBounds(bounds)
-        variables.append(var)
-        qp.addVariableSet(var)
-
-    # Cartesian goal constraint
-    cart_info = CartPosInfo(manip, "tool0", "base_link",
-                           target_pose, CartPosInfoType.FULL)
-    cart_constraint = CartPosConstraint(cart_info, variables[-1], "cart_goal")
-    qp.addConstraintSet(cart_constraint)
-
-    # Collision constraints (discrete, every other waypoint)
-    config = TrajOptCollisionConfig()
-    config.contact_margin_data.default_margin = 0.025
-    config.collision_coeff_data.default_coeff = 20.0
-
-    cache = CollisionCache(100)
-    for i in range(0, n_steps, 2):  # Every other waypoint
-        evaluator = SingleTimestepCollisionEvaluator(cache, manip, env, config)
-        collision = DiscreteCollisionConstraint(
-            evaluator, variables[i], f"collision_{i}"
-        )
-        qp.addConstraintSet(collision)
-
-    return qp, variables
-
-def move_obstacle(env, t):
-    """Move human obstacle along sinusoidal path."""
-    x = 0.8 + 0.3 * np.sin(2 * np.pi * t / 5.0)
-    y = 0.2 * np.cos(2 * np.pi * t / 5.0)
-    z = 0.0
-
-    # Update obstacle position in environment
-    # ... (implementation depends on obstacle setup)
-
-def run(steps=12, verbose=False):
-    """Main planning loop."""
-    robot = setup_robot()
-    env = robot.env
-    manip = env.getKinematicGroup("manipulator")
-    joint_names = list(manip.getJointNames())
-
-    # Target pose
-    target_pose = robot.fk(np.array([0.5, -0.3, 0.4, 0.0, 0.3, 0.0]))
-
-    # Solver setup
-    solver = TrustRegionSQPSolver(OSQPEigenSolver())
-    solver.params.max_iterations = 10
-    solver.params.initial_trust_box_size = 0.01
-
-    # Initial state
-    current_joints = np.zeros(len(joint_names))
-    trajectory = None
-
-    # Planning loop
-    num_iterations = 100
-    times = []
-
-    for iteration in range(num_iterations):
-        t_start = time.perf_counter()
-
-        # Update obstacle
-        move_obstacle(env, iteration * 0.01)
-
-        # Build and solve problem
-        qp, variables = build_problem(
-            env, manip, joint_names,
-            current_joints, target_pose,
-            n_steps=steps,
-            prev_trajectory=trajectory
-        )
-
-        solver.init(qp)
-        status = solver.stepSQPSolver(qp)
-        solver.setBoxSize(0.01)  # Reset trust region
-
-        # Extract trajectory
-        trajectory = np.array([var.GetValues() for var in variables])
-
-        # "Execute" first step (move robot)
-        if len(trajectory) > 1:
-            current_joints = trajectory[1]
-
-        t_end = time.perf_counter()
-        times.append(t_end - t_start)
-
-        if verbose:
-            print(f"Iter {iteration}: {(t_end-t_start)*1000:.1f}ms, status={status}")
-
-    # Report performance
-    avg_time = np.mean(times) * 1000
-    hz = 1000 / avg_time
-    print(f"\nPerformance: {avg_time:.1f}ms avg ({hz:.0f} Hz)")
-
-    return trajectory
-
-if __name__ == "__main__":
-    run()
+```python title="online_planning_sqp_example.py (setup)"
+--8<-- "src/tesseract_robotics/examples/online_planning_sqp_example.py:setup"
 ```
 
-??? example "Expected Output"
+### Problem construction
+
+```python title="online_planning_sqp_example.py (problem)"
+--8<-- "src/tesseract_robotics/examples/online_planning_sqp_example.py:problem"
+```
+
+### SQP loop
+
+```python title="online_planning_sqp_example.py (sqp_loop)"
+--8<-- "src/tesseract_robotics/examples/online_planning_sqp_example.py:sqp_loop"
+```
+
+Run the complete example:
+
+```bash
+tesseract_online_planning_sqp_example
+```
+
+??? example "Expected Output (indicative)"
     ```
-    Performance: 13.7ms avg (73 Hz)
+    Performance: ~13ms avg (~73 Hz discrete / ~128 Hz no-collision)
     ```
 
 ## Key Concepts
 
-### 1. Rebuild Problem Each Iteration
+### 1. Variable hierarchy (0.34+)
 
-Due to shared_ptr lifecycle, rebuild the QP problem each iteration:
-
-```python
-for iteration in range(num_iterations):
-    # Build fresh problem
-    qp, variables = build_problem(...)
-
-    # Re-initialize solver
-    solver.init(qp)
-
-    # Single step (not full solve)
-    solver.stepSQPSolver(qp)
-```
-
-!!! warning "Don't Reuse Problems"
-    Reusing the same `IfoptQPProblem` across iterations causes segfaults.
-    Always create a new problem.
-
-### 2. Warm-Start from Previous Solution
-
-Use previous trajectory to initialize variables:
+Use `createNodesVariables` to build `NodesVariables` → `Node` → `Var`:
 
 ```python
-for i in range(n_steps):
-    if prev_trajectory is not None and i < len(prev_trajectory):
-        init = prev_trajectory[i]  # Warm-start
-    else:
-        init = interpolate(start, goal, i / (n_steps-1))
+from tesseract_robotics.trajopt_ifopt import Bounds, createNodesVariables
 
-    var = JointPosition(init, joint_names, f"joint_pos_{i}")
+bounds = Bounds(-3.14, 3.14)
+nodes_variables = createNodesVariables(
+    "trajectory", joint_names, initial_states, bounds,
+)
+vars_list = [node.getVar("joints") for node in nodes_variables.getNodes()]
 ```
 
-### 3. Fix Start Position
+### 2. Warm-start from the previous solution
 
-The first waypoint must match current robot state:
+Between ticks, push the previous trajectory back into the variables:
 
 ```python
-if i == 0:
-    # Fix to current position
-    bounds = [Bounds(current[j], current[j]) for j in range(n_joints)]
-else:
-    # Allow optimization
-    bounds = [Bounds(lower[j], upper[j]) for j in range(n_joints)]
+nodes_variables.setVariables(trajectory.flatten())
+solver.init(problem)
+solver.stepSQPSolver()
 ```
 
-### 4. Single Step vs Full Solve
+### 3. Reset the trust region each tick
 
-For real-time, use `stepSQPSolver` instead of `solve`:
+`stepSQPSolver` shrinks the trust region — if you don't reset it, successive
+ticks get smaller and smaller steps:
 
 ```python
-# Full solve (slower, better convergence)
-solver.solve(qp)
-
-# Single step (faster, incremental)
-solver.stepSQPSolver(qp)
-solver.setBoxSize(0.01)  # Reset trust region after step
+solver.stepSQPSolver()
+solver.setBoxSize(0.01)  # Reset trust region
 ```
 
-### 5. Sparse Collision Checking
+### 4. Single step vs full solve
+
+- Use `solver.solve(problem)` on the first tick for global convergence.
+- Use `solver.stepSQPSolver()` per tick afterwards for incremental optimization.
+
+### 5. Sparse collision checking
 
 Check collision every N waypoints for speed:
 
@@ -271,33 +127,33 @@ for i in range(n_steps):
 
 ## Continuous Collision
 
-For higher precision (5-10 Hz):
+For higher precision (5-10 Hz) use the LVS continuous evaluator with
+`ContinuousCollisionConstraint`:
 
 ```python
 from tesseract_robotics.trajopt_ifopt import (
-    LVSDiscreteCollisionEvaluator, ContinuousCollisionConstraint
+    LVSContinuousCollisionEvaluator, ContinuousCollisionConstraint
 )
 
-# LVS evaluator samples along trajectory segment
-evaluator = LVSDiscreteCollisionEvaluator(
-    cache, manip, env, config,
-    dynamic_environment=True
+evaluator = LVSContinuousCollisionEvaluator(
+    manip, env, config,
+    dynamic_environment=True,
 )
 
 # Add constraint between consecutive waypoints
 for i in range(n_steps - 1):
     constraint = ContinuousCollisionConstraint(
         evaluator,
-        variables[i], variables[i+1],
+        variables[i], variables[i + 1],
         fixed0=False, fixed1=False,
-        name=f"cont_collision_{i}"
+        name=f"cont_collision_{i}",
     )
-    qp.addConstraintSet(constraint)
+    problem.addConstraintSet(constraint)
 ```
 
 ## Visualization
 
-Animate trajectory in viewer:
+Animate a trajectory in the viewer:
 
 ```python
 from tesseract_robotics.viewer import TesseractViewer
@@ -305,14 +161,9 @@ from tesseract_robotics.viewer import TesseractViewer
 viewer = TesseractViewer()
 viewer.update_environment(robot.env, [0, 0, 0])
 
-# Convert trajectory to viewer format
-joint_names = list(manip.getJointNames())
-dt = 0.1  # Time between waypoints
-
-trajectory_list = []
-for i, wp in enumerate(trajectory):
-    row = wp.tolist() + [i * dt]  # [joints..., time]
-    trajectory_list.append(row)
+# Convert trajectory to viewer format (joints + time column)
+dt = 0.1
+trajectory_list = [wp.tolist() + [i * dt] for i, wp in enumerate(trajectory)]
 
 viewer.update_trajectory_list(joint_names, trajectory_list)
 viewer.start_serve_background()
@@ -320,43 +171,33 @@ viewer.start_serve_background()
 
 ## Task Composer Alternative
 
-For slower updates (1-5 Hz), use Task Composer:
+For slower updates (1-5 Hz) with higher-level abstractions, use Task Composer.
+See [`online_planning_example.py`](https://github.com/tesseract-robotics/tesseract_nanobind/blob/main/src/tesseract_robotics/examples/online_planning_example.py):
 
-```python title="online_planning_example.py"
-from tesseract_robotics.planning import Robot, Composer
-import numpy as np
-
-robot = Robot.from_tesseract_support("abb_irb2400")
-
-for iteration in range(100):
-    # Update obstacle position
-    update_obstacle(robot.env, iteration)
-
-    # Replan with Task Composer
-    composer = Composer(robot)
-    composer.add_freespace(goal_joints=goal)
-
-    result = composer.plan()
-
-    if result.success:
-        # Execute first waypoint
-        trajectory = result.get_trajectories()[0]
-        execute(trajectory[0])
+```bash
+tesseract_online_planning_example
 ```
 
 ## Running the Examples
 
 ```bash
-# Low-level SQP (73 Hz)
-python examples/online_planning_sqp_example.py
+# Low-level SQP (~73 Hz discrete)
+tesseract_online_planning_sqp_example
 
 # Task Composer based
-python examples/online_planning_example.py
+tesseract_online_planning_example
+```
+
+Or via module invocation:
+
+```bash
+pixi run python -m tesseract_robotics.examples.online_planning_sqp_example
+pixi run python -m tesseract_robotics.examples.online_planning_example
 ```
 
 ## Performance Tuning
 
-### Faster Planning
+### Faster planning
 
 ```python
 # Fewer waypoints
@@ -373,14 +214,14 @@ solver.params.initial_trust_box_size = 0.01
 solver.params.max_iterations = 5
 ```
 
-### Better Quality
+### Better quality
 
 ```python
 # More waypoints
 n_steps = 20
 
 # Continuous collision
-use_continuous_collision = True
+# (use ContinuousCollisionConstraint + LVSContinuousCollisionEvaluator)
 
 # More iterations
 solver.params.max_iterations = 50

--- a/docs/examples/planning.md
+++ b/docs/examples/planning.md
@@ -2,339 +2,156 @@
 
 Motion planning examples from simple freespace to complex industrial tasks.
 
+All examples install as console scripts. Run them with:
+
+```bash
+# Installed console script (preferred)
+tesseract_freespace_ompl_example
+
+# Or via Python module invocation
+pixi run python -m tesseract_robotics.examples.freespace_ompl_example
+```
+
 ## Freespace OMPL
 
-Basic OMPL planning between joint configurations:
+Basic OMPL planning between joint configurations using the ABB IRB2400:
 
-```python title="freespace_ompl_example.py"
-from tesseract_robotics.planning import Robot, Planner
-import numpy as np
-
-# Load robot
-robot = Robot.from_tesseract_support("abb_irb2400")
-
-# Define start and goal
-start = np.array([0.0, 0.0, 0.0, 0.0, 0.0, 0.0])
-goal = np.array([1.0, -0.5, 0.5, 0.0, 0.5, 0.0])
-
-# Plan
-planner = Planner(robot)
-trajectory = planner.plan(start=start, goal=goal, planner="ompl")
-
-if trajectory:
-    print(f"Planned trajectory with {len(trajectory)} waypoints")
-    for i, wp in enumerate(trajectory[:3]):
-        print(f"  [{i}] {wp.positions}")
-    print("  ...")
-else:
-    print("Planning failed!")
+```bash
+tesseract_freespace_ompl_example
 ```
+
+See the source at
+[`freespace_ompl_example.py`](https://github.com/tesseract-robotics/tesseract_nanobind/blob/main/src/tesseract_robotics/examples/freespace_ompl_example.py).
 
 ## Basic Cartesian
 
 Cartesian straight-line motion with TrajOpt:
 
-```python title="basic_cartesian_example.py"
-from tesseract_robotics.planning import Robot, Planner
-from tesseract_robotics.tesseract_common import Isometry3d
-import numpy as np
-
-robot = Robot.from_tesseract_support("abb_irb2400")
-planner = Planner(robot)
-
-# Start configuration
-start = np.zeros(6)
-
-# Cartesian goal (tool pose)
-goal_pose = Isometry3d.Identity()
-goal_pose.translate([0.8, 0.3, 0.6])
-
-# Rotation: point tool down
-from scipy.spatial.transform import Rotation
-R = Rotation.from_euler('y', 90, degrees=True)
-goal_pose.rotate(R.as_matrix())
-
-# Plan Cartesian path
-trajectory = planner.plan(
-    start=start,
-    goal=goal_pose,  # Cartesian goal
-    planner="trajopt"
-)
-
-if trajectory:
-    print(f"Cartesian path with {len(trajectory)} waypoints")
-
-    # Verify final pose
-    final_joints = trajectory[-1].positions
-    final_pose = robot.fk(final_joints)
-    error = np.linalg.norm(final_pose.translation() - goal_pose.translation())
-    print(f"Position error: {error*1000:.2f} mm")
+```bash
+tesseract_basic_cartesian_example
 ```
+
+See the source at
+[`basic_cartesian_example.py`](https://github.com/tesseract-robotics/tesseract_nanobind/blob/main/src/tesseract_robotics/examples/basic_cartesian_example.py).
 
 ## Glass Upright (Orientation Constraint)
 
-Keep end-effector orientation constrained (e.g., carrying a glass of water):
+Keep end-effector orientation constrained (e.g. carrying a glass of water) —
+demonstrates 6-DOF Cartesian constraints inside a TrajOpt program:
 
-```python title="glass_upright_example.py"
-from tesseract_robotics.planning import Robot, Composer
-from tesseract_robotics.tesseract_common import Isometry3d
-import numpy as np
-
-robot = Robot.from_tesseract_support("abb_irb2400")
-composer = Composer(robot)
-
-# Define waypoints (keep tool pointing up)
-waypoint_1 = Isometry3d.Identity()
-waypoint_1.translate([0.6, 0.3, 0.8])
-
-waypoint_2 = Isometry3d.Identity()
-waypoint_2.translate([0.6, -0.3, 0.8])
-
-waypoint_3 = Isometry3d.Identity()
-waypoint_3.translate([0.8, 0.0, 0.6])
-
-# All waypoints with upright orientation constraint
-for wp in [waypoint_1, waypoint_2, waypoint_3]:
-    composer.add_cartesian(
-        goal_pose=wp,
-        orientation_tolerance=0.1  # ±0.1 rad tolerance on tilt
-    )
-
-# Plan with orientation constraint
-result = composer.plan()
-
-if result.success:
-    print("Glass upright path planned successfully")
-
-    # Verify orientation constraint
-    for i, traj in enumerate(result.get_trajectories()):
-        for wp in traj:
-            pose = robot.fk(wp.positions)
-            z_axis = pose.rotation()[:, 2]  # Tool Z-axis
-            tilt = np.arccos(np.dot(z_axis, [0, 0, 1]))
-            if tilt > 0.15:
-                print(f"Warning: tilt = {np.degrees(tilt):.1f}°")
+```bash
+tesseract_glass_upright_example
 ```
+
+See the source at
+[`glass_upright_example.py`](https://github.com/tesseract-robotics/tesseract_nanobind/blob/main/src/tesseract_robotics/examples/glass_upright_example.py).
 
 ## Pick and Place
 
-Complete pick and place workflow with object attachment:
+Complete pick and place workflow with object attachment. A KUKA IIWA picks a
+box from a table, the box is reparented to `iiwa_tool0` via
+[`move_link()`](../user-guide/environment.md), then it is placed on a shelf.
 
 ```python title="pick_and_place_example.py"
-from tesseract_robotics.planning import Robot, Composer
-from tesseract_robotics.tesseract_geometry import Box
-from tesseract_robotics.tesseract_scene_graph import Link, Joint, JointType, Visual, Collision
-from tesseract_robotics.tesseract_environment import AddLinkCommand, RemoveLinkCommand
-from tesseract_robotics.tesseract_common import Isometry3d
-import numpy as np
-
-robot = Robot.from_tesseract_support("abb_irb2400")
-env = robot.env
-
-# Add workpiece to scene
-def add_workpiece(env, name, position):
-    link = Link(name)
-
-    visual = Visual()
-    visual.geometry = Box(0.05, 0.05, 0.1)
-    link.addVisual(visual)
-
-    collision = Collision()
-    collision.geometry = Box(0.05, 0.05, 0.1)
-    link.addCollision(collision)
-
-    joint = Joint(f"{name}_joint")
-    joint.type = JointType.FIXED
-    joint.parent_link_name = "base_link"
-    joint.child_link_name = name
-    joint.parent_to_joint_origin_transform = Isometry3d.Identity()
-    joint.parent_to_joint_origin_transform.translate(position)
-
-    env.applyCommand(AddLinkCommand(link, joint))
-
-# Add workpiece at pick location
-add_workpiece(env, "workpiece", [0.6, 0.3, 0.05])
-
-# Define poses
-pick_approach = Isometry3d.Identity()
-pick_approach.translate([0.6, 0.3, 0.25])
-
-pick_pose = Isometry3d.Identity()
-pick_pose.translate([0.6, 0.3, 0.12])
-
-place_approach = Isometry3d.Identity()
-place_approach.translate([0.6, -0.3, 0.25])
-
-place_pose = Isometry3d.Identity()
-place_pose.translate([0.6, -0.3, 0.12])
-
-# Build pick sequence
-composer = Composer(robot)
-
-# 1. Approach pick
-composer.add_freespace(goal_pose=pick_approach)
-
-# 2. Linear down to pick
-composer.add_linear(goal_pose=pick_pose)
-
-# Plan pick approach
-pick_result = composer.plan()
-
-if pick_result.success:
-    print("Pick approach planned")
-
-    # 3. Attach workpiece to gripper
-    # (In practice, move joint parent from world to tool0)
-
-    # 4. Linear retreat
-    composer.clear()
-    composer.add_linear(goal_pose=pick_approach)
-
-    # 5. Transit to place
-    composer.add_freespace(goal_pose=place_approach)
-
-    # 6. Linear down to place
-    composer.add_linear(goal_pose=place_pose)
-
-    place_result = composer.plan()
-
-    if place_result.success:
-        print("Place sequence planned")
+--8<-- "src/tesseract_robotics/examples/pick_and_place_example.py:full_workflow"
 ```
+
+Run it:
+
+```bash
+tesseract_pick_and_place_example
+```
+
+Full source:
+[`pick_and_place_example.py`](https://github.com/tesseract-robotics/tesseract_nanobind/blob/main/src/tesseract_robotics/examples/pick_and_place_example.py).
 
 ## Raster Pattern
 
-Industrial raster pattern for welding/painting:
+Industrial raster pattern for welding / painting / milling. Multiple linear
+passes with freespace transitions between segments. The example builds the
+program programmatically from a list of Cartesian waypoints, then hands it to
+the `TrajOptPipeline`.
 
-```python title="raster_example.py"
-from tesseract_robotics.planning import Robot, Composer
-from tesseract_robotics.tesseract_common import Isometry3d
-import numpy as np
+**Building the program:**
 
-robot = Robot.from_tesseract_support("abb_irb2400")
-composer = Composer(robot)
-
-# Define raster pattern (5 passes, 10cm apart)
-start_x, start_y, z = 0.5, -0.2, 0.5
-pass_length = 0.4
-pass_spacing = 0.1
-num_passes = 5
-
-raster_poses = []
-for i in range(num_passes):
-    y = start_y + i * pass_spacing
-
-    # Direction alternates each pass
-    if i % 2 == 0:
-        x_start, x_end = start_x, start_x + pass_length
-    else:
-        x_start, x_end = start_x + pass_length, start_x
-
-    # Start of pass
-    pose_start = Isometry3d.Identity()
-    pose_start.translate([x_start, y, z])
-    raster_poses.append(pose_start)
-
-    # End of pass
-    pose_end = Isometry3d.Identity()
-    pose_end.translate([x_end, y, z])
-    raster_poses.append(pose_end)
-
-# Add approach
-approach = Isometry3d.Identity()
-approach.translate([start_x, start_y, z + 0.1])
-composer.add_freespace(goal_pose=approach)
-
-# Add raster passes (linear motion)
-for pose in raster_poses:
-    composer.add_linear(goal_pose=pose)
-
-# Plan
-result = composer.plan()
-
-if result.success:
-    print(f"Raster pattern with {num_passes} passes planned")
-    total_waypoints = sum(len(t) for t in result.get_trajectories())
-    print(f"Total waypoints: {total_waypoints}")
+```python title="raster_example.py (build_program)"
+--8<-- "src/tesseract_robotics/examples/raster_example.py:build_program"
 ```
+
+**Planning it:**
+
+```python title="raster_example.py (plan)"
+--8<-- "src/tesseract_robotics/examples/raster_example.py:plan"
+```
+
+Run it:
+
+```bash
+tesseract_raster_example
+```
+
+Full source:
+[`raster_example.py`](https://github.com/tesseract-robotics/tesseract_nanobind/blob/main/src/tesseract_robotics/examples/raster_example.py).
 
 ## Hybrid Planning (OMPL + TrajOpt)
 
-Use OMPL for exploration, TrajOpt for smoothing:
+OMPL finds a feasible path, TrajOpt smooths and optimizes it:
 
-```python title="freespace_hybrid_example.py"
-from tesseract_robotics.planning import Robot, Planner
-import numpy as np
-
-robot = Robot.from_tesseract_support("abb_irb2400")
-planner = Planner(robot)
-
-start = np.zeros(6)
-goal = np.array([1.5, -0.8, 0.6, 0.5, 0.8, -0.5])
-
-# Step 1: OMPL finds feasible path
-ompl_trajectory = planner.plan(start=start, goal=goal, planner="ompl")
-
-if ompl_trajectory:
-    print(f"OMPL found path with {len(ompl_trajectory)} waypoints")
-
-    # Step 2: TrajOpt smooths the path
-    smooth_trajectory = planner.refine(
-        trajectory=ompl_trajectory,
-        planner="trajopt"
-    )
-
-    if smooth_trajectory:
-        print(f"TrajOpt smoothed to {len(smooth_trajectory)} waypoints")
-
-        # Compare path lengths
-        def path_length(traj):
-            length = 0
-            for i in range(1, len(traj)):
-                length += np.linalg.norm(
-                    traj[i].positions - traj[i-1].positions
-                )
-            return length
-
-        print(f"OMPL path length: {path_length(ompl_trajectory):.3f} rad")
-        print(f"TrajOpt path length: {path_length(smooth_trajectory):.3f} rad")
+```bash
+tesseract_freespace_hybrid_example
 ```
 
-## Multi-Step with Task Composer
+See the source at
+[`freespace_hybrid_example.py`](https://github.com/tesseract-robotics/tesseract_nanobind/blob/main/src/tesseract_robotics/examples/freespace_hybrid_example.py).
 
-Complex sequence using full Task Composer pipeline:
+## Multi-Step with Task Composer (Car Seat)
 
-```python title="car_seat_example.py"
-from tesseract_robotics.planning import Robot, Composer
-import numpy as np
+Complex multi-phase sequence: an 8-DOF system (linear carriage + 7-axis arm)
+picks a car seat, attaches it via scene graph manipulation, then places it
+in a vehicle body. The snippet below is the core sequential-planning loop.
 
-robot = Robot.from_tesseract_support("abb_irb2400")
-composer = Composer(robot)
-
-# Define joint targets for car seat welding simulation
-home = np.zeros(6)
-positions = [
-    np.array([0.3, -0.3, 0.3, 0.0, 0.5, 0.0]),   # Position 1
-    np.array([0.5, -0.2, 0.4, 0.2, 0.4, 0.1]),   # Position 2
-    np.array([0.4, -0.4, 0.2, -0.1, 0.6, -0.1]), # Position 3
-    np.array([0.6, -0.1, 0.3, 0.1, 0.5, 0.2]),   # Position 4
-]
-
-# Build program: home → pos1 → pos2 → ... → home
-for pos in positions:
-    composer.add_freespace(goal_joints=pos)
-
-# Return home
-composer.add_freespace(goal_joints=home)
-
-# Plan entire sequence
-result = composer.plan()
-
-if result.success:
-    print(f"Multi-step sequence planned:")
-    for i, traj in enumerate(result.get_trajectories()):
-        print(f"  Segment {i+1}: {len(traj)} waypoints")
+```python title="car_seat_example.py (multi_step)"
+--8<-- "src/tesseract_robotics/examples/car_seat_example.py:multi_step"
 ```
+
+Run it:
+
+```bash
+tesseract_car_seat_example
+```
+
+Full source:
+[`car_seat_example.py`](https://github.com/tesseract-robotics/tesseract_nanobind/blob/main/src/tesseract_robotics/examples/car_seat_example.py).
+
+## Descartes + TrajOpt Chaining
+
+The `CartesianPipeline` runs Descartes (sampling-based, ladder-graph IK
+selection) followed by TrajOpt (smoothing). The snippet below shows the
+program + pipeline assembly:
+
+```python title="chain_example.py (descartes_then_trajopt)"
+--8<-- "src/tesseract_robotics/examples/chain_example.py:descartes_then_trajopt"
+```
+
+Run it:
+
+```bash
+tesseract_chain_example
+```
+
+Full source:
+[`chain_example.py`](https://github.com/tesseract-robotics/tesseract_nanobind/blob/main/src/tesseract_robotics/examples/chain_example.py).
+
+## 9-DOF with External Axis (Puzzle Piece)
+
+Cartesian toolpath planning with a 9-DOF system (robot + positioner + rail):
+
+```bash
+tesseract_puzzle_piece_auxillary_axes_example
+```
+
+See the source at
+[`puzzle_piece_auxillary_axes_example.py`](https://github.com/tesseract-robotics/tesseract_nanobind/blob/main/src/tesseract_robotics/examples/puzzle_piece_auxillary_axes_example.py).
 
 ## Visualization
 
@@ -347,7 +164,7 @@ viewer = TesseractViewer()
 viewer.update_environment(robot.env, [0, 0, 0])
 
 # Show trajectory
-if result.success:
+if result.successful:
     viewer.update_trajectory(result.raw_results)
 
 # Start server

--- a/docs/getting-started/concepts.md
+++ b/docs/getting-started/concepts.md
@@ -168,8 +168,20 @@ profiles.addProfile("ompl", "my_profile", ompl_profile)
 Checks collision at a single configuration:
 
 ```python
-# Check if configuration is collision-free
-is_safe = robot.check_collision(joint_values)
+from tesseract_robotics.tesseract_collision import (
+    ContactRequest,
+    ContactResultMap,
+    ContactTestType_ALL,
+)
+
+robot.set_joints(joint_values_dict)
+manager = robot.env.getDiscreteContactManager()
+manager.setActiveCollisionObjects(robot.env.getActiveLinkNames())
+manager.setCollisionObjectsTransform(robot.env.getState().link_transforms)
+
+contacts = ContactResultMap()
+manager.contactTest(contacts, ContactRequest(ContactTestType_ALL))
+is_safe = contacts.size() == 0
 ```
 
 ### Continuous Collision

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -3,7 +3,7 @@
 ## Users: Install from PyPI
 
 ```bash
-pip install tesseract-robotics
+pip install tesseract-robotics-nanobind
 ```
 
 The wheel bundles all C++ dependencies (~50MB). No compiler needed.

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -1,144 +1,152 @@
 # Quickstart
 
-This guide walks you through your first motion planning task.
+This guide walks you through your first motion planning task using the high-level `tesseract_robotics.planning` API.
 
 ## Load a Robot
 
 ```python
 from tesseract_robotics.planning import Robot
-import numpy as np
 
-# Load a bundled example robot (ABB IRB2400)
+# Load a bundled example robot (ABB IRB2400, KUKA LBR IIWA, etc.)
 robot = Robot.from_tesseract_support("abb_irb2400")
 
-# Or load from your own URDF/SRDF files
+# Or from your own URDF/SRDF via package:// URLs
 robot = Robot.from_urdf(
-    urdf_path="/path/to/robot.urdf",
-    srdf_path="/path/to/robot.srdf"
+    urdf_url="package://my_robot/urdf/robot.urdf",
+    srdf_url="package://my_robot/urdf/robot.srdf",
 )
+
+# Or from local files
+robot = Robot.from_files("/path/to/robot.urdf", "/path/to/robot.srdf")
 ```
 
 ## Forward Kinematics
 
-Compute the TCP (Tool Center Point) pose from joint values:
-
 ```python
-# Home position (6 joints for ABB IRB2400)
+import numpy as np
+
 joints = np.zeros(6)
-
-# Get TCP pose as Isometry3d (4x4 transform)
-tcp_pose = robot.fk(joints, group="manipulator")
-
-print(f"Position: {tcp_pose.translation()}")
-print(f"Rotation matrix:\n{tcp_pose.rotation()}")
+# group_name is the first positional argument; tip_link defaults to the chain's tip.
+tcp_pose = robot.fk("manipulator", joints)
+print(f"Position: {tcp_pose.position}")
+print(f"Quaternion (scalar-last, matches scipy): {tcp_pose.quaternion}")
 ```
 
 ## Inverse Kinematics
 
-Find joint values that achieve a target TCP pose:
-
 ```python
-# Create target pose (translate TCP by 10cm in X)
-target = robot.fk(joints)
-target.translate([0.1, 0, 0])
+from tesseract_robotics.planning import Pose
 
-# Solve IK (may return multiple solutions)
-solutions = robot.ik(target, group="manipulator")
+# Scalar-last quaternion convention (matches scipy.spatial.transform.Rotation)
+target = Pose.from_xyz_rpy(0.6, 0.0, 0.5, 0.0, 0.0, 0.0)
+ik_solution = robot.ik("manipulator", target, seed=joints)
 
-if solutions:
-    print(f"Found {len(solutions)} IK solutions")
-    print(f"First solution: {solutions[0]}")
+if ik_solution is not None:
+    print(f"IK solution: {ik_solution}")
 else:
-    print("No IK solution found - target may be unreachable")
+    print("Unreachable target")
 ```
 
 ## Collision Checking
 
-Check if a configuration is collision-free:
+Use the environment's discrete contact manager directly:
 
 ```python
-# Check current configuration
-is_safe = robot.check_collision(joints)
-print(f"Collision-free: {is_safe}")
-
-# Get detailed collision results
-contacts = robot.get_contacts(joints)
-for contact in contacts:
-    print(f"Contact between {contact.link_names}: {contact.distance:.3f}m")
-```
-
-## Motion Planning
-
-Plan a collision-free path between configurations:
-
-```python
-from tesseract_robotics.planning import Planner
-
-# Define start and goal
-start = np.zeros(6)
-goal = np.array([0.5, -0.5, 0.5, 0.0, 0.5, 0.0])
-
-# Create planner and plan
-planner = Planner(robot)
-trajectory = planner.plan(
-    start=start,
-    goal=goal,
-    planner="ompl",  # Options: ompl, trajopt, trajopt_ifopt, simple
-    profile="DEFAULT"
+from tesseract_robotics.tesseract_collision import (
+    ContactRequest,
+    ContactResultMap,
+    ContactTestType_ALL,
 )
 
-if trajectory:
-    print(f"Planned trajectory with {len(trajectory)} waypoints")
+robot.set_joints({"joint_1": 0.5, "joint_2": -0.3})
 
-    # Access waypoints
-    for i, waypoint in enumerate(trajectory):
-        print(f"  Waypoint {i}: {waypoint.positions}")
+manager = robot.env.getDiscreteContactManager()
+manager.setActiveCollisionObjects(robot.env.getActiveLinkNames())
+manager.setCollisionObjectsTransform(robot.env.getState().link_transforms)
+
+contacts = ContactResultMap()
+manager.contactTest(contacts, ContactRequest(ContactTestType_ALL))
+print(f"Collision-free: {contacts.size() == 0}")
 ```
 
-## Using the Composer (Advanced)
-
-For complex multi-step tasks, use the TaskComposer:
+## Motion Planning (freespace)
 
 ```python
-from tesseract_robotics.planning import Composer
+from tesseract_robotics.planning import (
+    MotionProgram, JointTarget, CartesianTarget, plan_freespace,
+)
 
-# Create composer with robot
-composer = Composer(robot)
+program = (
+    MotionProgram("manipulator")
+    .move_to(JointTarget(np.zeros(6)))
+    .move_to(CartesianTarget(target))
+)
 
-# Add waypoints
-composer.add_freespace(goal_joints=np.array([0.5, 0, 0, 0, 0, 0]))
-composer.add_cartesian(goal_pose=target_pose)
-composer.add_freespace(goal_joints=start)
-
-# Execute planning
-result = composer.plan()
-
-if result.success:
-    trajectories = result.get_trajectories()
-    print(f"Planned {len(trajectories)} trajectory segments")
+result = plan_freespace(robot, program)
+if result.successful:
+    for i, state in enumerate(result.trajectory):
+        print(f"[{i}] {state.positions}")
 ```
 
-## Visualization
+## Cartesian Planning (Descartes)
 
-Use the TesseractViewer to visualize robots and trajectories:
+The same `program` works with different planning backends — here Descartes for dense Cartesian toolpaths:
+
+```python
+from tesseract_robotics.planning import plan_cartesian
+
+result = plan_cartesian(robot, program)
+```
+
+## OMPL Planning (pure sampling)
+
+Or OMPL for pure sampling-based search:
+
+```python
+from tesseract_robotics.planning import plan_ompl
+
+result = plan_ompl(robot, program)
+```
+
+## Using the Task Composer (Advanced)
+
+For multi-stage pipelines (sampling then optimization then time parameterization):
+
+```python
+from tesseract_robotics.planning import TaskComposer
+
+composer = TaskComposer.from_config()
+composer.warmup(["TrajOptPipeline"])  # optional: pay plugin load cost up front
+result = composer.plan(robot, program, pipeline="TrajOptPipeline")
+```
+
+See [`TaskComposer.get_available_pipelines()`](../user-guide/task-composer.md) for the full list of 36 pipelines.
+
+## Visualization
 
 ```python
 from tesseract_robotics.viewer import TesseractViewer
 
 viewer = TesseractViewer()
 viewer.update_environment(robot.env, [0, 0, 0])
-
-# Animate a trajectory
-if trajectory:
-    viewer.update_trajectory(trajectory.raw_results)
+if result.successful:
+    viewer.update_trajectory(result.raw_results)
 
 viewer.start_serve_background()
 print("Open http://localhost:8000 in your browser")
 input("Press Enter to exit...")
 ```
 
+## Installation
+
+```bash
+pip install tesseract-robotics-nanobind
+```
+
+See [Installation](installation.md) for developer-mode setup via pixi.
+
 ## Next Steps
 
-- [Core Concepts](concepts.md) - Understand the architecture
-- [Motion Planning Guide](../user-guide/planning.md) - Deep dive into planners
-- [Examples](../examples/index.md) - Learn from working examples
+- [Core Concepts](concepts.md) — Understand the architecture
+- [Motion Planning Guide](../user-guide/planning.md) — Deep dive into planners
+- [Examples](../examples/index.md) — Working examples

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,8 +18,9 @@ Python bindings for the Tesseract Motion Planning Framework.
 graph TB
     subgraph high["High-Level API"]
         Robot["Robot"]
-        Planner["Planner"]
-        Composer["Composer"]
+        MP["MotionProgram"]
+        PF["plan_freespace / plan_ompl / plan_cartesian"]
+        TC["TaskComposer"]
     end
 
     subgraph low["Low-Level Modules"]
@@ -34,47 +35,47 @@ graph TB
     subgraph sqp["SQP (Real-time Optimization)"]
         tsqp["trajopt_sqp"]
         tifopt["trajopt_ifopt"]
-        ifopt["ifopt"]
     end
 
     Robot --> env
     Robot --> kin
-    Planner --> mp
-    Composer --> tc
+    MP --> cmd
+    PF --> mp
+    TC --> tc
     mp --> tsqp
     tc --> tsqp
     tsqp --> tifopt
-    tifopt --> ifopt
 ```
 
 ## Quick Example
 
 ```python
-from tesseract_robotics.planning import Robot
 import numpy as np
+from tesseract_robotics.planning import (
+    Robot, MotionProgram, JointTarget, CartesianTarget, Pose, plan_freespace,
+)
 
-# Load robot from URDF
-robot = Robot.from_urdf("robot.urdf", "robot.srdf")
+# Load a bundled robot
+robot = Robot.from_tesseract_support("abb_irb2400")
 
-# Forward kinematics
-joints = np.array([0.0, -0.5, 0.5, 0.0, 0.5, 0.0])
-tcp_pose = robot.fk(joints, group="manipulator")
-print(f"TCP position: {tcp_pose.translation()}")
+# Forward kinematics (note: group_name is first positional arg)
+joints = np.zeros(6)
+tcp_pose = robot.fk("manipulator", joints)
+print(f"TCP position: {tcp_pose.position}")
 
 # Inverse kinematics
-target = tcp_pose
-target.translate([0.1, 0, 0])  # Move 10cm in X
-solutions = robot.ik(target, group="manipulator")
+target = Pose.from_xyz_rpy(0.6, 0.0, 0.5, 0.0, 0.0, 0.0)
+ik_solution = robot.ik("manipulator", target, seed=joints)
 
-# Check for collisions
-is_collision_free = robot.check_collision(solutions[0])
-
-# Plan motion
-trajectory = robot.plan(
-    start=joints,
-    goal=solutions[0],
-    planner="ompl"
+# Plan a freespace motion
+program = (
+    MotionProgram("manipulator")
+    .move_to(JointTarget(joints))
+    .move_to(CartesianTarget(target))
 )
+result = plan_freespace(robot, program)
+if result.successful:
+    print(f"Found trajectory with {len(result.trajectory)} waypoints")
 ```
 
 ## Planners
@@ -89,13 +90,10 @@ trajectory = robot.plan(
 
 ## Performance
 
-The low-level SQP API enables real-time trajectory optimization:
-
-| Configuration | Rate |
-|---------------|------|
-| Without collision | 128 Hz |
-| With discrete collision | 73 Hz |
-| With LVS continuous collision | 5-10 Hz |
+The low-level SQP API enables real-time trajectory optimization.
+Rates depend on problem size and collision mode. See
+[`online_planning_sqp_example.py`](https://github.com/tesseract-robotics/tesseract_nanobind/blob/main/src/tesseract_robotics/examples/online_planning_sqp_example.py)
+which prints measured rates for a reference 6-DOF problem on your machine.
 
 ## Next Steps
 

--- a/docs/superpowers/specs/2026-04-24-mkdocs-refresh-design.md
+++ b/docs/superpowers/specs/2026-04-24-mkdocs-refresh-design.md
@@ -1,0 +1,160 @@
+# MkDocs refresh — API-truth sweep
+
+**Date:** 2026-04-24
+**Status:** design
+**Owner:** @jelleferinga
+
+## Problem
+
+`docs/` has drifted from `src/` to the point that key guides are no longer instructional — they are misleading. The worst offenders do not just describe an old API; they describe an **API that never existed**:
+
+- `docs/index.md` and `docs/getting-started/quickstart.md` show a `Planner(robot)` class with `.plan(start, goal, planner="ompl")`. No such class exists; real planning is `plan_freespace(robot, MotionProgram(...))`.
+- Quickstart shows `Composer(robot).add_freespace(...).add_cartesian(...)`. No such class; real class is `TaskComposer` with `.plan(robot, program, ...)`.
+- Quickstart shows `robot.check_collision(joints)` and `robot.get_contacts(joints)`. Neither method exists.
+- `robot.fk(joints, group="manipulator")` — wrong arg order; real signature is `fk(group_name, joint_positions, tip_link=None)`.
+- `pip install tesseract-robotics-nanobind` — wrong package name; PyPI name is `tesseract_robotics`.
+
+`docs/user-guide/low-level-sqp.md` is worse: every snippet uses the pre-0.34 `JointPosition` / `CartPosInfo` / `CollisionCache` API, and imports from `tesseract_robotics.ifopt` — a module **removed** in 0.34. Users following the page hit `ImportError` on line 1 of the basic example.
+
+Meanwhile, real post-0.34 work isn't covered: the viewer submodule refactor (`f277eb5`), `TaskComposer.warmup()` (`06d25ad`), the polymorphic `CompositeInstruction.push_back` (`6d17314`, CHANGELOG 0.35.0.0 seed), and the `CHANGELOG.md` itself (added in `afbf858`, not linked from the rendered site).
+
+Commit-history alone won't catch this. Much of the drift predates any identifiable "breaking commit" — it's hallucinated API that was never correct. The fix is a content-first sweep: treat current `src/` as source of truth and walk every page.
+
+## Goal
+
+Bring `docs/` into agreement with current `src/` (post-0.34, post-flatten, post-viewer-refactor, post-example-relocation). Wire `CHANGELOG.md` into the rendered site. Make `mkdocs build --strict` pass and keep it green via CI.
+
+## Non-goals
+
+- Writing-style rewrites for their own sake. Fix content; preserve voice where content is correct.
+- `mkdocs-macros` / doctest / snippet-execution infrastructure. Flagship self-verification via existing `tests/examples/` is sufficient.
+- Deprecating `changes.md`. It's a stable 0.33→0.34 migration artifact; relabel in nav, content untouched.
+- Fresh 0.34→0.35 migration guide. `CHANGELOG.md` covers it. Revisit only if 0.35 ships breaking changes.
+- Touching `pyproject.toml` / `mkdocs.yml` beyond: nav (CHANGELOG + Viewer), removing dead `polyfill.io` CDN, `changes.md` nav label.
+
+## Methodology
+
+1. **Source of truth priority:** current `src/tesseract_robotics/**` > `src/tesseract_robotics/examples/**` > commit log (for context only) > existing docs prose.
+2. **Two snippet tiers:**
+   - *Prose pages* (`index.md`, `getting-started/`, `user-guide/*.md` except flagship pointers, `api/` prose preambles, `developer/`): short hand-crafted snippets, each checked once against `src/`.
+   - *Flagship workflows* (examples pages, pick-and-place / raster / online-planning / viewer walkthroughs): pulled verbatim from `src/tesseract_robotics/examples/<name>.py` via `--8<-- "src/…"` snippet markers. `pymdownx.snippets` is already enabled in `mkdocs.yml` with `base_path: ['.', 'docs']`, so this requires only `# --8<-- [start:region]` / `# --8<-- [end:region]` annotations in the example files — no config changes.
+3. **Verification tiers:**
+   - `mkdocs build --strict` green locally and in a new CI workflow.
+   - Flagship snippets = self-verifying via existing `tests/examples/` suite.
+   - Prose snippets = manually verified during refresh via signature match against `src/`.
+4. **Order of attack:** one branch, one PR, commit per page group in priority order — worst drift first so each commit is individually reviewable and bisectable.
+
+## Scope — per-page plan
+
+**Legend:** 🔴 broken/wrong · 🟡 stale but mostly right · 🟢 correct, minor polish
+
+### Narrative pages
+
+| Page | State | Action |
+|---|---|---|
+| `index.md` | 🔴 | Rewrite quick example against real API (`plan_freespace(robot, program)` + `MotionProgram` builder). Fix `robot.fk` signature. Verify architecture mermaid vs. actual module graph. If Performance Hz table (128/73/5-10) can't be re-sourced from `online_planning_sqp_example.py`, drop specific numbers and link to the example. |
+| `getting-started/installation.md` | 🟢 | Recent (`9fd37aa`, 2026-02). Spot-check pixi commands match `pyproject.toml [tool.pixi.tasks]`. Verify both user-via-PyPI and developer-via-pixi paths. |
+| `getting-started/quickstart.md` | 🔴 | Full rewrite. Replace `Planner(robot).plan(...)` with `plan_freespace(robot, program)`. Replace `Composer(robot).add_freespace(...)` with `TaskComposer.plan(robot, program)`. Remove `robot.check_collision` / `robot.get_contacts`. Fix `pip install tesseract-robotics-nanobind` → `tesseract_robotics`. |
+| `getting-started/concepts.md` | 🟡 | Remove final `robot.check_collision` ref. Keep Command Language / Poly explanation — still accurate. Update Task Composer pipeline ascii box to reference `get_available_pipelines()` (36 pipelines). |
+| `user-guide/environment.md` | 🟡 | Last touched 2025-12; predates flatten + viewer refactor. Audit imports + signatures. |
+| `user-guide/kinematics.md` | 🟡 | Audit FK/IK snippets against `planning/core.py`. Verify scalar-last quaternion convention is documented. |
+| `user-guide/collision.md` | 🟡 | Verify against `tesseract_collision` + 0.34 `CollisionEvaluatorType` enum (`DISCRETE`/`CONTINUOUS`/`LVS_DISCRETE`/`LVS_CONTINUOUS`, not `SINGLE_TIMESTEP`). |
+| `user-guide/planning.md` | 🔴 | Tab blocks use fictional `Planner(robot).plan(start, goal, planner="ompl")`. Replace with real `plan_freespace` / `plan_ompl` / `plan_cartesian`. Keep costs-vs-constraints + Motion Types + Profile Caching sections. Drop "Collision Configuration (0.33 API)" section header — it's just *the* API now. |
+| `user-guide/task-composer.md` | 🟡 | Verify `TaskComposer` API against `planning/composer.py`. Document `warmup()` (shipped `06d25ad`, currently undocumented). Reference `get_available_pipelines()`. |
+| `user-guide/serialization.md` | 🟢 | Recent (`56dce3e`). Spot-check. |
+| `user-guide/low-level-sqp.md` | 🔴🔴 | **Full rewrite.** Replace `JointPosition` with `Var`/`Node`/`createNodesVariables`. Replace `CartPosInfo` with direct `CartPosConstraint` ctor. Remove `CollisionCache`. Replace `from tesseract_robotics.ifopt import Bounds` with `from tesseract_robotics.trajopt_ifopt import Bounds`. Replace `evaluateTotalExactCost(x)` with `getTotalExactCost()`. Use `online_planning_sqp_example.py` as canonical via `--8<--`. |
+| `user-guide/viewer.md` | ➕ NEW | Create. Cover `TesseractViewer` basics (`update_environment`, `update_trajectory`, `start_serve_background`). Flagship walkthroughs via `--8<--` from `shapes_viewer.py`, `abb_irb2400_viewer.py`, `twc_workcell_positioner_viewer.py`. Note submodule requirement for TWC workcell. |
+
+### Examples pages
+
+| Page | State | Action |
+|---|---|---|
+| `examples/index.md` | 🟡 | Fix invocation: `python examples/foo.py` → `tesseract_<name>_example` console script (installed via `[project.scripts]`) or `python -m tesseract_robotics.examples.<name>`. Fix `pip install tesseract-robotics-nanobind` → `tesseract_robotics`. Add `reeds_shepp_example.py` + `twc_workcell_positioner_viewer.py` (currently missing from tables). |
+| `examples/basic.md` | 🟡 | Audit each linked example; update invocation; use `--8<--` for flagship (kinematics). |
+| `examples/planning.md` | 🟡 | Audit. Use `--8<--` for pick-and-place, raster, car-seat, chain flagships. |
+| `examples/online-planning.md` | 🟡 | Audit. Align with low-level-sqp rewrite (cross-link). |
+
+### API reference pages
+
+| Page | State | Action |
+|---|---|---|
+| `api/index.md` | 🔴 | "Robot, Planner, Composer classes" line — Planner is fictional. Fix module table to: `Robot`, `MotionProgram`, `TaskComposer`, `plan_freespace/plan_ompl/plan_cartesian`. |
+| `api/planning.md` | 🟡 | mkdocstrings auto-block is fine. Hand-written preamble says "Classes: Robot / Planner / Composer" — fix names. |
+| `api/tesseract_common.md` | 🟡 | Audit `Isometry3d` snippets. Verify `Pose` class (from `planning/transforms.py`) is mentioned. |
+| `api/tesseract_collision.md` | 🟡 | Verify 0.34 enum names (`CollisionEvaluatorType.DISCRETE` etc.). Verify `clone()` bindings (`dab4625`). |
+| `api/tesseract_command_language.md` | 🟡 | Audit. Add polymorphic `push_back(CompositeInstruction)` (`6d17314`, 0.35.0.0). |
+| `api/tesseract_environment.md` | 🟡 | Audit. Check `Robot.from_urdf` snippet shows both URDF + SRDF args. |
+| `api/tesseract_geometry.md` | 🟢 | Spot-check against `geometry_showcase_example.py`. |
+| `api/tesseract_kinematics.md` | 🟢 | Spot-check. |
+| `api/tesseract_scene_graph.md` | 🟢 | Spot-check. |
+| `api/tesseract_serialization.md` | 🟡 | Verify Boost→Cereal switch not leaked as Boost references. |
+| `api/tesseract_motion_planners.md` | 🟡 | Verify `PlannerRequest` fields against current source. |
+| `api/tesseract_motion_planners_ompl.md` | 🟡 | Verify profile class names + 0.34 enum values. |
+| `api/tesseract_motion_planners_trajopt.md` | 🟡 | Verify `TrajOptCollisionConfig` location (trajopt_ifopt, re-exported from trajopt). |
+| `api/tesseract_motion_planners_descartes.md` | 🟡 | Verify. |
+| `api/tesseract_motion_planners_simple.md` | 🟡 | Verify. |
+| `api/tesseract_task_composer.md` | 🟡 | Verify against current 36-pipeline list. |
+| `api/trajopt_ifopt.md` | 🔴 | Rewrite to 0.34 (`Var`/`Node`/`NodesVariables`, no `JointPosition`, no `CartPosInfo`, no `CollisionCache`). |
+| `api/trajopt_sqp.md` | 🟡 | Verify `IfoptProblem`/`IfoptQPProblem` two-level split (0.34 change). |
+
+### Developer pages
+
+| Page | State | Action |
+|---|---|---|
+| `developer/index.md` | 🟡 | Fix mermaid diagram ("Robot, Planner, Composer" → real names). Fix "run an example" command. Otherwise recent & accurate. |
+| `developer/migration.md` | 🟢 | SWIG→Nanobind historical; stable. Spot-check only. |
+| `developer/trajopt_ifopt_missing_constraints.md` | 🟡 | Verify "all 4 constraints bound" claim against current bindings. Fix obsolete `JointPosition` refs in shown C++ signatures. If claim holds, reframe page as historical reference and note completion. |
+
+### Structural / config
+
+| Item | Action |
+|---|---|
+| `mkdocs.yml` nav | Add top-level `Changelog: changelog.md` entry. Rename `Changes: "0.33 → 0.34"` → `Migration Guides > "0.33 → 0.34": changes.md`. Add `User Guide > Viewer: user-guide/viewer.md`. |
+| `mkdocs.yml` CDN cleanup | Remove `polyfill.io` line (dead/hijacked domain). Audit `mathjax` CDN — if math isn't rendered in any doc, drop the whole math block. |
+| `docs/CHANGELOG.md` | Symlink (or copy + add pre-commit sync hook) from repo root `CHANGELOG.md`. Symlink preferred; cross-platform concern is moot because mkdocs runs on CI + dev boxes (both POSIX). |
+| `docs/QUICKSTART.md` | Currently excluded from mkdocs via `plugins.exclude.glob`. Decision: `git rm` if vestigial. Check `git log docs/QUICKSTART.md` for intent — if it was GitHub-landing content, leave it and keep exclusion. |
+| `docs/requirements.txt` | Verify mkdocs-material / mkdocstrings pins are still sane vs `pyproject.toml [tool.pixi.dependencies]`. |
+| `.github/workflows/docs.yml` | ➕ NEW — `mkdocs build --strict` on PRs touching `docs/**` or `mkdocs.yml`. |
+
+## Commit sequence
+
+Single branch `docs/refresh-api-truth`, single PR to `main`. Each commit is individually bisectable and reviewable.
+
+1. `docs: fix fictional Robot/Planner/Composer API in quickstart + index` — `index.md`, `quickstart.md`.
+2. `docs: drop invented robot.check_collision in concepts + collision audit` — `concepts.md`.
+3. `docs(user-guide): rewrite planning.md against real API` — `user-guide/planning.md`.
+4. `docs(user-guide): rewrite low-level-sqp to 0.34 Var/Node/NodesVariables` — `user-guide/low-level-sqp.md`.
+5. `docs(user-guide): audit environment/kinematics/collision/task-composer` — add `warmup()`, reference `get_available_pipelines()`.
+6. `docs(user-guide): add viewer page` — new `user-guide/viewer.md` using `--8<--` flagships.
+7. `docs(examples): fix invocation + list missing examples` — console-script commands, add `reeds_shepp`, `twc_workcell_positioner_viewer`, wire `--8<--`.
+8. `docs(api): fix hand-written preambles + code blocks` — including full `trajopt_ifopt.md` rewrite.
+9. `docs(developer): fix index mermaid + example-run command; audit missing-constraints page`.
+10. `docs(nav): wire CHANGELOG, relabel changes.md, drop polyfill.io` — `mkdocs.yml` + `docs/CHANGELOG.md` symlink.
+11. `ci: add docs.yml workflow running mkdocs build --strict` — `.github/workflows/docs.yml`.
+
+## Verification
+
+- **Per commit, locally:** `pixi run docs-build` completes; `mkdocs build --strict` green.
+- **At PR-open:** new `.github/workflows/docs.yml` runs strict build.
+- **Flagship `--8<--` snippets:** self-verified via existing `tests/examples/` suite (already in pre-push hook + CI).
+- **Prose snippets:** each verified against current `src/` during refresh. One-time manual check; no CI coverage (acceptable — the fictional-API drift that motivated this refresh happened once and is cheap to catch at review time).
+
+## Done criteria
+
+1. `mkdocs build --strict` green locally and in the new CI workflow.
+2. Zero references in `docs/` to: `Planner(robot)`, `Composer(robot)`, `robot.check_collision`, `robot.get_contacts`, `from tesseract_robotics import ifopt`, `JointPosition`, `CartPosInfo`, `CollisionCache`, `python examples/` (as invocation), `tesseract-robotics-nanobind` (pip name), `polyfill.io`.
+3. `CHANGELOG.md` wired into nav and rendered at `/changelog/`.
+4. `user-guide/viewer.md` exists with working `--8<--` flagship snippets.
+5. Single PR merged to `main`; nothing left on feature branches.
+
+## Open items resolved during implementation
+
+- **Performance numbers in `index.md`:** if the 128/73/5-10 Hz figures cannot be re-sourced from `online_planning_sqp_example.py` output, remove the specific numbers and link to the example.
+- **`QUICKSTART.md` fate:** `git log docs/QUICKSTART.md` tells us intent — vestigial → `git rm`, GitHub-landing → leave + keep exclusion.
+- **`trajopt_ifopt_missing_constraints.md` fate:** verify 4-constraint claim; if all bound, reframe as historical; else keep as actionable TODO.
+
+## Risks
+
+- **`--8<--` snippet regions require markers in example files.** Small one-time edit to `src/tesseract_robotics/examples/*.py` to add `# --8<-- [start:X]` / `# --8<-- [end:X]` comments. Markers are Python comments; runtime unaffected; `ruff` leaves them alone.
+- **`docs/CHANGELOG.md` as symlink:** mkdocs follows symlinks by default. CI runners are Linux/macOS (POSIX). No Windows dev concern at present (Windows wheels still WIP per CHANGELOG). If this changes, convert to a pre-commit sync hook.
+- **CI cost:** one extra GitHub Actions job per PR touching docs. Runs on `ubuntu-latest` in under a minute. Negligible.

--- a/docs/user-guide/collision.md
+++ b/docs/user-guide/collision.md
@@ -4,30 +4,43 @@ tesseract_robotics provides discrete and continuous collision checking using FCL
 
 ## Quick Collision Check
 
-=== "High-Level API"
+The collision API is driven by the environment's contact manager — there is no one-call shortcut on `Robot`. See [`src/tesseract_robotics/examples/tesseract_collision_example.py`](https://github.com/tesseract-robotics/tesseract_nanobind/blob/main/src/tesseract_robotics/examples/tesseract_collision_example.py) for the canonical pattern.
 
-    ```python
-    from tesseract_robotics.planning import Robot
-    import numpy as np
+```python
+from tesseract_robotics.planning import Robot
+from tesseract_robotics.tesseract_collision import (
+    ContactRequest,
+    ContactResultMap,
+    ContactResultVector,
+    ContactTestType_ALL,
+)
+import numpy as np
 
-    robot = Robot.from_tesseract_support("abb_irb2400")
-    joints = np.array([0.5, -0.5, 0.5, 0.0, 0.5, 0.0])
+robot = Robot.from_tesseract_support("abb_irb2400")
+joint_names = [f"joint_{i + 1}" for i in range(6)]
+joints = np.array([0.5, -0.5, 0.5, 0.0, 0.5, 0.0])
 
-    # Simple check
-    is_safe = robot.check_collision(joints)
-    print(f"Collision-free: {is_safe}")
-    ```
+# Update state, then sync the manager with the new link transforms
+robot.set_joints(joints, joint_names=joint_names)
+state = robot.env.getState()
 
-=== "With Contact Details"
+manager = robot.env.getDiscreteContactManager()
+manager.setActiveCollisionObjects(robot.env.getActiveLinkNames())
+manager.setCollisionObjectsTransform(state.link_transforms)
 
-    ```python
-    contacts = robot.get_contacts(joints)
+# contactTest() populates the ContactResultMap passed in (returns None)
+contacts = ContactResultMap()
+manager.contactTest(contacts, ContactRequest(ContactTestType_ALL))
 
-    for contact in contacts:
-        print(f"Contact: {contact.link_names[0]} <-> {contact.link_names[1]}")
-        print(f"  Distance: {contact.distance:.4f} m")
-        print(f"  Point: {contact.nearest_points[0]}")
-    ```
+print(f"Collision-free: {contacts.size() == 0}")
+
+# Flatten to a vector for iteration
+results = ContactResultVector()
+contacts.flattenMoveResults(results)
+for i in range(len(results)):
+    r = results[i]
+    print(f"{r.link_names[0]} <-> {r.link_names[1]}: distance = {r.distance:.4f} m")
+```
 
 ## Collision Managers
 
@@ -61,52 +74,65 @@ graph LR
 
 ```python
 from tesseract_robotics.tesseract_collision import (
-    DiscreteContactManager,
     ContactRequest,
-    ContactTestType
+    ContactResultMap,
+    ContactTestType_ALL,
 )
 
 # Get discrete manager
-manager = env.getDiscreteContactManager()
+manager = robot.env.getDiscreteContactManager()
 
 # Configure request
-request = ContactRequest()
-request.type = ContactTestType.ALL  # or FIRST, CLOSEST
+request = ContactRequest(ContactTestType_ALL)  # or _FIRST, _CLOSEST, _LIMITED
 request.calculate_distance = True
 request.calculate_penetration = True
 
-# Set state and check
-env.setState(joint_names, joint_values)
-manager.setActiveCollisionObjects(env.getActiveLinkNames())
-manager.setContactDistanceThreshold(0.05)  # 5cm margin
+# Sync manager with current state
+manager.setActiveCollisionObjects(robot.env.getActiveLinkNames())
+manager.setCollisionObjectsTransform(robot.env.getState().link_transforms)
+manager.setDefaultCollisionMargin(0.05)  # 5cm margin
 
-contacts = manager.contactTest(request)
+# contactTest populates `contacts` in-place
+contacts = ContactResultMap()
+manager.contactTest(contacts, request)
 
-for key, results in contacts.items():
-    link_a, link_b = key
-    for result in results:
-        print(f"{link_a} <-> {link_b}: {result.distance:.4f}m")
+# Iterate pairs via flattened vector (simplest idiom)
+from tesseract_robotics.tesseract_collision import ContactResultVector
+results = ContactResultVector()
+contacts.flattenMoveResults(results)
+for i in range(len(results)):
+    r = results[i]
+    print(f"{r.link_names[0]} <-> {r.link_names[1]}: {r.distance:.4f}m")
 ```
 
 ## Continuous Collision Checking
 
-Check for collisions along a motion segment:
+Check for collisions along a motion segment. Each active link needs a start and end transform via `setCollisionObjectsTransformCast`:
 
 ```python
-from tesseract_robotics.tesseract_collision import ContinuousContactManager
-
-# Get continuous manager
-manager = env.getContinuousContactManager()
-
-# Set start and end transforms
-manager.setCollisionObjectsTransform(
-    link_names,
-    start_transforms,
-    end_transforms
+from tesseract_robotics.tesseract_collision import (
+    ContactRequest,
+    ContactResultMap,
+    ContactTestType_ALL,
 )
 
+# Resolve link transforms at the two endpoints
+joint_names = robot.get_joint_names("manipulator")
+start_transforms = robot.env.getState(joint_names, start_joints).link_transforms
+end_transforms = robot.env.getState(joint_names, end_joints).link_transforms
+
+# Get continuous manager
+manager = robot.env.getContinuousContactManager()
+manager.setActiveCollisionObjects(robot.env.getActiveLinkNames())
+
+# Set start and end poses per link
+for link_name, pose_start in start_transforms.items():
+    pose_end = end_transforms[link_name]
+    manager.setCollisionObjectsTransformCast(link_name, pose_start, pose_end)
+
 # Check swept volume
-contacts = manager.contactTest(request)
+contacts = ContactResultMap()
+manager.contactTest(contacts, ContactRequest(ContactTestType_ALL))
 ```
 
 ## LVS (Longest Valid Segment)
@@ -131,29 +157,30 @@ Used in TrajOpt for efficient continuous collision approximation:
 from tesseract_robotics.trajopt_ifopt import TrajOptCollisionConfig
 from tesseract_robotics.tesseract_collision import CollisionEvaluatorType
 
-# 0.33 API: TrajOptCollisionConfig(margin, coeff) constructor
+# TrajOptCollisionConfig(margin, coeff)
 config = TrajOptCollisionConfig(0.025, 20.0)  # 2.5cm margin, coeff=20
 config.collision_margin_buffer = 0.005  # Additional buffer beyond margin
 config.collision_check_config.type = CollisionEvaluatorType.LVS_DISCRETE
 config.collision_check_config.longest_valid_segment_length = 0.05  # 5cm interpolation
 ```
 
+`CollisionEvaluatorType` members (from `tesseract_collision`): `DISCRETE`, `CONTINUOUS`, `LVS_DISCRETE`, `LVS_CONTINUOUS`.
+
 ## Contact Margins
 
-Contact margins define the safety buffer around objects:
+Contact margins define the safety buffer around objects. Use `CollisionMarginData` from `tesseract_common`:
 
 ```python
-from tesseract_robotics.tesseract_collision import ContactMarginData
+from tesseract_robotics.tesseract_common import CollisionMarginData
 
-margin_data = ContactMarginData()
+# Default margin for all pairs (applied to the contact manager)
+manager.setCollisionMarginData(CollisionMarginData(0.02))  # 2cm
 
-# Default margin for all pairs
-margin_data.default_margin = 0.02  # 2cm
+# Or set the default margin directly
+manager.setDefaultCollisionMargin(0.02)
 
-# Override for specific pair
-margin_data.setPairMargin("link_6", "obstacle", 0.05)  # 5cm for this pair
-
-manager.setContactMarginData(margin_data)
+# Per-pair override (link-a, link-b, margin)
+manager.setCollisionMarginPair("link_6", "obstacle", 0.05)
 ```
 
 ### Margin Visualization
@@ -174,20 +201,33 @@ manager.setContactMarginData(margin_data)
 
 ## Allowed Collision Matrix
 
-Skip collision checks for adjacent or always-safe pairs:
+Skip collision checks for adjacent or always-safe pairs. The ACM lives on the scene graph and is owned by the environment:
 
 ```python
-acm = env.getAllowedCollisionMatrix()
+# Fetch the ACM (mutable via scene graph commands on the environment)
+acm = robot.env.getAllowedCollisionMatrix()
 
-# Links always in contact (adjacent)
-acm.addAllowedCollision("link_1", "link_2", "Adjacent")
-
-# Robot holding an object
-acm.addAllowedCollision("gripper", "workpiece", "Attached")
-
-# Apply to manager
-manager.setIsContactAllowedFn(acm.isCollisionAllowed)
+# Query whether a pair is allowed
+if acm.isCollisionAllowed("link_1", "link_2"):
+    print("link_1 and link_2 are whitelisted")
 ```
+
+To add entries, issue a scene graph command through the environment (see `car_seat_example.py` for the canonical pattern):
+
+```python
+from tesseract_robotics.tesseract_common import AllowedCollisionMatrix
+from tesseract_robotics.tesseract_environment import (
+    ModifyAllowedCollisionsCommand, ModifyAllowedCollisionsType,
+)
+
+additions = AllowedCollisionMatrix()
+additions.addAllowedCollision("gripper", "workpiece", "Attached")
+robot.env.applyCommand(
+    ModifyAllowedCollisionsCommand(additions, ModifyAllowedCollisionsType.ADD)
+)
+```
+
+Adjacent links already defined in the SRDF are added automatically when the environment is loaded.
 
 ## Performance Optimization
 
@@ -209,32 +249,42 @@ manager.setIsContactAllowedFn(acm.isCollisionAllowed)
 
 !!! tip "Choose the Right Test Type"
     ```python
+    from tesseract_robotics.tesseract_collision import (
+        ContactTestType_FIRST,
+        ContactTestType_ALL,
+    )
+
     # Stop at first collision (fastest)
-    request.type = ContactTestType.FIRST
+    request = ContactRequest(ContactTestType_FIRST)
 
     # Get all collisions (for debugging)
-    request.type = ContactTestType.ALL
+    request = ContactRequest(ContactTestType_ALL)
     ```
 
 ## Integration with Planning
 
-Planners automatically use collision checking:
+Planners automatically use collision checking — configure collision margins through planner profiles rather than calling the contact manager yourself:
 
 ```python
-from tesseract_robotics.planning import Planner
-
-planner = Planner(robot)
-
-# OMPL checks at sampled states
-trajectory = planner.plan(start, goal, planner="ompl")
-
-# TrajOpt uses collision cost/constraint
-trajectory = planner.plan(
-    start, goal,
-    planner="trajopt",
-    collision_margin=0.025
+from tesseract_robotics.planning import (
+    MotionProgram, JointTarget, plan_freespace,
 )
+import numpy as np
+
+# Build a program (start/goal joint states)
+program = (
+    MotionProgram("manipulator")
+    .move_to(JointTarget(np.zeros(6)))
+    .move_to(JointTarget(np.array([0.5, -0.5, 0.5, 0.0, 0.5, 0.0])))
+)
+
+# OMPL (sampling) — checks collisions at sampled states
+# TrajOpt — would use collision cost/constraint via TrajOptCollisionConfig
+# Descartes (plan_cartesian) — expects Cartesian targets, not joint targets
+result = plan_freespace(robot, program)
 ```
+
+Collision margins for TrajOpt pipelines live in `TrajOptCollisionConfig` (see LVS section above) and are applied via composite profiles — see [`src/tesseract_robotics/planning/profiles.py`](https://github.com/tesseract-robotics/tesseract_nanobind/blob/main/src/tesseract_robotics/planning/profiles.py) for the stock profile builder.
 
 ## Collision Geometry Types
 
@@ -248,33 +298,59 @@ trajectory = planner.plan(
 | **ConvexMesh** | Medium | High |
 
 !!! tip "Use Convex Decomposition"
-    For complex meshes, use convex decomposition for better performance:
+    For complex meshes, use `makeConvexMesh` to build a convex hull:
 
     ```python
-    from tesseract_robotics.tesseract_geometry import ConvexMesh
+    from tesseract_robotics.tesseract_collision import makeConvexMesh
 
-    convex = ConvexMesh.fromMesh(mesh, convex_hull=True)
+    convex = makeConvexMesh(mesh)
+    ```
+
+    To load a convex mesh directly from a file, use the planning helper:
+
+    ```python
+    from tesseract_robotics.planning import convex_mesh_from_file
+
+    convex = convex_mesh_from_file("/path/to/mesh.stl")
     ```
 
 ## Debugging Collisions
 
 ```python
-def debug_collision(robot, joints):
-    """Print detailed collision info."""
-    contacts = robot.get_contacts(joints)
+from tesseract_robotics.tesseract_collision import (
+    ContactRequest,
+    ContactResultMap,
+    ContactResultVector,
+    ContactTestType_ALL,
+)
 
-    if not contacts:
+def debug_collision(robot, joints, joint_names):
+    """Print detailed collision info."""
+    robot.set_joints(joints, joint_names=joint_names)
+    state = robot.env.getState()
+
+    manager = robot.env.getDiscreteContactManager()
+    manager.setActiveCollisionObjects(robot.env.getActiveLinkNames())
+    manager.setCollisionObjectsTransform(state.link_transforms)
+
+    contacts = ContactResultMap()
+    manager.contactTest(contacts, ContactRequest(ContactTestType_ALL))
+
+    if contacts.size() == 0:
         print("No collisions detected")
         return
 
-    print(f"Found {len(contacts)} contact(s):")
-    for i, contact in enumerate(contacts):
-        print(f"\n  Contact {i+1}:")
-        print(f"    Links: {contact.link_names[0]} <-> {contact.link_names[1]}")
-        print(f"    Distance: {contact.distance:.4f} m")
-        print(f"    Normal: {contact.normal}")
-        if contact.distance < 0:
-            print(f"    PENETRATION: {-contact.distance:.4f} m")
+    results = ContactResultVector()
+    contacts.flattenMoveResults(results)
+    print(f"Found {len(results)} contact(s):")
+    for i in range(len(results)):
+        r = results[i]
+        print(f"\n  Contact {i + 1}:")
+        print(f"    Links: {r.link_names[0]} <-> {r.link_names[1]}")
+        print(f"    Distance: {r.distance:.4f} m")
+        print(f"    Normal: {r.normal}")
+        if r.distance < 0:
+            print(f"    PENETRATION: {-r.distance:.4f} m")
 ```
 
 ## Next Steps

--- a/docs/user-guide/environment.md
+++ b/docs/user-guide/environment.md
@@ -1,6 +1,6 @@
 # Environment & Scene Graph
 
-The Environment is the central data structure in tesseract_robotics, containing the robot model, scene graph, and collision information.
+The `Environment` is the central data structure in tesseract_robotics — it owns the robot model, the scene graph of links/joints, the current state, and the collision data. The high-level `Robot` wrapper exposes it via `robot.env`.
 
 ## Creating an Environment
 
@@ -9,9 +9,21 @@ The Environment is the central data structure in tesseract_robotics, containing 
     ```python
     from tesseract_robotics.planning import Robot
 
+    robot = Robot.from_files(
+        "/path/to/robot.urdf",
+        "/path/to/robot.srdf",
+    )
+    env = robot.env
+    ```
+
+=== "From `package://` URLs"
+
+    ```python
+    from tesseract_robotics.planning import Robot
+
     robot = Robot.from_urdf(
-        urdf_path="/path/to/robot.urdf",
-        srdf_path="/path/to/robot.srdf"
+        "package://my_robot/urdf/robot.urdf",
+        "package://my_robot/urdf/robot.srdf",
     )
     env = robot.env
     ```
@@ -21,10 +33,13 @@ The Environment is the central data structure in tesseract_robotics, containing 
     ```python
     from tesseract_robotics.planning import Robot
 
-    # Available: abb_irb2400, kuka_iiwa, fanuc_lrmate200id
+    # Available: abb_irb2400, lbr_iiwa_14_r820, ...
     robot = Robot.from_tesseract_support("abb_irb2400")
     env = robot.env
     ```
+
+!!! info "`Environment.init()` signature"
+    `Robot.from_files()` wraps `Environment.init(urdf_path, srdf_path, locator)`. See `src/tesseract_environment/tesseract_environment_bindings.cpp` for the other overloads (scene graph, URDF string, etc.).
 
 ## Scene Graph Structure
 
@@ -50,13 +65,11 @@ graph TD
 scene = env.getSceneGraph()
 
 # Get all links
-links = scene.getLinks()
-for link in links:
+for link in scene.getLinks():
     print(f"Link: {link.getName()}")
 
 # Get all joints
-joints = scene.getJoints()
-for joint in joints:
+for joint in scene.getJoints():
     print(f"Joint: {joint.getName()} ({joint.type})")
 
 # Get specific link/joint
@@ -66,12 +79,17 @@ joint = scene.getJoint("joint_6")
 
 ## Modifying the Scene
 
+Scene modifications are issued as **commands** applied through `env.applyCommand(...)`. The command classes live in `tesseract_robotics.tesseract_environment`.
+
 ### Adding Objects
 
 ```python
-from tesseract_robotics.tesseract_geometry import Box, Sphere, Cylinder
-from tesseract_robotics.tesseract_scene_graph import Link, Joint, JointType
 from tesseract_robotics.tesseract_common import Isometry3d
+from tesseract_robotics.tesseract_environment import AddLinkCommand
+from tesseract_robotics.tesseract_geometry import Box
+from tesseract_robotics.tesseract_scene_graph import (
+    Collision, Joint, JointType, Link, Visual,
+)
 import numpy as np
 
 # Create a box obstacle
@@ -79,6 +97,7 @@ box = Box(0.5, 0.5, 0.5)  # 50cm cube
 
 # Create link with visual and collision
 obstacle_link = Link("obstacle")
+
 visual = Visual()
 visual.geometry = box
 visual.origin = Isometry3d.Identity()
@@ -89,13 +108,15 @@ collision.geometry = box
 collision.origin = Isometry3d.Identity()
 obstacle_link.addCollision(collision)
 
-# Create fixed joint to world
+# Create a fixed joint attaching the obstacle to the world
 obstacle_joint = Joint("obstacle_joint")
 obstacle_joint.type = JointType.FIXED
 obstacle_joint.parent_link_name = "base_link"
 obstacle_joint.child_link_name = "obstacle"
-obstacle_joint.parent_to_joint_origin_transform = Isometry3d.Identity()
-obstacle_joint.parent_to_joint_origin_transform.translate([1.0, 0, 0.5])
+
+origin = np.eye(4)
+origin[:3, 3] = [1.0, 0.0, 0.5]
+obstacle_joint.parent_to_joint_origin_transform = Isometry3d(origin)
 
 # Add to scene
 env.applyCommand(AddLinkCommand(obstacle_link, obstacle_joint))
@@ -103,15 +124,19 @@ env.applyCommand(AddLinkCommand(obstacle_link, obstacle_joint))
 
 !!! tip "Use `addVisual` and `addCollision`"
     Always use `link.addVisual(v)` and `link.addCollision(c)` instead of
-    `link.visual.append(v)`. The append method silently fails due to
-    nanobind returning copies of C++ vectors.
+    `link.visual.append(v)`. The append method silently fails because
+    nanobind returns copies of the underlying C++ vectors.
 
 ### Moving Objects
 
+`MoveLinkCommand` takes a replacement `Joint` that re-parents the child link.
+
 ```python
-# Move an existing link
-transform = Isometry3d.Identity()
-transform.translate([2.0, 0, 0.5])
+from tesseract_robotics.tesseract_environment import MoveLinkCommand
+
+origin = np.eye(4)
+origin[:3, 3] = [2.0, 0.0, 0.5]
+obstacle_joint.parent_to_joint_origin_transform = Isometry3d(origin)
 
 env.applyCommand(MoveLinkCommand(obstacle_joint))
 ```
@@ -119,6 +144,8 @@ env.applyCommand(MoveLinkCommand(obstacle_joint))
 ### Removing Objects
 
 ```python
+from tesseract_robotics.tesseract_environment import RemoveLinkCommand
+
 env.applyCommand(RemoveLinkCommand("obstacle"))
 ```
 
@@ -126,69 +153,103 @@ env.applyCommand(RemoveLinkCommand("obstacle"))
 
 ### Getting Current State
 
-```python
-# Get current joint state
-state = env.getState()
-joint_names = state.joint_names
-joint_values = state.position
+`env.getState()` returns a `SceneState` whose key fields are:
 
-print(f"Current state: {dict(zip(joint_names, joint_values))}")
+- `state.joints` — `dict[str, float]` mapping joint name to value
+- `state.link_transforms` — `dict[str, Isometry3d]` for every link
+- `state.joint_transforms` — `dict[str, Isometry3d]` for every joint
+
+```python
+state = env.getState()
+print(dict(state.joints))          # {'joint_1': 0.0, 'joint_2': 0.0, ...}
+
+# Get a subset of joint values as a numpy array
+vals = state.getJointValues(["joint_1", "joint_2"])
 ```
 
 ### Setting State
 
 ```python
-# Set specific joints
+# By joint-name dict
 env.setState({"joint_1": 0.5, "joint_2": -0.3})
 
-# Or set all joints
+# Or by parallel name/value sequences
+joint_names = ["joint_1", "joint_2", "joint_3", "joint_4", "joint_5", "joint_6"]
+joint_values = np.zeros(6)
 env.setState(joint_names, joint_values)
 ```
+
+The `Robot` wrapper exposes the same behaviour via `robot.set_joints({...})` or `robot.set_joints(values, joint_names=[...])`.
 
 ### Link Transforms
 
 ```python
-# Get transform of any link in current state
 tcp_transform = env.getLinkTransform("tool0")
-print(f"TCP position: {tcp_transform.translation()}")
-print(f"TCP rotation:\n{tcp_transform.rotation()}")
+print(f"TCP position: {tcp_transform.translation()}")  # np.ndarray(3,)
+print(f"TCP rotation:\n{tcp_transform.rotation()}")    # np.ndarray(3, 3)
 ```
+
+## Collision Checking
+
+Collision checking runs through the environment's discrete (or continuous) contact manager. This is the canonical pattern used throughout the examples:
+
+```python
+from tesseract_robotics.tesseract_collision import (
+    ContactRequest, ContactResultMap, ContactTestType_ALL,
+)
+
+manager = robot.env.getDiscreteContactManager()
+manager.setActiveCollisionObjects(robot.env.getActiveLinkNames())
+manager.setCollisionObjectsTransform(robot.env.getState().link_transforms)
+
+contacts = ContactResultMap()
+manager.contactTest(contacts, ContactRequest(ContactTestType_ALL))
+print(f"Collision-free: {contacts.size() == 0}")
+```
+
+See the [Collision Detection guide](collision.md) for continuous collision, flattening `ContactResultMap` into a vector, and margin configuration.
 
 ## Allowed Collision Matrix
 
-The ACM defines which link pairs should be ignored during collision checking:
+The ACM defines which link pairs should be ignored during collision checking. The SRDF typically seeds it with adjacent-link exclusions.
 
 ```python
 acm = env.getAllowedCollisionMatrix()
-
-# Check if collision is allowed between two links
-is_allowed = acm.isCollisionAllowed("link_1", "link_2")
-
-# Add allowed collision pair
-acm.addAllowedCollision("link_a", "link_b", "Adjacent links")
-
-# Remove allowed collision
-acm.removeAllowedCollision("link_a", "link_b")
+if acm.isCollisionAllowed("link_1", "link_2"):
+    print("link_1 <-> link_2 is whitelisted")
 ```
 
-!!! info "SRDF Defines Default ACM"
-    The SRDF file typically defines adjacent link pairs and self-collision
-    exclusions. You only need to modify the ACM for dynamic objects.
+To add or remove entries, issue a `ModifyAllowedCollisionsCommand`:
+
+```python
+from tesseract_robotics.tesseract_common import AllowedCollisionMatrix
+from tesseract_robotics.tesseract_environment import (
+    ModifyAllowedCollisionsCommand, ModifyAllowedCollisionsType,
+)
+
+additions = AllowedCollisionMatrix()
+additions.addAllowedCollision("gripper", "workpiece", "Attached")
+env.applyCommand(
+    ModifyAllowedCollisionsCommand(additions, ModifyAllowedCollisionsType.ADD)
+)
+```
 
 ## Environment Commands
 
-All scene modifications use the command pattern:
+All scene modifications use the command pattern. The full list is bound in `tesseract_environment/tesseract_environment_bindings.cpp`:
 
 | Command | Purpose |
 |---------|---------|
-| `AddLinkCommand` | Add new link and joint |
-| `RemoveLinkCommand` | Remove link from scene |
-| `MoveLinkCommand` | Change joint transform |
-| `MoveJointCommand` | Reparent a joint |
-| `AddSceneGraphCommand` | Add entire sub-graph |
+| `AddLinkCommand` | Add new link and optional parent joint |
+| `RemoveLinkCommand` | Remove link (and children) from scene |
+| `MoveLinkCommand` | Re-parent a link via a new joint |
+| `MoveJointCommand` | Re-parent an existing joint |
+| `AddSceneGraphCommand` | Add an entire sub-graph |
 | `ChangeJointOriginCommand` | Modify joint origin |
 | `ChangeJointPositionLimitsCommand` | Update position limits |
 | `ChangeJointVelocityLimitsCommand` | Update velocity limits |
+| `ChangeCollisionMarginsCommand` | Change default/pair collision margins |
+| `ModifyAllowedCollisionsCommand` | Add/remove ACM entries |
 
 ## Best Practices
 
@@ -198,15 +259,14 @@ All scene modifications use the command pattern:
 
 !!! tip "Cloning for Planning"
     Motion planners internally clone the environment. You don't need to
-    clone manually unless doing parallel planning.
+    clone manually unless you're running parallel planners.
 
 ```python
-# Clone for thread-safe access
 env_copy = env.clone()
 ```
 
 ## Next Steps
 
-- [Kinematics Guide](kinematics.md) - Forward and inverse kinematics
-- [Collision Detection](collision.md) - Collision checking details
-- [Motion Planning](planning.md) - Planning with the environment
+- [Kinematics Guide](kinematics.md) — Forward and inverse kinematics
+- [Collision Detection](collision.md) — Collision checking details
+- [Motion Planning](planning.md) — Planning with the environment

--- a/docs/user-guide/kinematics.md
+++ b/docs/user-guide/kinematics.md
@@ -1,6 +1,6 @@
 # Kinematics
 
-tesseract_robotics provides forward and inverse kinematics through kinematic groups defined in the SRDF.
+tesseract_robotics provides forward and inverse kinematics through **kinematic groups** defined in the SRDF. The high-level `Robot` wrapper exposes them as `robot.fk(...)` / `robot.ik(...)`.
 
 ## Kinematic Groups
 
@@ -22,15 +22,15 @@ robot = Robot.from_tesseract_support("abb_irb2400")
 manip = robot.env.getKinematicGroup("manipulator")
 
 # Group info
-print(f"Joint names: {manip.getJointNames()}")
-print(f"Link names: {manip.getLinkNames()}")
-print(f"Base link: {manip.getBaseLinkName()}")
-print(f"Tip link: {manip.getTipLinkNames()}")
+print(f"Joint names:     {list(manip.getJointNames())}")
+print(f"Link names:      {list(manip.getLinkNames())}")
+print(f"Base link:       {manip.getBaseLinkName()}")
+print(f"Tip link(s):     {list(manip.getTipLinkNames())}")
 ```
 
 ## Forward Kinematics
 
-Compute end-effector pose from joint values:
+Compute a link's pose from joint values.
 
 === "High-Level API"
 
@@ -39,87 +39,99 @@ Compute end-effector pose from joint values:
 
     joints = np.array([0.0, -0.5, 0.5, 0.0, 0.5, 0.0])
 
-    # Returns Isometry3d (4x4 transform)
-    tcp_pose = robot.fk(joints, group="manipulator")
+    # group_name is the FIRST positional argument;
+    # tip_link defaults to the last active link in the chain.
+    tcp_pose = robot.fk("manipulator", joints)
 
-    print(f"Position: {tcp_pose.translation()}")
-    print(f"Rotation:\n{tcp_pose.rotation()}")
+    print(f"Position:   {tcp_pose.position}")      # np.ndarray([x, y, z])
+    print(f"Quaternion: {tcp_pose.quaternion}")    # [qx, qy, qz, qw] scalar-last
     ```
+
+    !!! info "Quaternion convention"
+        `Pose.quaternion` returns `[qx, qy, qz, qw]` (scalar-last) — the same
+        convention used by `scipy.spatial.transform.Rotation.as_quat()`. This
+        differs from C++ Eigen, which uses scalar-first `[qw, qx, qy, qz]`.
 
 === "Low-Level API"
 
     ```python
-    manip = robot.env.getKinematicGroup("manipulator")
-
-    # Returns dict of link_name -> Isometry3d
+    # Returns dict[str, Isometry3d] — one transform per link in the chain
     transforms = manip.calcFwdKin(joints)
 
-    tcp_pose = transforms["tool0"]
+    tcp_isometry = transforms["tool0"]
+    print(tcp_isometry.translation())   # method, not property
+    print(tcp_isometry.rotation())
     ```
 
-### Transform Operations
+### Pose vs Isometry3d
+
+`Pose` is the Python-side wrapper around a 4x4 matrix (see `planning/transforms.py`). `Isometry3d` is the low-level C++/Eigen type.
 
 ```python
+from tesseract_robotics.planning import Pose
 from tesseract_robotics.tesseract_common import Isometry3d
 import numpy as np
 
-# Create identity transform
-pose = Isometry3d.Identity()
+# Pose -> Isometry3d
+pose = Pose.from_xyz_rpy(0.5, 0.0, 0.3, 0, 0, np.pi / 4)
+iso = pose.to_isometry()
 
-# Translation
-pose.translate([0.1, 0.2, 0.3])
-position = pose.translation()  # np.array([0.1, 0.2, 0.3])
+# Isometry3d -> Pose
+pose2 = Pose.from_isometry(iso)
 
-# Rotation (3x3 matrix)
-rotation = pose.rotation()
+# Composition (Pose uses Python's @ operator)
+combined = pose @ pose2
 
-# Full 4x4 matrix
-matrix = pose.matrix()
-
-# Compose transforms
-pose2 = Isometry3d.Identity()
-pose2.rotate(Eigen.AngleAxisd(np.pi/4, [0, 0, 1]))
-combined = pose * pose2
+# Low-level composition (Isometry3d uses *)
+iso_combined = iso * iso
 ```
 
 ## Inverse Kinematics
 
-Find joint values that achieve a target pose:
+Find joint values that achieve a target pose.
 
 === "High-Level API"
 
     ```python
-    # Target pose
-    target = robot.fk(np.zeros(6))
-    target.translate([0.1, 0, 0])  # Move 10cm in X
+    from tesseract_robotics.planning import Pose
 
-    # Solve IK (returns list of solutions)
-    solutions = robot.ik(target, group="manipulator")
+    target = Pose.from_xyz_rpy(0.6, 0.0, 0.5, 0.0, np.pi, 0.0)
 
-    if solutions:
-        print(f"Found {len(solutions)} solutions")
-        for i, sol in enumerate(solutions):
-            print(f"  Solution {i}: {sol}")
+    # Returns a single np.ndarray solution, None, or a list if all_solutions=True
+    solution = robot.ik("manipulator", target, seed=joints)
+    if solution is not None:
+        print(f"Solution: {solution}")
     else:
         print("No IK solution found")
+
+    # Enumerate all solutions (e.g. redundant 7-DOF arms)
+    solutions = robot.ik("manipulator", target, seed=joints, all_solutions=True)
+    if solutions:
+        print(f"Found {len(solutions)} solution(s)")
     ```
+
+    The full signature is `robot.ik(group_name, target_pose, seed=None, tip_link=None, all_solutions=False)` — see `planning/core.py`.
 
 === "Low-Level API"
 
     ```python
-    manip = robot.env.getKinematicGroup("manipulator")
+    from tesseract_robotics.tesseract_kinematics import KinGroupIKInput
 
-    # With seed (initial guess)
+    target_iso = target.to_isometry()
+    working_frame = manip.getBaseLinkName()
+    tip_link = list(manip.getActiveLinkNames())[-1]
+
+    ik_input = KinGroupIKInput(target_iso, working_frame, tip_link)
     seed = np.zeros(6)
-    solutions = manip.calcInvKin(target, seed)
+    solutions = manip.calcInvKin(ik_input, seed)  # list[np.ndarray]
     ```
 
-!!! warning "IK May Return Empty"
-    IK returns an empty list if:
+!!! warning "IK may return `None`"
+    `robot.ik(...)` returns `None` when:
 
-    - Target is outside workspace
-    - No IK solver is configured in SRDF
-    - Solver iterations exceeded
+    - the target is outside the workspace,
+    - no IK solver is configured in the SRDF,
+    - the solver hit its iteration limit.
 
 ### IK Solvers
 
@@ -129,7 +141,7 @@ Find joint values that achieve a target pose:
 | **OPW** | Analytical | 6-DOF industrial arms (ABB, KUKA, Fanuc) |
 | **UR** | Analytical | Universal Robots |
 
-Configure in SRDF:
+Configure the solver in the SRDF:
 
 ```xml
 <kinematics_plugin_config>
@@ -144,26 +156,25 @@ Configure in SRDF:
 ```python
 limits = manip.getLimits()
 
-# Position limits (rad for revolute, m for prismatic)
+# Position limits: 2-column matrix [lower, upper] per joint
 pos_limits = limits.joint_limits
-print(f"Joint 1: [{pos_limits.col(0)[0]}, {pos_limits.col(1)[0]}]")
+print(f"Joint 1: [{pos_limits[0, 0]}, {pos_limits[0, 1]}]")
 
-# Velocity limits (rad/s or m/s)
+# Velocity / acceleration limits (same shape)
 vel_limits = limits.velocity_limits
-print(f"Max velocity: {vel_limits}")
-
-# Acceleration limits
 acc_limits = limits.acceleration_limits
 ```
+
+`Robot.get_joint_limits("manipulator")` returns the same information as a `{joint_name: {lower, upper, velocity, acceleration}}` dict.
 
 ### Checking Limits
 
 ```python
-def is_within_limits(joints, manip):
+def is_within_limits(joints: np.ndarray, manip) -> bool:
     limits = manip.getLimits()
     lower = limits.joint_limits[:, 0]
     upper = limits.joint_limits[:, 1]
-    return np.all(joints >= lower) and np.all(joints <= upper)
+    return bool(np.all(joints >= lower) and np.all(joints <= upper))
 ```
 
 ## Jacobian
@@ -171,10 +182,9 @@ def is_within_limits(joints, manip):
 The Jacobian relates joint velocities to end-effector velocities:
 
 ```python
-# 6xN Jacobian matrix
+# 6xN Jacobian matrix at the named link
 jacobian = manip.calcJacobian(joints, "tool0")
 
-# Use for velocity kinematics
 joint_velocities = np.array([0.1, 0.1, 0.1, 0.1, 0.1, 0.1])
 tcp_velocity = jacobian @ joint_velocities  # 6D twist [vx, vy, vz, wx, wy, wz]
 ```
@@ -182,33 +192,31 @@ tcp_velocity = jacobian @ joint_velocities  # 6D twist [vx, vy, vz, wx, wy, wz]
 ### Singularity Detection
 
 ```python
-def manipulability(jacobian):
+def manipulability(jacobian: np.ndarray) -> float:
     """Yoshikawa manipulability index."""
-    return np.sqrt(np.linalg.det(jacobian @ jacobian.T))
+    return float(np.sqrt(np.linalg.det(jacobian @ jacobian.T)))
 
-def is_near_singularity(jacobian, threshold=0.01):
-    """Check if near a singularity."""
+def is_near_singularity(jacobian: np.ndarray, threshold: float = 0.01) -> bool:
     return manipulability(jacobian) < threshold
 ```
 
 ## Tool Frames
 
-Define tool center point (TCP) offsets:
+Define Tool Center Point (TCP) offsets relative to the flange:
 
 ```python
-from tesseract_robotics.tesseract_common import Isometry3d
+from tesseract_robotics.planning import Pose
 
-# Tool offset (e.g., gripper extends 15cm from flange)
-tool_offset = Isometry3d.Identity()
-tool_offset.translate([0, 0, 0.15])
+# Gripper extends 15 cm from the flange
+tool_offset = Pose.from_xyz(0.0, 0.0, 0.15)
 
-# Apply to FK result
-flange_pose = robot.fk(joints)
-tcp_pose = flange_pose * tool_offset
+# FK to flange, then apply the tool offset
+flange_pose = robot.fk("manipulator", joints)
+tcp_pose = flange_pose @ tool_offset
 
-# For IK, transform target to flange frame
-target_flange = target_tcp * tool_offset.inverse()
-solutions = robot.ik(target_flange)
+# For IK, transform the target back into the flange frame
+target_flange = target_tcp @ tool_offset.inverse()
+solution = robot.ik("manipulator", target_flange)
 ```
 
 ## Working with Multiple Groups
@@ -217,32 +225,30 @@ Some robots have multiple kinematic groups:
 
 ```python
 # Dual-arm robot
-left_arm = env.getKinematicGroup("left_arm")
-right_arm = env.getKinematicGroup("right_arm")
+left_arm  = robot.env.getKinematicGroup("left_arm")
+right_arm = robot.env.getKinematicGroup("right_arm")
 
-# External axis + manipulator
-full_chain = env.getKinematicGroup("manipulator_with_positioner")
+# Manipulator + external positioner
+full_chain = robot.env.getKinematicGroup("manipulator_with_positioner")
 ```
 
 ## Performance Tips
 
-!!! tip "Cache Kinematic Groups"
-    Creating a kinematic group involves parsing. Cache the group object:
+!!! tip "Cache kinematic groups"
+    Creating a kinematic group walks the SRDF. Cache the group if you're
+    looping over many configurations:
 
     ```python
-    # Do this once
-    manip = env.getKinematicGroup("manipulator")
-
-    # Reuse for all FK/IK calls
+    manip = robot.env.getKinematicGroup("manipulator")
     for joints in trajectory:
-        pose = manip.calcFwdKin(joints)
+        transforms = manip.calcFwdKin(joints)
     ```
 
-!!! tip "Use Analytical IK When Available"
-    OPW solver is ~100x faster than KDL for supported robots.
-    Configure it in your SRDF for production use.
+!!! tip "Prefer analytical IK when available"
+    OPW is dramatically faster than KDL for supported 6-DOF arms. Configure
+    it in your SRDF for production workloads.
 
 ## Next Steps
 
-- [Collision Detection](collision.md) - Check for collisions
-- [Motion Planning](planning.md) - Plan collision-free paths
+- [Collision Detection](collision.md) — Check for collisions against the world
+- [Motion Planning](planning.md) — Plan collision-free trajectories

--- a/docs/user-guide/low-level-sqp.md
+++ b/docs/user-guide/low-level-sqp.md
@@ -1,464 +1,141 @@
 # Low-Level SQP API
 
-The low-level SQP (Sequential Quadratic Programming) API enables real-time trajectory optimization at 100+ Hz.
+Real-time trajectory optimization via Sequential Quadratic Programming. Use this when you need sub-10ms optimizer steps for online replanning — lower-level than `TaskComposer`, higher-control than `plan_cartesian`.
 
-## Overview
+## When to reach for this
 
-```mermaid
-graph LR
-    A[Problem Setup] --> B[TrustRegionSQPSolver]
-    B --> C[OSQP QP Solver]
-    C --> D[Optimized Trajectory]
+| Situation | Use |
+|---|---|
+| Offline, one-shot plan | `plan_freespace` / `plan_cartesian` |
+| Multi-stage pipeline (sampling → optimize → time-param) | `TaskComposer` |
+| **Online replanning with moving obstacle, ~100 Hz** | **Low-level SQP (this page)** |
 
-    subgraph "Per Timestep"
-        E[JointPosition Variables]
-        F[Collision Constraints]
-        G[Cartesian Constraints]
-        H[Velocity/Accel Costs]
-    end
-
-    E --> B
-    F --> B
-    G --> B
-    H --> B
-```
-
-## Performance
-
-| Configuration | Update Rate |
-|---------------|-------------|
-| Without collision | 128 Hz |
-| Discrete collision | 73 Hz |
-| LVS continuous collision | 5-10 Hz |
+Measured step rates for a reference 8-DOF gantry problem are printed at runtime by
+[`online_planning_sqp_example.py`](https://github.com/tesseract-robotics/tesseract_nanobind/blob/main/src/tesseract_robotics/examples/online_planning_sqp_example.py) — run it locally to see numbers on your machine.
 
 ## Modules
 
-Three modules provide the SQP functionality:
-
 | Module | Purpose |
-|--------|---------|
-| `tesseract_robotics.ifopt` | Base optimization classes (Bounds, VariableSet, ConstraintSet) |
-| `tesseract_robotics.trajopt_ifopt` | Robotics-specific constraints (collision, Cartesian, joint limits) |
-| `tesseract_robotics.trajopt_sqp` | SQP solver (TrustRegionSQPSolver, OSQPEigenSolver) |
+|---|---|
+| `tesseract_robotics.trajopt_ifopt` | Variables (`Var`, `Node`, `NodesVariables`), constraints (joint, Cartesian, collision), factory helpers |
+| `tesseract_robotics.trajopt_sqp` | `IfoptProblem` (NLP), `IfoptQPProblem` (QP wrapper), `TrustRegionSQPSolver`, `OSQPEigenSolver` |
 
-## Basic Example
+The standalone `tesseract_robotics.ifopt` module was **removed in 0.34**.
+All types merged into `tesseract_robotics.trajopt_ifopt`. See the
+[0.33 → 0.34 migration guide](../changes.md) for details.
 
-```python
-import numpy as np
-from tesseract_robotics.planning import Robot
-from tesseract_robotics.ifopt import Bounds
-from tesseract_robotics.trajopt_ifopt import (
-    JointPosition, CartPosConstraint, CartPosInfo, CartPosInfoType,
-    TrajOptCollisionConfig, CollisionCache, SingleTimestepCollisionEvaluator,
-    DiscreteCollisionConstraint
-)
-from tesseract_robotics.trajopt_sqp import (
-    TrustRegionSQPSolver, OSQPEigenSolver, IfoptQPProblem,
-    SQPParameters, CostPenaltyType
-)
+## Variable Hierarchy (0.34+)
 
-# Load robot
-robot = Robot.from_tesseract_support("abb_irb2400")
-env = robot.env
-manip = env.getKinematicGroup("manipulator")
+The `JointPosition` class is gone. Variables now use a three-level hierarchy:
 
-# Problem parameters
-n_steps = 10
-joint_names = list(manip.getJointNames())
-n_joints = len(joint_names)
+- **`Var`** — a single variable (e.g., joint values at one waypoint)
+- **`Node`** — groups multiple `Var`s (e.g., joints + velocities at one waypoint)
+- **`NodesVariables`** — container of `Node`s passed to the problem constructor
 
-# Get joint limits
-limits = manip.getLimits()
-lower = limits.joint_limits[:, 0]
-upper = limits.joint_limits[:, 1]
-
-# Create QP problem
-qp_problem = IfoptQPProblem()
-
-# Add joint position variables for each timestep
-variables = []
-for i in range(n_steps):
-    var = JointPosition(
-        np.zeros(n_joints),  # Initial values
-        joint_names,
-        f"joint_pos_{i}"
-    )
-    var.SetBounds([Bounds(lower[j], upper[j]) for j in range(n_joints)])
-    variables.append(var)
-    qp_problem.addVariableSet(var)
-
-# Add Cartesian goal constraint (last waypoint)
-target_pose = robot.fk(np.array([0.5, -0.3, 0.4, 0, 0.3, 0]))
-cart_info = CartPosInfo(
-    manip, "tool0", "base_link",
-    target_pose, CartPosInfoType.FULL
-)
-cart_constraint = CartPosConstraint(cart_info, variables[-1], "cart_goal")
-qp_problem.addConstraintSet(cart_constraint)
-
-# Configure solver
-solver = TrustRegionSQPSolver(OSQPEigenSolver())
-solver.params.max_iterations = 100
-solver.params.min_approx_improve = 1e-3
-solver.params.initial_trust_box_size = 0.1
-
-# Solve
-solver.init(qp_problem)
-solver.solve(qp_problem)
-
-# Extract trajectory
-trajectory = np.array([var.GetValues() for var in variables])
-```
-
-## Variables
-
-### JointPosition
-
-Represents joint values at a single timestep:
+Build the full hierarchy with `createNodesVariables`:
 
 ```python
-from tesseract_robotics.trajopt_ifopt import JointPosition
-from tesseract_robotics.ifopt import Bounds
+from tesseract_robotics.trajopt_ifopt import Bounds, createNodesVariables
 
-# Create variable
-var = JointPosition(
-    initial_values,  # np.array of joint values
-    joint_names,     # List of joint names
-    "waypoint_0"     # Unique name
-)
-
-# Set bounds
-bounds = [Bounds(lower[i], upper[i]) for i in range(n_joints)]
-var.SetBounds(bounds)
-
-# Access values
-values = var.GetValues()
-var.SetVariables(new_values)
-```
-
-### Bounds
-
-Define variable limits:
-
-```python
-from tesseract_robotics.ifopt import Bounds
-
-# Position bound
-pos_bound = Bounds(-3.14, 3.14)
-
-# Special bounds
-no_bound = Bounds.NoBound()      # (-inf, inf)
-zero = Bounds.BoundZero()        # (0, 0)
-positive = Bounds.BoundGreaterZero()  # (0, inf)
-negative = Bounds.BoundSmallerZero()  # (-inf, 0)
-```
-
-## Constraints
-
-### CartPosConstraint
-
-Constrain end-effector pose:
-
-```python
-from tesseract_robotics.trajopt_ifopt import (
-    CartPosConstraint, CartPosInfo, CartPosInfoType
-)
-
-# Full 6-DOF constraint
-cart_info = CartPosInfo(
-    manip,           # Kinematic group
-    "tool0",         # Target link
-    "base_link",     # Source link
-    target_pose,     # Isometry3d target
-    CartPosInfoType.FULL
-)
-
-constraint = CartPosConstraint(cart_info, joint_var, "cart_goal")
-qp_problem.addConstraintSet(constraint)
-```
-
-CartPosInfoType options:
-
-| Type | Constrains |
-|------|------------|
-| `FULL` | Position + Orientation (6 DOF) |
-| `POSITION_ONLY` | Position only (3 DOF) |
-
-### JointPosConstraint
-
-Limit joint positions:
-
-```python
-from tesseract_robotics.trajopt_ifopt import JointPosConstraint
-
-constraint = JointPosConstraint(
-    joint_var,
-    target_values,
-    [0, 1, 2],  # Indices to constrain
-    "joint_pos"
+bounds = Bounds(-3.14, 3.14)
+nodes_variables = createNodesVariables(
+    "trajectory", joint_names, initial_states, bounds,
 )
 ```
 
-### JointVelConstraint
-
-Limit joint velocities between timesteps:
+Get `Var` references for passing to constraints:
 
 ```python
-from tesseract_robotics.trajopt_ifopt import JointVelConstraint
-
-constraint = JointVelConstraint(
-    var_prev, var_next,  # Adjacent timesteps
-    velocity_limits,      # Max velocities
-    "joint_vel"
-)
+vars_list = [node.getVar("joints") for node in nodes_variables.getNodes()]
 ```
 
-### JointAccelConstraint
-
-Limit joint accelerations:
+## Problem Setup
 
 ```python
-from tesseract_robotics.trajopt_ifopt import JointAccelConstraint
-
-constraint = JointAccelConstraint(
-    var_prev, var_curr, var_next,  # Three consecutive timesteps
-    accel_limits,
-    "joint_accel"
-)
+--8<-- "src/tesseract_robotics/examples/online_planning_sqp_example.py:setup"
 ```
 
-### DiscreteCollisionConstraint
+## Constraints and Costs
 
-Avoid collisions at a single timestep:
+The `build_optimization_problem` function shows the full 0.34 pattern — `NodesVariables`
+factory, `IfoptProblem` (NLP) for joint/Cartesian constraints, then `IfoptQPProblem(nlp)`
+wrapping for collision constraints, followed by `problem.setup()`:
 
 ```python
-from tesseract_robotics.trajopt_ifopt import (
-    TrajOptCollisionConfig, CollisionCache,
-    SingleTimestepCollisionEvaluator, DiscreteCollisionConstraint
-)
-
-# Collision configuration (0.33 API)
-# Constructor: TrajOptCollisionConfig(margin, coeff) or default
-config = TrajOptCollisionConfig(0.025, 20.0)  # 2.5cm margin, coeff=20
-config.collision_margin_buffer = 0.005  # Additional buffer beyond margin
-
-# Create evaluator
-cache = CollisionCache(100)  # Cache size
-evaluator = SingleTimestepCollisionEvaluator(
-    cache, manip, env, config
-)
-
-# Add constraint
-collision_constraint = DiscreteCollisionConstraint(
-    evaluator, joint_var, "collision"
-)
-qp_problem.addConstraintSet(collision_constraint)
+--8<-- "src/tesseract_robotics/examples/online_planning_sqp_example.py:problem"
 ```
 
-### ContinuousCollisionConstraint
+Available constraint types in `tesseract_robotics.trajopt_ifopt`:
 
-Avoid collisions between consecutive timesteps:
+| Constraint | Purpose |
+|---|---|
+| `JointPosConstraint` | Target joint values at specific waypoints |
+| `JointVelConstraint` | Velocity limits across waypoints |
+| `JointAccelConstraint` | Acceleration limits |
+| `JointJerkConstraint` | Jerk (3rd derivative) limits — smoother motion |
+| `CartPosConstraint` | TCP pose at a waypoint |
+| `CartLineConstraint` | TCP on a line segment |
+| `DiscreteCollisionConstraint` | Collision at single timesteps |
+| `DiscreteCollisionNumericalConstraint` | Alt. collision jacobian |
+| `ContinuousCollisionConstraint` | Collision across segments (LVS) |
+| `InverseKinematicsConstraint` | IK-based optimization |
+
+Available collision evaluators:
+
+| Evaluator | Pairs with |
+|---|---|
+| `SingleTimestepCollisionEvaluator` | `DiscreteCollisionConstraint` |
+| `LVSDiscreteCollisionEvaluator` | `ContinuousCollisionConstraint` (LVS discrete) |
+| `LVSContinuousCollisionEvaluator` | `ContinuousCollisionConstraint` (LVS continuous) |
+
+## SQP Solver Loop
+
+The solver loop: initial global `solve`, then per-tick `setVariables` + `stepSQPSolver`
+for warm-started incremental optimization. `setBoxSize` resets the trust region each
+tick (trust-region shrinking can drive the box to zero):
 
 ```python
-from tesseract_robotics.trajopt_ifopt import (
-    LVSDiscreteCollisionEvaluator, ContinuousCollisionConstraint
-)
-
-# LVS evaluator (samples along segment)
-evaluator = LVSDiscreteCollisionEvaluator(
-    cache, manip, env, config,
-    dynamic_environment=False
-)
-
-# Constraint between adjacent variables
-constraint = ContinuousCollisionConstraint(
-    evaluator,
-    var_prev, var_next,
-    fixed0=False, fixed1=False,
-    max_num_cnt=3,
-    name="continuous_collision"
-)
+--8<-- "src/tesseract_robotics/examples/online_planning_sqp_example.py:sqp_loop"
 ```
 
-## Solver Configuration
+## Warm-Starting
 
-### SQPParameters
+Between solver steps, update `NodesVariables` with the previous solution:
 
 ```python
-from tesseract_robotics.trajopt_sqp import SQPParameters, CostPenaltyType
-
-params = SQPParameters()
-
-# Convergence criteria
-params.max_iterations = 100
-params.min_approx_improve = 1e-3
-params.min_approx_improve_frac = 1e-4
-params.min_trust_box_size = 1e-4
-
-# Trust region
-params.initial_trust_box_size = 0.1
-params.trust_shrink_ratio = 0.1
-params.trust_expand_ratio = 1.5
-
-# Penalty method
-params.initial_constraint_penalty = 10.0
-params.constraint_penalty_type = CostPenaltyType.SQUARED
+nodes_variables.setVariables(trajectory.flatten())
+solver.init(problem)
+solver.stepSQPSolver()
 ```
 
-### Solver Methods
+The example above rebuilds the problem each tick because the obstacle pose is baked
+into collision constraints. If your scene is static, you can reuse the same problem
+and only call `setVariables` + `stepSQPSolver`.
 
-```python
-solver = TrustRegionSQPSolver(OSQPEigenSolver())
-solver.params = params
+## Python Subclassing
 
-# Initialize with problem
-solver.init(qp_problem)
+You can subclass `ConstraintSet` from Python to define custom constraints — the
+trampoline landed in 0.34.1.1 (see the
+[CHANGELOG](https://github.com/tesseract-robotics/tesseract_nanobind/blob/main/CHANGELOG.md)).
+`scipy` is required at runtime because nanobind's sparse-matrix conversion
+goes through `scipy.sparse`.
 
-# Solve to convergence
-status = solver.solve(qp_problem)
+## Migrating from 0.33
 
-# Or take single step (for real-time)
-status = solver.stepSQPSolver(qp_problem)
+If you have 0.33 SQP code, see the [full migration guide](../changes.md) —
+critical items:
 
-# Reset trust region after step
-solver.setBoxSize(params.initial_trust_box_size)
-```
+- `from tesseract_robotics import ifopt` → `from tesseract_robotics import trajopt_ifopt`
+- `JointPosition(...)` → `createNodesVariables(...)` + `Var` refs
+- `IfoptQPProblem()` → `IfoptProblem(nodes_variables)` + `IfoptQPProblem(nlp)`
+- `CartPosInfo` struct removed — `CartPosConstraint` takes args directly
+- `CollisionCache` removed — caching is internal
+- `getTotalExactCost()` / `getExactCosts()` take no arguments
+- `getStaticKey()` → `getKey()` (instance method on profiles)
+- Call `problem.setup()` after adding all constraint/cost sets
 
-## Real-Time Planning Pattern
+## See also
 
-For online/incremental planning, rebuild the problem each iteration:
-
-```python
-def plan_step(current_joints, target_pose, obstacle_pose):
-    """Single planning iteration (~10-70ms)."""
-
-    # 1. Update environment with new obstacle position
-    update_obstacle(env, obstacle_pose)
-
-    # 2. Build fresh problem
-    qp_problem = IfoptQPProblem()
-
-    # Add variables (warm-start from previous solution)
-    variables = []
-    for i in range(n_steps):
-        if i == 0:
-            init = current_joints  # Fix start
-        else:
-            init = previous_trajectory[i]  # Warm-start
-        var = JointPosition(init, joint_names, f"joint_pos_{i}")
-        var.SetBounds(joint_bounds)
-        variables.append(var)
-        qp_problem.addVariableSet(var)
-
-    # Fix start position
-    for j in range(n_joints):
-        variables[0].SetBounds([Bounds(current_joints[j], current_joints[j])])
-
-    # Add constraints
-    add_collision_constraints(qp_problem, variables)
-    add_cartesian_goal(qp_problem, variables[-1], target_pose)
-
-    # 3. Solve incrementally
-    solver.init(qp_problem)
-    solver.stepSQPSolver(qp_problem)
-    solver.setBoxSize(0.01)  # Reset trust region
-
-    # 4. Extract trajectory
-    trajectory = np.array([var.GetValues() for var in variables])
-    return trajectory
-```
-
-!!! warning "Rebuild Problem Each Iteration"
-    Due to shared_ptr lifecycle issues, you must rebuild the QP problem
-    each iteration. Reusing the same problem causes segfaults.
-
-## Results and Status
-
-### SQPStatus
-
-```python
-from tesseract_robotics.trajopt_sqp import SQPStatus
-
-status = solver.solve(qp_problem)
-
-if status == SQPStatus.CONVERGED:
-    print("Optimization converged")
-elif status == SQPStatus.ITERATION_LIMIT:
-    print("Hit iteration limit")
-elif status == SQPStatus.CALLBACK_STOPPED:
-    print("Stopped by callback")
-```
-
-### SQPResults
-
-```python
-results = solver.getResults()
-
-print(f"Final cost: {results.overall_cost}")
-print(f"Iterations: {results.iterations}")
-print(f"Best variables: {results.best_var_vals}")
-```
-
-## Callbacks
-
-Monitor optimization progress:
-
-```python
-from tesseract_robotics.trajopt_sqp import SQPCallback
-
-class MyCallback(SQPCallback):
-    def __call__(self, iteration, cost, constraint_violation):
-        print(f"Iter {iteration}: cost={cost:.4f}, viol={constraint_violation:.6f}")
-        return True  # Continue optimization
-
-solver.registerCallback(MyCallback())
-```
-
-## Velocity Smoothing Cost
-
-Add velocity smoothing as a cost:
-
-```python
-from tesseract_robotics.trajopt_ifopt import JointVelConstraint
-from tesseract_robotics.ifopt import Bounds
-
-# Create "constraint" with slack (acts as cost)
-for i in range(n_steps - 1):
-    vel_cost = JointVelConstraint(
-        variables[i], variables[i+1],
-        velocity_limits,
-        f"vel_cost_{i}"
-    )
-    # Set loose bounds to make it a soft cost
-    vel_cost.SetBounds([Bounds(-1e10, 1e10)] * n_joints)
-    qp_problem.addConstraintSet(vel_cost)
-```
-
-## Complete Online Planning Example
-
-See `examples/online_planning_sqp_example.py` for a complete example that:
-
-1. Loads ABB IRB2400 with human obstacle
-2. Moves obstacle along a trajectory
-3. Replans at 73 Hz using discrete collision
-4. Visualizes in TesseractViewer
-
-```python
-# Run the example
-python examples/online_planning_sqp_example.py
-```
-
-## Comparison: High-Level vs Low-Level
-
-| Aspect | Task Composer | Low-Level SQP |
-|--------|---------------|---------------|
-| Setup complexity | Low | High |
-| Planning time | 100ms - 10s | 1-20ms |
-| Real-time capable | No | Yes |
-| Collision handling | Automatic | Manual |
-| Use case | Offline planning | Online control |
-
-## Next Steps
-
-- [Online Planning Example](../examples/online-planning.md) - Full walkthrough
-- [Task Composer](task-composer.md) - High-level alternative
+- [`online_planning_sqp_example.py`](https://github.com/tesseract-robotics/tesseract_nanobind/blob/main/src/tesseract_robotics/examples/online_planning_sqp_example.py) — full working example
+- [Online Planning examples](../examples/online-planning.md)
+- [0.33 → 0.34 Migration Guide](../changes.md)

--- a/docs/user-guide/planning.md
+++ b/docs/user-guide/planning.md
@@ -1,6 +1,11 @@
 # Motion Planning
 
-tesseract_robotics provides multiple motion planners for different use cases.
+tesseract_robotics provides multiple motion planners for different use cases. The
+high-level `tesseract_robotics.planning` API exposes three module-level entry
+points — `plan_freespace`, `plan_ompl`, and `plan_cartesian` — each accepting a
+`MotionProgram` describing the waypoints. Under the hood these dispatch to
+`TaskComposer` pipelines, so you can drop down to `TaskComposer.plan(...)` when
+you need a specific pipeline variant.
 
 ## Planner Comparison
 
@@ -14,50 +19,77 @@ tesseract_robotics provides multiple motion planners for different use cases.
 
 ## Quick Planning
 
+All three entry points take the same shape: a `Robot` plus a `MotionProgram` of
+`JointTarget` / `CartesianTarget` waypoints.
+
 === "OMPL (Freespace)"
 
+    `plan_ompl` defaults to the `FreespacePipeline` — OMPL RRTConnect for path
+    finding, TrajOpt for smoothing, and time parameterization.
+
     ```python
-    from tesseract_robotics.planning import Robot, Planner
     import numpy as np
+    from tesseract_robotics.planning import (
+        Robot, MotionProgram, JointTarget, plan_ompl,
+    )
 
     robot = Robot.from_tesseract_support("abb_irb2400")
-    planner = Planner(robot)
-
-    start = np.zeros(6)
-    goal = np.array([0.5, -0.5, 0.5, 0.0, 0.5, 0.0])
-
-    trajectory = planner.plan(
-        start=start,
-        goal=goal,
-        planner="ompl"
+    program = (
+        MotionProgram("manipulator")
+        .move_to(JointTarget(np.zeros(6)))
+        .move_to(JointTarget(np.array([0.5, -0.5, 0.5, 0.0, 0.5, 0.0])))
     )
+
+    result = plan_ompl(robot, program)
+    if result.successful:
+        for state in result.trajectory:
+            print(state.positions)
     ```
 
-=== "TrajOpt (Cartesian)"
+=== "TrajOpt (Freespace)"
+
+    `plan_freespace` drives the `TrajOptPipeline` — pure optimization-based
+    freespace planning. Ideal when the direct path is roughly correct and just
+    needs smoothing plus collision margin enforcement.
 
     ```python
-    from tesseract_robotics.tesseract_common import Isometry3d
+    from tesseract_robotics.planning import plan_freespace
 
-    target_pose = Isometry3d.Identity()
-    target_pose.translate([0.8, 0.2, 0.5])
+    result = plan_freespace(robot, program)
+    ```
 
-    trajectory = planner.plan(
-        start=start,
-        goal=target_pose,  # Cartesian goal
-        planner="trajopt"
+=== "Cartesian (Descartes)"
+
+    `plan_cartesian` drives the `DescartesPipeline` — Descartes graph search for
+    precise Cartesian paths, with TrajOpt smoothing. Use this when the program
+    contains `CartesianTarget` waypoints and you need tool-pose accuracy.
+
+    ```python
+    from tesseract_robotics.planning import CartesianTarget, Pose, plan_cartesian
+
+    program = (
+        MotionProgram("manipulator", tcp_frame="tool0")
+        .move_to(CartesianTarget(Pose.from_xyz(0.5, -0.2, 0.5)))
+        .linear_to(CartesianTarget(Pose.from_xyz(0.5, 0.2, 0.5)))
     )
+
+    result = plan_cartesian(robot, program)
     ```
 
 === "Hybrid (OMPL + TrajOpt)"
 
+    For hybrid planning (OMPL for global search, TrajOpt for local refinement)
+    use the `FreespacePipeline` directly via `TaskComposer` — it chains OMPL,
+    TrajOpt, and time parameterization in one call.
+
     ```python
-    # OMPL finds path, TrajOpt smooths it
-    trajectory = planner.plan(
-        start=start,
-        goal=goal,
-        planner="freespace_hybrid"
-    )
+    from tesseract_robotics.planning import TaskComposer
+
+    composer = TaskComposer.from_config()
+    result = composer.plan(robot, program, pipeline="FreespacePipeline")
     ```
+
+    `plan_ompl(robot, program)` is a shortcut for exactly this pipeline.
 
 ## OMPL Planner
 
@@ -76,16 +108,25 @@ graph LR
 
 ### OMPL Profiles
 
+Profiles control per-call planner behaviour. The `create_ompl_default_profiles`
+helper packages sensible defaults (parallel RRTConnect with a 10 s budget):
+
 ```python
-from tesseract_robotics.tesseract_motion_planners_ompl import (
-    OMPLDefaultPlanProfile
+from tesseract_robotics.planning.profiles import create_ompl_default_profiles
+
+profiles = create_ompl_default_profiles(
+    planning_time=5.0,   # Max planning time (seconds)
+    num_planners=4,      # Parallel RRTConnect instances
+    max_solutions=10,    # Stop after this many solutions
+    optimize=True,       # Continue improving until timeout
 )
 
-profile = OMPLDefaultPlanProfile()
-profile.planning_time = 5.0  # Max planning time (seconds)
-profile.simplify = True      # Simplify path after planning
-profile.collision_check_config.contact_margin = 0.02  # 2cm margin
+result = plan_ompl(robot, program, profiles=profiles)
 ```
+
+For freespace-pipeline use (OMPL + TrajOpt together), use
+`create_freespace_pipeline_profiles` — same arguments plus the TrajOpt smoothing
+profile in the same dictionary.
 
 ### Available OMPL Planners
 
@@ -97,6 +138,8 @@ profile.collision_check_config.contact_margin = 0.02  # 2cm margin
 | `PRM` | Probabilistic Roadmap |
 | `LazyPRM` | Lazy collision checking PRM |
 | `BKPIECE` | Bi-directional KPIECE |
+
+Use `create_ompl_planner_configurators` to mix planner types inside one profile.
 
 ## TrajOpt Planner
 
@@ -135,7 +178,7 @@ composite_profile.smooth_velocities = True
 composite_profile.smooth_accelerations = True
 ```
 
-### Collision Configuration (0.33 API)
+### Collision Configuration
 
 ```python
 from tesseract_robotics.tesseract_motion_planners_trajopt import TrajOptCollisionConfig
@@ -147,6 +190,9 @@ collision_config.collision_margin_buffer = 0.005  # Additional buffer
 collision_config.collision_check_config.type = CollisionEvaluatorType.DISCRETE
 collision_config.collision_check_config.longest_valid_segment_length = 0.05  # For LVS modes
 ```
+
+`TrajOptCollisionConfig` lives in `trajopt_ifopt` (trajopt_common) and is
+re-exported from `tesseract_motion_planners_trajopt`, so either import works.
 
 ## Costs vs Constraints (Soft vs Hard)
 
@@ -268,34 +314,36 @@ Best for:
 - Machining toolpaths
 
 ```python
-from tesseract_robotics.tesseract_motion_planners_descartes import (
-    DescartesDefaultPlanProfile
+from tesseract_robotics.planning.profiles import create_descartes_default_profiles
+
+profiles = create_descartes_default_profiles(
+    enable_collision=True,        # Check vertex (waypoint) collisions
+    enable_edge_collision=False,  # Check transition collisions (slower)
+    num_threads=4,                # Parallel IK solving
 )
 
-profile = DescartesDefaultPlanProfile()
-profile.num_threads = 4  # Parallel IK solving
+result = plan_cartesian(robot, program, profiles=profiles)
 ```
 
 ## Motion Types
 
+Motion type is set via the `MotionProgram` builder methods:
+
 ### Freespace Motion
 
-Any collision-free path between configurations:
+Any collision-free path between configurations. Use `move_to(...)`:
 
 ```python
-from tesseract_robotics.tesseract_command_language import (
-    MoveInstruction, MoveInstructionType
-)
-
-move = MoveInstruction(waypoint, MoveInstructionType.FREESPACE, "DEFAULT")
+program.move_to(JointTarget(joint_values))
+program.move_to(CartesianTarget(pose))  # freespace to pose
 ```
 
 ### Linear Motion
 
-Straight-line Cartesian path:
+Straight-line Cartesian path. Use `linear_to(...)`:
 
 ```python
-move = MoveInstruction(waypoint, MoveInstructionType.LINEAR, "DEFAULT")
+program.linear_to(CartesianTarget(pose))
 ```
 
 !!! warning "Linear Motion Requirements"
@@ -307,125 +355,159 @@ move = MoveInstruction(waypoint, MoveInstructionType.LINEAR, "DEFAULT")
 
 ### Circular Motion
 
-Arc motion (specialized planners):
+Arc motion (specialized planners). Use `circular_to(...)`:
 
 ```python
-move = MoveInstruction(waypoint, MoveInstructionType.CIRCULAR, "DEFAULT")
+program.circular_to(CartesianTarget(pose))
 ```
 
 ## Program Structure
 
-Complex motions are defined as programs:
+Use the `MotionProgram` builder — it handles all the poly-type wrapping
+automatically. For reference, the equivalent low-level call would be:
 
 ```python
 from tesseract_robotics.tesseract_command_language import (
-    CompositeInstruction, MoveInstruction,
-    StateWaypointPoly, CartesianWaypointPoly
+    CartesianWaypoint, CartesianWaypointPoly_wrap_CartesianWaypoint,
+    CompositeInstruction, MoveInstruction, MoveInstructionType_LINEAR,
+    MoveInstructionPoly_wrap_MoveInstruction,
 )
 
-# Create program
-program = CompositeInstruction("DEFAULT")
-
-# Add start state
-start_wp = StateWaypointPoly.wrap_StateWaypoint(
-    StateWaypoint(joint_names, start_joints)
-)
-program.appendMoveInstruction(
-    MoveInstruction(start_wp, MoveInstructionType.START, "DEFAULT")
-)
-
-# Add goal waypoints
+composite = CompositeInstruction("DEFAULT")
 for pose in waypoints:
-    cart_wp = CartesianWaypointPoly.wrap_CartesianWaypoint(
-        CartesianWaypoint(pose)
+    wp = CartesianWaypointPoly_wrap_CartesianWaypoint(CartesianWaypoint(pose))
+    instr = MoveInstructionPoly_wrap_MoveInstruction(
+        MoveInstruction(wp, MoveInstructionType_LINEAR, "DEFAULT")
     )
-    program.appendMoveInstruction(
-        MoveInstruction(cart_wp, MoveInstructionType.LINEAR, "DEFAULT")
-    )
+    composite.appendMoveInstruction(instr)
 ```
+
+The `MotionProgram` fluent API builds exactly the same structure with far less
+ceremony, and the planning entry points accept either form.
 
 ## Planning with Constraints
 
 ### Orientation Constraints
 
-Keep end-effector upright (e.g., carrying a glass):
+Keep end-effector upright (e.g., carrying a glass). The `UPRIGHT` profile is
+pre-baked by `create_trajopt_upright_profiles`:
 
 ```python
-# In TrajOpt profile
-profile.cartesian_coeff = [1, 1, 1, 10, 10, 1]  # High rotation weights
+from tesseract_robotics.planning.profiles import create_trajopt_upright_profiles
+
+profiles = create_trajopt_upright_profiles()
+result = plan_freespace(robot, program, profiles=profiles)
+```
+
+Equivalent manual setup:
+
+```python
+# In TrajOpt plan profile — position free (0), orientation constrained (5)
+plan_profile.cartesian_constraint_config.coeff = [0, 0, 0, 5, 5, 5]
 ```
 
 ### Joint Constraints
 
-Limit specific joints:
+Weight individual joints to lock or favour them:
 
 ```python
-# Lock joint 1
-profile.joint_coeff = [100, 1, 1, 1, 1, 1]  # High weight on joint 1
+# High weight on joint 1 - strongly discouraged from moving
+plan_profile.joint_constraint_config.coeff = [100, 1, 1, 1, 1, 1]
 ```
 
 ## Handling Planning Failures
 
 ```python
-trajectory = planner.plan(start, goal, planner="ompl")
+result = plan_freespace(robot, program)
 
-if trajectory is None:
-    print("Planning failed!")
+if not result.successful:
+    print(f"Planning failed: {result.message}")
 
     # Debug strategies:
+
     # 1. Check if start/goal are collision-free
-    print(f"Start collision-free: {robot.check_collision(start)}")
-    print(f"Goal collision-free: {robot.check_collision(goal)}")
-
-    # 2. Increase planning time
-    trajectory = planner.plan(
-        start, goal,
-        planner="ompl",
-        planning_time=10.0
+    from tesseract_robotics.tesseract_collision import (
+        ContactRequest, ContactResultMap, ContactTestType_ALL,
     )
+    manager = robot.env.getDiscreteContactManager()
+    manager.setActiveCollisionObjects(robot.env.getActiveLinkNames())
+    manager.setCollisionObjectsTransform(robot.env.getState().link_transforms)
+    contacts = ContactResultMap()
+    manager.contactTest(contacts, ContactRequest(ContactTestType_ALL))
+    print(f"Collision-free: {contacts.size() == 0}")
 
-    # 3. Try different planner
-    trajectory = planner.plan(start, goal, planner="trajopt")
+    # 2. Try a different backend
+    result = plan_ompl(robot, program)       # sampling-based (OMPL + TrajOpt)
+    result = plan_cartesian(robot, program)  # graph search (Descartes)
+
+    # 3. Increase planning time on OMPL
+    from tesseract_robotics.planning.profiles import create_ompl_default_profiles
+    profiles = create_ompl_default_profiles(planning_time=30.0)
+    result = plan_ompl(robot, program, profiles=profiles)
 ```
 
 ## Trajectory Output
 
 ```python
-if trajectory:
-    print(f"Waypoints: {len(trajectory)}")
+if result.successful:
+    print(f"Waypoints: {len(result.trajectory)}")
 
-    for i, waypoint in enumerate(trajectory):
-        print(f"  [{i}] positions: {waypoint.positions}")
-        print(f"       velocities: {waypoint.velocities}")
-        print(f"       time: {waypoint.time}")
+    for i, state in enumerate(result.trajectory):
+        print(f"  [{i}] positions:     {state.positions}")
+        print(f"       velocities:    {state.velocities}")
+        print(f"       accelerations: {state.accelerations}")
+        print(f"       time:          {state.time}")
 ```
+
+Each `TrajectoryPoint` carries `joint_names`, `positions`, and optionally
+`velocities`, `accelerations`, and `time` (time from start, seconds). Velocities
+and timing are populated by pipelines that include time parameterization
+(`FreespacePipeline`, `CartesianPipeline`, etc.); pure OMPL output has positions
+only. `result.to_numpy()` returns an `(N, num_joints)` array of positions.
 
 ## Performance Tips
 
-!!! tip "Warm-Start TrajOpt"
-    Provide an initial trajectory for faster convergence:
+!!! tip "Warm-Start via FreespacePipeline"
+    The `FreespacePipeline` (what `plan_ompl` runs by default) already does
+    warm-start internally: OMPL finds a feasible path, TrajOpt then refines it
+    in the same call. If you only need a sampling solution, pass
+    `pipeline="OMPLPipeline"` to drop the TrajOpt step.
 
     ```python
-    # Use OMPL solution as TrajOpt initial guess
-    initial = planner.plan(start, goal, planner="ompl")
-    refined = planner.refine(initial, planner="trajopt")
+    from tesseract_robotics.planning import plan_ompl
+
+    # Default: OMPL + TrajOpt refinement
+    result = plan_ompl(robot, program)
+
+    # Raw OMPL output (no refinement)
+    result = plan_ompl(robot, program, pipeline="OMPLPipeline")
     ```
 
-!!! tip "Reduce Search Space"
+!!! tip "Pre-Load Plugins"
+    First `plan_*()` call takes ~10–15 s due to plugin `dlopen`. In interactive
+    or long-running sessions, warm up once at startup:
+
     ```python
-    # Tighter joint limits for faster planning
-    profile.joint_limits_scale = 0.8  # 80% of full limits
+    from tesseract_robotics.planning import TaskComposer
+
+    composer = TaskComposer.from_config(warmup=True)  # ~10–15s once
+    # Subsequent composer.plan() calls are fast
     ```
 
 !!! tip "Profile Caching"
-    Profiles are expensive to create. Cache and reuse:
+    Profile factory helpers do real work — cache and reuse the returned
+    `ProfileDictionary`:
 
     ```python
+    from tesseract_robotics.planning.profiles import (
+        create_freespace_pipeline_profiles,
+    )
+
     # Create once
-    self.ompl_profile = OMPLDefaultPlanProfile()
+    self.freespace_profiles = create_freespace_pipeline_profiles()
 
     # Reuse for all plans
-    trajectory = planner.plan(..., profile=self.ompl_profile)
+    result = plan_ompl(robot, program, profiles=self.freespace_profiles)
     ```
 
 ## Next Steps

--- a/docs/user-guide/task-composer.md
+++ b/docs/user-guide/task-composer.md
@@ -1,6 +1,6 @@
 # Task Composer
 
-The Task Composer orchestrates complex planning tasks by chaining planners together.
+The Task Composer orchestrates complex planning pipelines by chaining planners (OMPL, TrajOpt, Descartes), collision checks, and time parameterization into a dataflow graph. The high-level `TaskComposer` wrapper lives in `tesseract_robotics.planning`.
 
 ## Overview
 
@@ -22,121 +22,165 @@ graph TD
 === "High-Level API"
 
     ```python
-    from tesseract_robotics.planning import Robot, Composer
     import numpy as np
+    from tesseract_robotics.planning import (
+        CartesianTarget, JointTarget, MotionProgram, Pose, Robot, TaskComposer,
+    )
 
     robot = Robot.from_tesseract_support("abb_irb2400")
-    composer = Composer(robot)
 
-    # Define waypoints
-    start = np.zeros(6)
-    via = np.array([0.5, 0, 0, 0, 0, 0])
-    goal = np.array([0.5, -0.5, 0.5, 0, 0.5, 0])
+    program = (
+        MotionProgram("manipulator")
+        .move_to(JointTarget(np.zeros(6)))
+        .move_to(CartesianTarget(Pose.from_xyz_rpy(0.6, 0.0, 0.5, 0, 0, 0)))
+    )
 
-    # Add segments
-    composer.add_freespace(goal_joints=via)
-    composer.add_freespace(goal_joints=goal)
-    composer.add_freespace(goal_joints=start)  # Return home
+    composer = TaskComposer.from_config()
+    result = composer.plan(robot, program, pipeline="TrajOptPipeline")
 
-    # Plan all segments
-    result = composer.plan()
-
-    if result.success:
-        trajectories = result.get_trajectories()
-        print(f"Planned {len(trajectories)} segments")
+    if result.successful:
+        print(f"Planned {len(result.trajectory)} waypoints")
+        for state in result.trajectory:
+            print(state.positions)
+    else:
+        print(f"Planning failed: {result.message}")
     ```
 
 === "Low-Level API"
 
     ```python
+    from tesseract_robotics.tesseract_common import FilesystemPath, GeneralResourceLocator
     from tesseract_robotics.tesseract_task_composer import (
-        TaskComposerPluginFactory,
+        AnyPoly_wrap_CompositeInstruction,
+        AnyPoly_wrap_EnvironmentConst,
+        AnyPoly_wrap_ProfileDictionary,
         TaskComposerDataStorage,
-        TaskComposerContext,
-        TaskComposerFuture
+        TaskComposerPluginFactory,
     )
 
-    # Load plugin factory
-    factory = TaskComposerPluginFactory()
+    locator = GeneralResourceLocator()
+    factory = TaskComposerPluginFactory(FilesystemPath(str(config_path)), locator)
 
-    # Create executor
+    # Executor + pipeline node
     executor = factory.createTaskComposerExecutor("TaskflowExecutor")
+    pipeline = factory.createTaskComposerNode("TrajOptPipeline")
 
-    # Create pipeline
-    pipeline = factory.createTaskComposerGraph("FreespaceMotionPipeline")
-
-    # Set up data storage
+    # AnyPoly-wrap the inputs the pipeline expects
     storage = TaskComposerDataStorage()
-    storage.setData("planning_input", program)
-    storage.setData("environment", env)
-    storage.setData("profiles", profiles)
+    storage.setData("planning_input", AnyPoly_wrap_CompositeInstruction(composite))
+    storage.setData("environment",    AnyPoly_wrap_EnvironmentConst(env))
+    storage.setData("profiles",       AnyPoly_wrap_ProfileDictionary(profiles))
 
     # Execute
     future = executor.run(pipeline, storage)
     future.wait()
 
-    # Get result
-    context = future.context
-    trajectory = context.data_storage.getData("output_program")
+    output_key = pipeline.getOutputKeys().get("program")
+    output = future.context.data_storage.getData(output_key)
     ```
 
-## Pipeline Types
+!!! tip "Prefer the wrapper"
+    `TaskComposer` hides all the AnyPoly wrapping, input/output key discovery,
+    profile selection and trajectory extraction. Drop to the low-level API
+    only when you need to assemble a custom task graph at runtime.
 
-### FreespaceMotionPipeline
+## Plugin Warmup
 
-For joint-space motion without Cartesian constraints:
+!!! warning "First `plan()` call is slow (~10-15 s)"
+    The Task Composer uses dynamic plugin loading (`boost_plugin_loader` /
+    `dlopen`). The first call to `createTaskComposerNode(...)` loads the
+    shared library for TrajOpt, OMPL, Descartes, etc. Subsequent calls in
+    the same process are instant (plugins cached in memory). This is
+    inherent to the plugin architecture — the same behaviour is observed in
+    the C++ TaskComposer.
 
-```
-MinLengthTask → OMPLTask → TrajOptTask → TimeParam → ContactCheck
-```
-
-```python
-composer.add_freespace(goal_joints=target_joints)
-```
-
-### CartesianMotionPipeline
-
-For Cartesian-constrained motion:
-
-```
-DescartesTask → TrajOptTask → TimeParam → ContactCheck
-```
+`TaskComposer.warmup(...)` amortizes that cost up front. See
+`planning/composer.py` for the full docstring.
 
 ```python
-from tesseract_robotics.tesseract_common import Isometry3d
+from tesseract_robotics.planning import TaskComposer
 
-target_pose = Isometry3d.Identity()
-target_pose.translate([0.8, 0.2, 0.5])
+# Option 1: explicit warmup — clearest timing profile
+composer = TaskComposer.from_config()
+composer.warmup(["FreespacePipeline"])          # ~10-15 s
+result = composer.plan(robot, program, pipeline="FreespacePipeline")  # fast
 
-composer.add_cartesian(goal_pose=target_pose)
-```
+# Option 2: warmup=True — loads a curated set of common pipelines
+composer = TaskComposer.from_config(warmup=True)
 
-### RasterMotionPipeline
-
-For industrial raster patterns (welding, painting):
-
-```
-Descartes(approach) → Descartes(raster) → Descartes(departure) → TrajOpt → TimeParam
-```
-
-```python
-composer.add_raster(
-    approach_pose=approach,
-    raster_poses=raster_waypoints,
-    departure_pose=depart
+# Option 3: warmup=[...] — specific pipelines only
+composer = TaskComposer.from_config(
+    warmup=["TrajOptPipeline", "OMPLPipeline"],
 )
+```
+
+**When warmup helps:**
+
+- Interactive use (REPL, Jupyter) — pay once, plan many times.
+- GUI / service applications — initialize at startup, fast responses after.
+- Benchmarking — separate plugin-load time from algorithm time.
+
+**When warmup doesn't help:**
+
+- Single-run scripts — total wall-clock time is roughly the same either way.
+
+## Available Pipelines
+
+`TaskComposer.get_available_pipelines()` introspects the factory and returns every pipeline that actually loaded from the config. As of the current `task_composer_plugins.yaml` this is **36 pipelines**:
+
+```python
+composer = TaskComposer.from_config()
+pipelines = composer.get_available_pipelines()
+print(pipelines)
+```
+
+A representative sample:
+
+| Pipeline | What it runs |
+|----------|--------------|
+| `FreespacePipeline` | OMPL → TrajOpt → time parameterization |
+| `CartesianPipeline` | Cartesian path with TrajOpt |
+| `TrajOptPipeline` | TrajOpt optimization only |
+| `OMPLPipeline` | OMPL sampling only |
+| `RasterFtPipeline` | Industrial raster with freespace transitions |
+| `DescartesFPipeline` | Descartes forward graph search |
+
+See `TaskComposer.get_available_pipelines()` at runtime for the full 36.
+
+!!! info "Pipeline count is not a contract"
+    The exact number is driven by `task_composer_plugins.yaml` in the
+    packaged `tesseract_task_composer` data. It may grow or shrink in
+    future versions. Treat `get_available_pipelines()` as the source of
+    truth, not the literal "36".
+
+### Convenience methods
+
+`TaskComposer` also exposes per-backend shortcuts:
+
+```python
+composer.plan_freespace(robot, program)   # TrajOptPipeline
+composer.plan_ompl(robot, program)        # OMPLPipeline
+composer.plan_cartesian(robot, program)   # DescartesPipeline
+```
+
+Or use the module-level functions from `tesseract_robotics.planning`:
+
+```python
+from tesseract_robotics.planning import plan_freespace, plan_ompl, plan_cartesian
+
+result = plan_freespace(robot, program)
 ```
 
 ## Task Types
 
 | Task | Purpose |
 |------|---------|
-| `MinLengthTask` | Ensure minimum waypoints |
+| `MinLengthTask` | Ensure a minimum number of waypoints |
 | `OMPLMotionPlannerTask` | Sampling-based planning |
 | `TrajOptMotionPlannerTask` | Trajectory optimization |
 | `DescartesMotionPlannerTask` | Cartesian graph search |
 | `SimpleMotionPlannerTask` | Joint interpolation |
-| `TimeOptimalParameterizationTask` | Add timing |
+| `TimeOptimalParameterizationTask` | Add time parametrization (TOTG) |
 | `IterativeSplineParameterizationTask` | Smooth timing |
 | `ContactCheckTask` | Collision validation |
 | `FixStateBoundsTask` | Clamp to joint limits |
@@ -144,76 +188,70 @@ composer.add_raster(
 
 ## Profiles
 
-Profiles configure each task's behavior:
+Profiles configure each task's behaviour. `TaskComposer.plan(...)` auto-selects a pipeline-appropriate default set from `planning/profiles.py`. You can also build profiles yourself and pass them via the `profiles` keyword:
 
 ```python
-from tesseract_robotics.tesseract_motion_planners_ompl import (
-    OMPLDefaultPlanProfile
-)
+from tesseract_robotics.planning import create_trajopt_default_profiles
+
+profiles = create_trajopt_default_profiles()
+result = composer.plan(robot, program, pipeline="TrajOptPipeline", profiles=profiles)
+```
+
+For a manual `ProfileDictionary`:
+
+```python
+from tesseract_robotics.tesseract_command_language import ProfileDictionary
+from tesseract_robotics.tesseract_motion_planners_ompl import OMPLDefaultPlanProfile
 from tesseract_robotics.tesseract_motion_planners_trajopt import (
     TrajOptDefaultPlanProfile,
-    TrajOptDefaultCompositeProfile
 )
 
-# OMPL profile
-ompl_profile = OMPLDefaultPlanProfile()
-ompl_profile.planning_time = 5.0
-
-# TrajOpt profiles
-trajopt_plan = TrajOptDefaultPlanProfile()
-trajopt_composite = TrajOptDefaultCompositeProfile()
-trajopt_composite.smooth_velocities = True
-
-# Add to profile dictionary
 profiles = ProfileDictionary()
-profiles.addProfile("ompl", "DEFAULT", ompl_profile)
-profiles.addProfile("trajopt", "DEFAULT", trajopt_plan)
-profiles.addProfile("trajopt", "DEFAULT", trajopt_composite)
+profiles.addProfile("ompl",    "DEFAULT", OMPLDefaultPlanProfile())
+profiles.addProfile("trajopt", "DEFAULT", TrajOptDefaultPlanProfile())
 ```
 
 ## Error Handling
 
+`TaskComposer.plan(...)` always returns a `PlanningResult`. On failure the result is populated from the task composer's aborting node info:
+
 ```python
-result = composer.plan()
-
-if not result.success:
+result = composer.plan(robot, program)
+if not result.successful:
     print(f"Planning failed: {result.message}")
-
-    # Check which task failed
-    for task_name, task_result in result.task_results.items():
-        if not task_result.success:
-            print(f"  Failed task: {task_name}")
-            print(f"  Reason: {task_result.message}")
 ```
 
 ### Common Failures
 
 | Error | Cause | Solution |
 |-------|-------|----------|
-| "OMPL failed to find solution" | Start/goal in collision or unreachable | Check collision, increase time |
-| "TrajOpt failed to converge" | Bad initial trajectory | Use simpler planner first |
-| "Contact check failed" | Trajectory has collisions | Increase collision margin |
-| "IK failed" | Cartesian target unreachable | Check workspace limits |
+| `OMPL failed to find solution` | Start/goal in collision or unreachable | Check collisions, increase time |
+| `TrajOpt failed to converge` | Bad initial trajectory | Feed it an OMPL seed first |
+| `Contact check failed` | Trajectory has collisions | Increase collision margin |
+| `IK failed` | Cartesian target unreachable | Verify workspace + TCP offset |
 
 ## Parallel Execution
 
-The Task Composer uses Taskflow for parallel execution:
+The Task Composer uses Taskflow for parallel execution. Override the thread count via `TaskComposer.from_config(num_threads=...)` or pass a pre-built executor:
 
 ```python
-# Configure thread pool
-executor = factory.createTaskComposerExecutor(
-    "TaskflowExecutor",
-    num_threads=8
-)
+from tesseract_robotics.tesseract_task_composer import TaskflowTaskComposerExecutor
+
+# Override YAML-configured thread count
+composer = TaskComposer.from_config(num_threads=8)
+
+# Or provide a custom executor
+executor = TaskflowTaskComposerExecutor("MyExecutor", 8)
+composer = TaskComposer.from_config(executor=executor)
 ```
 
 !!! info "Automatic Parallelization"
-    Independent tasks (like IK for different waypoints) run in parallel
+    Independent tasks (such as IK for different waypoints) run in parallel
     automatically. The task graph determines dependencies.
 
 ## Custom Pipelines
 
-Define custom task graphs in YAML:
+Define custom task graphs in YAML and point `TaskComposer.from_config(path)` at them:
 
 ```yaml
 # custom_pipeline.yaml
@@ -242,107 +280,24 @@ task_composer_plugins:
 
 ## Integration Example
 
-Complete pick-and-place with Task Composer:
+Use a warmed-up composer behind a small service class:
 
 ```python
-from tesseract_robotics.planning import Robot, Composer
-import numpy as np
+from tesseract_robotics.planning import Robot, TaskComposer
 
-robot = Robot.from_tesseract_support("abb_irb2400")
-composer = Composer(robot)
+class PlanningServer:
+    def __init__(self, robot: Robot):
+        self.robot = robot
+        self.composer = TaskComposer.from_config()
+        self.composer.warmup(["FreespacePipeline"])    # one-time cost
 
-# Define poses
-home = np.zeros(6)
-pick_approach = np.array([0.3, -0.4, 0.3, 0, 0.5, 0])
-pick = np.array([0.3, -0.4, 0.5, 0, 0.5, 0])
-place_approach = np.array([-0.3, -0.4, 0.3, 0, 0.5, 0])
-place = np.array([-0.3, -0.4, 0.5, 0, 0.5, 0])
-
-# Build program
-composer.add_freespace(goal_joints=pick_approach)   # Approach pick
-composer.add_linear(goal_joints=pick)              # Linear to pick
-# ... attach object ...
-composer.add_linear(goal_joints=pick_approach)     # Retreat
-composer.add_freespace(goal_joints=place_approach) # Transit to place
-composer.add_linear(goal_joints=place)             # Linear to place
-# ... detach object ...
-composer.add_linear(goal_joints=place_approach)    # Retreat
-composer.add_freespace(goal_joints=home)           # Return home
-
-# Execute planning
-result = composer.plan()
-
-if result.success:
-    # Visualize
-    from tesseract_robotics.viewer import TesseractViewer
-    viewer = TesseractViewer()
-    viewer.update_environment(robot.env, [0, 0, 0])
-    viewer.update_trajectory(result.raw_results)
-    viewer.start_serve_background()
+    def plan_motion(self, program):
+        return self.composer.plan(
+            self.robot, program, pipeline="FreespacePipeline"
+        )
 ```
-
-## Performance Tips
-
-### Plugin Loading Overhead
-
-!!! warning "First `plan()` call is slow (~10-15s)"
-    The Task Composer uses dynamic plugin loading (`dlopen`). The first call to
-    `plan()` loads shared libraries for TrajOpt, OMPL, collision checking, etc.
-    Subsequent calls in the same process are fast (plugins cached in memory).
-
-    This is inherent to the plugin architecture (same behavior in C++).
-
-**Use `warmup()` for interactive applications:**
-
-```python
-from tesseract_robotics.planning import TaskComposer
-
-# Option 1: Explicit warmup (recommended for timing visibility)
-composer = TaskComposer.from_config()
-composer.warmup(["TrajOptPipeline"])  # ~10-15s upfront
-result = composer.plan(robot, program)  # Now fast (~1-2s)
-
-# Option 2: warmup=True parameter
-composer = TaskComposer.from_config(warmup=True)  # Loads common pipelines
-
-# Option 3: Specific pipelines only
-composer = TaskComposer.from_config(warmup=["TrajOptPipeline", "OMPLPipeline"])
-```
-
-**When warmup helps:**
-
-- Interactive use (REPL, Jupyter) - pay once, plan many times
-- GUI/service applications - initialize at startup, fast responses after
-- Benchmarking - separate loading time from algorithm time
-
-**When warmup doesn't help:**
-
-- Single-run scripts (same total time either way)
-
-### Reuse the Composer
-
-!!! tip "Create once, reuse many times"
-    ```python
-    class PlanningServer:
-        def __init__(self, robot):
-            self.composer = TaskComposer.from_config()
-            self.composer.warmup(["TrajOptPipeline"])  # One-time cost
-            self.robot = robot
-
-        def plan_motion(self, program):
-            return self.composer.plan(self.robot, program)  # Fast
-    ```
-
-### Warm Starting
-
-!!! tip "Use previous solution as seed"
-    For similar plans, use previous solution as seed:
-
-    ```python
-    result = composer.plan(seed_trajectory=previous_result.trajectory)
-    ```
 
 ## Next Steps
 
-- [Low-Level SQP](low-level-sqp.md) - Real-time trajectory optimization
-- [Online Planning Example](../examples/online-planning.md) - Dynamic replanning
+- [Low-Level SQP](low-level-sqp.md) — Real-time trajectory optimization
+- [Online Planning Example](../examples/online-planning.md) — Dynamic replanning

--- a/docs/user-guide/viewer.md
+++ b/docs/user-guide/viewer.md
@@ -1,0 +1,85 @@
+# Viewer
+
+`tesseract_robotics.viewer` provides a web-based 3D viewer for scenes and trajectories, backed by Three.js. It started life as a standalone package and is now a first-class submodule of `tesseract_robotics`.
+
+## Installation
+
+The viewer ships with the main package. No separate install step.
+
+```python
+from tesseract_robotics.viewer import TesseractViewer
+```
+
+## Basic Usage
+
+Build an `Environment`, then hand it to the viewer and start the background HTTP server at `http://localhost:8000`:
+
+```python
+--8<-- "src/tesseract_robotics/examples/shapes_viewer.py:setup"
+```
+
+```python
+--8<-- "src/tesseract_robotics/examples/shapes_viewer.py:serve"
+```
+
+## Visualizing a Robot
+
+Load a URDF/SRDF pair via `GeneralResourceLocator`, then push the environment into the viewer:
+
+```python
+--8<-- "src/tesseract_robotics/examples/abb_irb2400_viewer.py:load_robot"
+```
+
+## Animating a Planned Trajectory
+
+After running a motion planner, feed the resulting `CompositeInstruction` to `update_trajectory`. The viewer animates the robot using the timestamps baked into the trajectory:
+
+```python
+--8<-- "src/tesseract_robotics/examples/abb_irb2400_viewer.py:plan_and_animate"
+```
+
+Then push the result into the viewer (from the same example):
+
+```python
+viewer.update_trajectory(final_results_instruction)
+viewer.plot_trajectory(final_results_instruction, manip_info, axes_length=0.05)
+```
+
+## Industrial Workcells
+
+The Tesseract Robotics Workcell Collection (TWC) ships multi-robot positioner cells. The viewer supports both rail and positioner workcell topologies:
+
+```python
+--8<-- "src/tesseract_robotics/examples/twc_workcell_positioner_viewer.py:load_workcell"
+```
+
+!!! note "Submodule Required"
+    TWC workcell assets ship as a git submodule. Initialize with:
+    ```bash
+    git submodule update --init
+    ```
+
+## API Quick Reference
+
+| Method | Purpose |
+|---|---|
+| `TesseractViewer(server_address=("127.0.0.1", 8000))` | Create viewer instance; spawns background event loop thread |
+| `update_environment(tesseract_env, origin_offset=[0, 0, 0])` | Load or reload a scene |
+| `update_joint_positions(joint_names, joint_positions)` | Set stationary joint state (stops any animation) |
+| `update_trajectory(tesseract_trajectory)` | Animate a `CompositeInstruction` trajectory |
+| `update_trajectory_list(joint_names, trajectory)` | Animate a raw list-of-waypoints trajectory |
+| `plot_trajectory(tesseract_trajectory, manipulator_info)` | Draw trajectory path + waypoint axes in the scene |
+| `start_serve_background()` | Start HTTP server on `server_address` |
+| `close()` | Stop the server and join the background thread |
+| `add_axes_marker / add_arrow_marker / add_box_marker / add_sphere_marker / add_cylinder_marker / add_capsule_marker / add_lines_marker` | Add geometric markers to the scene |
+| `clear_all_markers / clear_markers_by_tags / clear_markers_by_name` | Remove markers |
+| `save(directory)` / `save_scene_gltf(fname)` / `save_scene_glb(fname)` | Export the scene for offline viewing |
+
+For the full API, see [`tesseract_robotics.viewer` source](https://github.com/tesseract-robotics/tesseract_nanobind/blob/main/src/tesseract_robotics/viewer/tesseract_viewer.py).
+
+## Examples
+
+- [`shapes_viewer.py`](https://github.com/tesseract-robotics/tesseract_nanobind/blob/main/src/tesseract_robotics/examples/shapes_viewer.py) — primitives
+- [`tesseract_material_mesh_viewer.py`](https://github.com/tesseract-robotics/tesseract_nanobind/blob/main/src/tesseract_robotics/examples/tesseract_material_mesh_viewer.py) — materials + meshes
+- [`abb_irb2400_viewer.py`](https://github.com/tesseract-robotics/tesseract_nanobind/blob/main/src/tesseract_robotics/examples/abb_irb2400_viewer.py) — robot + planned trajectory
+- [`twc_workcell_positioner_viewer.py`](https://github.com/tesseract-robotics/tesseract_nanobind/blob/main/src/tesseract_robotics/examples/twc_workcell_positioner_viewer.py) — industrial workcell (requires `git submodule update --init`)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -166,7 +166,8 @@ nav:
     - SQP Modules:
       - tesseract_robotics.trajopt_ifopt: api/trajopt_ifopt.md
       - tesseract_robotics.trajopt_sqp: api/trajopt_sqp.md
-  - Changes:
+  - Changelog: CHANGELOG.md
+  - Migration Guides:
     - "0.33 → 0.34": changes.md
   - Developer:
     - developer/index.md
@@ -193,7 +194,6 @@ extra_css:
 
 extra_javascript:
   - javascripts/mathjax.js
-  - https://polyfill.io/v3/polyfill.min.js?features=es6
   - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
 
-copyright: Copyright &copy; 2024-2025 Tesseract Robotics
+copyright: Copyright &copy; 2024-2026 Tesseract Robotics

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -52,6 +52,8 @@ plugins:
   - exclude:
       glob:
         - QUICKSTART.md
+        - superpowers/**
+        - plans/**
   - mkdocstrings:
       enable_inventory: false
       handlers:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -137,6 +137,7 @@ nav:
     - Task Composer: user-guide/task-composer.md
     - Serialization: user-guide/serialization.md
     - Low-Level SQP API: user-guide/low-level-sqp.md
+    - Viewer: user-guide/viewer.md
   - Examples:
     - examples/index.md
     - Basic Examples: examples/basic.md

--- a/src/tesseract_robotics/examples/abb_irb2400_viewer.py
+++ b/src/tesseract_robotics/examples/abb_irb2400_viewer.py
@@ -60,7 +60,6 @@ import sys
 
 import numpy as np
 
-
 OMPL_DEFAULT_NAMESPACE = "OMPLMotionPlannerTask"
 TRAJOPT_DEFAULT_NAMESPACE = "TrajOptMotionPlannerTask"
 
@@ -68,6 +67,7 @@ TRAJOPT_DEFAULT_NAMESPACE = "TrajOptMotionPlannerTask"
 def main():
     HEADLESS = "pytest" in sys.modules
 
+    # --8<-- [start:load_robot]
     # Load robot
     locator = GeneralResourceLocator()
     abb_irb2400_urdf_package_url = "package://tesseract_support/urdf/abb_irb2400.urdf"
@@ -86,6 +86,7 @@ def main():
     manip_info.tcp_frame = "tool0"
     manip_info.manipulator = "manipulator"
     manip_info.working_frame = "base_link"
+    # --8<-- [end:load_robot]
 
     viewer = None
     if not HEADLESS:
@@ -125,6 +126,7 @@ def main():
     program.appendMoveInstruction(MoveInstructionPoly_wrap_MoveInstruction(start_instruction))
     program.appendMoveInstruction(MoveInstructionPoly_wrap_MoveInstruction(plan_f1))
 
+    # --8<-- [start:plan_and_animate]
     # OMPL planning
     plan_profile = OMPLRealVectorPlanProfile()
     profiles = ProfileDictionary()
@@ -143,6 +145,7 @@ def main():
     interpolated_results_instruction = generateInterpolatedProgram(
         results_instruction, t_env, 3.14, 1.0, 3.14, 10
     )
+    # --8<-- [end:plan_and_animate]
 
     # TrajOpt trajectory optimization for smooth trajectories
     trajopt_success = False

--- a/src/tesseract_robotics/examples/car_seat_example.py
+++ b/src/tesseract_robotics/examples/car_seat_example.py
@@ -386,6 +386,7 @@ def run(pipeline="TrajOptPipeline", num_planners=None):
     else:
         profiles = create_car_seat_profiles()
 
+    # --8<-- [start:multi_step]
     # === PHASE 2: PICK MOTION ===
     # Plan freespace motion from Home to Pick1 (above seat_1)
     pick_result = plan_motion(
@@ -404,6 +405,7 @@ def run(pipeline="TrajOptPipeline", num_planners=None):
     place_result = plan_motion(
         robot, composer, joint_names, pick_pos, place_pos, "PLACE", pipeline, profiles
     )
+    # --8<-- [end:multi_step]
 
     return {
         "pick_result": pick_result,

--- a/src/tesseract_robotics/examples/chain_example.py
+++ b/src/tesseract_robotics/examples/chain_example.py
@@ -88,6 +88,7 @@ def run(pipeline="CartesianPipeline", num_planners=None):
     wp5 = Pose.from_xyz_quat(1.0, -0.2, 0.8, *quat_down)
     wp6 = Pose.from_xyz_quat(1.0, 0.2, 0.8, *quat_down)
 
+    # --8<-- [start:descartes_then_trajopt]
     # Build motion program with FREESPACE and CARTESIAN segments
     # FREESPACE profile: uses OMPL sampling-based planner (handles obstacles)
     # CARTESIAN profile: uses Descartes ladder graph (optimal IK selection)
@@ -132,6 +133,7 @@ def run(pipeline="CartesianPipeline", num_planners=None):
         planning_time = time.time() - start_time
         print(f"Exception after {planning_time:.2f}s: {e}")
         result = None
+    # --8<-- [end:descartes_then_trajopt]
 
     return {
         "result": result,

--- a/src/tesseract_robotics/examples/online_planning_sqp_example.py
+++ b/src/tesseract_robotics/examples/online_planning_sqp_example.py
@@ -39,6 +39,7 @@ Architecture (0.34 API)
    - Extract trajectory from results
 """
 
+# --8<-- [start:setup]
 import sys
 import time
 
@@ -53,8 +54,10 @@ from tesseract_robotics.tesseract_common import Isometry3d
 TesseractViewer = None
 if "pytest" not in sys.modules:
     from tesseract_robotics.viewer import TesseractViewer
+# --8<-- [end:setup]
 
 
+# --8<-- [start:problem]
 def build_optimization_problem(
     robot, joint_names, start_pos, target_pos, steps=10, use_continuous_collision=True
 ):
@@ -179,6 +182,9 @@ def build_optimization_problem(
     }
 
 
+# --8<-- [end:problem]
+
+
 def update_human_position(robot, human_x, human_y):
     """Update human obstacle position via joint values."""
     robot.env.setState({"human_x_joint": human_x, "human_y_joint": human_y})
@@ -216,6 +222,7 @@ def run(steps=12, verbose=False, use_continuous_collision=False):
     problem = problem_data["problem"]
     problem.print()
 
+    # --8<-- [start:sqp_loop]
     # Create SQP solver with OSQP
     # Match C++ defaults: box_size=0.01
     box_size = 0.01
@@ -281,6 +288,7 @@ def run(steps=12, verbose=False, use_continuous_collision=False):
         if verbose:
             cost = problem.getTotalExactCost()
             print(f"  Iter {iteration + 1}: cost={cost:.4f}, time={dt * 1000:.1f}ms")
+    # --8<-- [end:sqp_loop]
 
     avg_time = np.mean(timings[1:]) * 1000
     print(f"Replan timing: avg={avg_time:.1f}ms ({1000 / avg_time:.0f} Hz)")

--- a/src/tesseract_robotics/examples/pick_and_place_example.py
+++ b/src/tesseract_robotics/examples/pick_and_place_example.py
@@ -196,6 +196,7 @@ def run(pipeline="TrajOptPipeline", num_planners=None):
     else:
         profiles = create_profiles()
 
+    # --8<-- [start:full_workflow]
     # ==================== PICK PHASE ====================
     # Motion: start -> approach (15cm above) -> grasp (on box)
     print("\n=== PICK ===")
@@ -285,6 +286,7 @@ def run(pipeline="TrajOptPipeline", num_planners=None):
     place_result = composer.plan(robot, place_program, pipeline=pipeline, profiles=profiles)
     assert place_result.successful, f"PLACE failed: {place_result.message}"
     print(f"PLACE OK: {len(place_result)} waypoints")
+    # --8<-- [end:full_workflow]
 
     return {
         "pick_result": pick_result,

--- a/src/tesseract_robotics/examples/raster_example.py
+++ b/src/tesseract_robotics/examples/raster_example.py
@@ -142,6 +142,7 @@ def run(pipeline="TrajOptPipeline", num_planners=None):
     waypoints = [Pose.from_xyz_quat(x_const, y, z_const, *tool_quat) for y in y_values]
     print(f"Created {len(waypoints)} waypoints")
 
+    # --8<-- [start:build_program]
     # === BUILD MOTION PROGRAM ===
     # Raster structure (from C++ example):
     # - from_start: home -> first waypoint (freespace)
@@ -173,7 +174,9 @@ def run(pipeline="TrajOptPipeline", num_planners=None):
     program.move_to(StateTarget(home_pos, names=joint_names, profile="FREESPACE"))
 
     print(f"Created program with {len(program)} waypoints ({num_segments} segments)")
+    # --8<-- [end:build_program]
 
+    # --8<-- [start:plan]
     # === PLAN WITH TRAJOPT ===
     # TrajOpt optimizes the trajectory for smooth motion and collision avoidance
     print(f"\nRunning planner ({pipeline})...")
@@ -183,6 +186,7 @@ def run(pipeline="TrajOptPipeline", num_planners=None):
 
     assert result.successful, f"Planning failed: {result.message}"
     print(f"Planning successful! {len(result)} waypoints")
+    # --8<-- [end:plan]
 
     return {"result": result, "robot": robot, "joint_names": joint_names}
 

--- a/src/tesseract_robotics/examples/shapes_viewer.py
+++ b/src/tesseract_robotics/examples/shapes_viewer.py
@@ -9,7 +9,6 @@ from tesseract_robotics.tesseract_common import ResourceLocator, SimpleLocatedRe
 from tesseract_robotics.tesseract_environment import Environment
 from tesseract_robotics.viewer import TesseractViewer
 
-
 shapes_urdf = """
 <robot name="multipleshapes">
 
@@ -105,16 +104,20 @@ class TesseractSupportResourceLocator(ResourceLocator):
 def main():
     HEADLESS = "pytest" in sys.modules
 
+    # --8<-- [start:setup]
     t_env = Environment()
 
     # locator must be kept alive by maintaining a reference
     locator = TesseractSupportResourceLocator()
     t_env.init(shapes_urdf, locator)
+    # --8<-- [end:setup]
 
     if not HEADLESS:
+        # --8<-- [start:serve]
         viewer = TesseractViewer()
         viewer.update_environment(t_env, [0, 0, 0])
         viewer.start_serve_background()
+        # --8<-- [end:serve]
         input("Press Enter to exit...")
     else:
         print("shapes_viewer.py: PASSED")

--- a/src/tesseract_robotics/examples/tesseract_kinematics_example.py
+++ b/src/tesseract_robotics/examples/tesseract_kinematics_example.py
@@ -58,6 +58,7 @@ from tesseract_robotics.planning import Pose, Robot
 
 
 def main():
+    # --8<-- [start:fk_ik]
     # =========================================================================
     # STEP 1: Load Robot with Kinematic Solver
     # =========================================================================
@@ -107,6 +108,7 @@ def main():
     print(f"\nFound {len(ik_solutions)} solution(s)")
     for i, sol in enumerate(ik_solutions):
         print(f"Solution {i}: {sol}")
+    # --8<-- [end:fk_ik]
 
 
 if __name__ == "__main__":

--- a/src/tesseract_robotics/examples/twc_workcell_positioner_viewer.py
+++ b/src/tesseract_robotics/examples/twc_workcell_positioner_viewer.py
@@ -195,6 +195,7 @@ def main():
     workcell = args.workcell
     config = WORKCELLS[workcell]
 
+    # --8<-- [start:load_workcell]
     urdf_path = TWC_SUPPORT_PATH / config["urdf"]
     srdf_path = TWC_SUPPORT_PATH / config["srdf"]
 
@@ -221,6 +222,7 @@ def main():
     if not success:
         print("ERROR: Failed to initialize environment")
         sys.exit(1)
+    # --8<-- [end:load_workcell]
 
     print(f"Environment initialized: {t_env.getName()}")
     print(f"Links: {len(list(t_env.getLinkNames()))}")

--- a/src/tesseract_robotics/planning/profiles.py
+++ b/src/tesseract_robotics/planning/profiles.py
@@ -12,6 +12,7 @@ Also provides helpers for:
 from __future__ import annotations
 
 import os
+from typing import Any
 
 from tesseract_robotics.tesseract_command_language import ProfileDictionary
 
@@ -442,7 +443,9 @@ def create_ompl_default_profiles(
 
 
 def create_ompl_planner_configurators(
-    planners: list[str] | None = None, num_planners: int | None = None, **kwargs
+    planners: list[str] | None = None,
+    num_planners: int | None = None,
+    **kwargs: float | bool,
 ) -> list:
     """Create OMPL planner configurators with custom parameters.
 
@@ -873,7 +876,7 @@ def create_cartesian_pipeline_profiles(
 def create_time_optimal_parameterization(
     path_tolerance: float = 0.1,
     min_angle_change: float = 0.001,
-):
+) -> Any:
     """Create Time-Optimal Trajectory Generation (TOTG) parameterization.
 
     TOTG finds the time-optimal trajectory that respects velocity, acceleration,
@@ -925,7 +928,9 @@ def create_time_optimal_parameterization(
     return TimeOptimalTrajectoryGeneration()
 
 
-def create_iterative_spline_parameterization(add_points: bool = True):
+def create_iterative_spline_parameterization(
+    add_points: bool = True,
+) -> Any:
     """Create Iterative Spline Parameterization (ISP).
 
     ISP iteratively fits a spline to the trajectory while respecting velocity,

--- a/src/tesseract_robotics/planning/transforms.py
+++ b/src/tesseract_robotics/planning/transforms.py
@@ -97,8 +97,13 @@ class Pose:
         Create pose from position and quaternion.
 
         Args:
-            x, y, z: Position coordinates
-            qx, qy, qz, qw: Quaternion components (scalar-last convention)
+            x: X position.
+            y: Y position.
+            z: Z position.
+            qx: Quaternion X component.
+            qy: Quaternion Y component.
+            qz: Quaternion Z component.
+            qw: Quaternion W component (scalar-last convention).
         """
         mat = np.eye(4)
         mat[:3, 3] = [x, y, z]
@@ -148,8 +153,12 @@ class Pose:
         Create pose from position and roll-pitch-yaw angles.
 
         Args:
-            x, y, z: Position coordinates
-            roll, pitch, yaw: Euler angles in radians (XYZ convention)
+            x: X position.
+            y: Y position.
+            z: Z position.
+            roll: Roll angle in radians.
+            pitch: Pitch angle in radians.
+            yaw: Yaw angle in radians (XYZ convention).
         """
         mat = np.eye(4)
         mat[:3, 3] = [x, y, z]


### PR DESCRIPTION

- Refresh mkdocs site to match current `src/` (post-0.34, post-flatten, post-viewer-refactor). Worst drift was wholly fictional API in narrative pages: `Planner(robot)`, `Composer(robot)`, `robot.check_collision`, `robot.get_contacts` — none of those classes/methods exist. Replaced with real `plan_freespace(robot, MotionProgram(...))`, `TaskComposer.from_config().plan(...)`, and `env.getDiscreteContactManager()` patterns throughout.
- Full rewrite of `user-guide/low-level-sqp.md` and `api/trajopt_ifopt.md` from pre-0.34 (`JointPosition`, `CartPosInfo`, `CollisionCache`, removed `ifopt` module) to 0.34 `Var`/`Node`/`NodesVariables` API.
- New `user-guide/viewer.md` with flagship `--8<--` snippets pulled from tested examples (`shapes_viewer.py`, `abb_irb2400_viewer.py`, `twc_workcell_positioner_viewer.py`). Same idiom applied across `examples/planning.md` for pick-and-place, raster, car-seat, chain.
- Wire `CHANGELOG.md` into nav as a top-level "Changelog" entry; relabel old `changes.md` as "Migration Guides > 0.33 → 0.34". Drop dead `polyfill.io` CDN.
- Document `TaskComposer.warmup()` (shipped `06d25ad`, previously undocumented) and polymorphic `CompositeInstruction.push_back` (`6d17314`, 0.35.0.0 seed).
- Add `.github/workflows/docs.yml` running `mkdocs build --strict` on PRs touching docs to prevent regression.
- Fix pip install name across docs (`tesseract-robotics-nanobind`, not the import name `tesseract_robotics`).
- Fix `robot.fk` / `robot.ik` signature throughout (`group_name` is first positional, not a kwarg).

