### PR TITLE
feat(task_composer): add TaskComposerDataStorage AnyPoly casting/wrapping

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -367,6 +367,7 @@ add_tesseract_nanobind_extension(
   tesseract::tesseract_task_composer_taskflow
   tesseract::tesseract_environment
   tesseract::tesseract_command_language
+  tesseract::tesseract_collision_core
   tesseract::tesseract_common
 )
 

--- a/src/tesseract_robotics/tesseract_task_composer/__init__.py
+++ b/src/tesseract_robotics/tesseract_task_composer/__init__.py
@@ -18,5 +18,7 @@ __all__ = [
     "AnyPoly_wrap_CompositeInstruction",
     "AnyPoly_wrap_ProfileDictionary",
     "AnyPoly_wrap_EnvironmentConst",
+    "AnyPoly_wrap_TaskComposerDataStorage",
     "AnyPoly_as_CompositeInstruction",
+    "AnyPoly_as_TaskComposerDataStorage",
 ]

--- a/src/tesseract_robotics/tesseract_task_composer/__init__.py
+++ b/src/tesseract_robotics/tesseract_task_composer/__init__.py
@@ -21,4 +21,5 @@ __all__ = [
     "AnyPoly_wrap_TaskComposerDataStorage",
     "AnyPoly_as_CompositeInstruction",
     "AnyPoly_as_TaskComposerDataStorage",
+    "AnyPoly_as_ContactResultMapVector",
 ]

--- a/src/tesseract_robotics/tesseract_task_composer/_tesseract_task_composer.pyi
+++ b/src/tesseract_robotics/tesseract_task_composer/_tesseract_task_composer.pyi
@@ -213,5 +213,11 @@ def AnyPoly_wrap_ProfileDictionary(profiles: "tesseract_common::ProfileDictionar
 def AnyPoly_wrap_EnvironmentConst(environment: "tesseract_environment::Environment") -> AnyPoly:
     """Wrap a const Environment shared_ptr into an AnyPoly"""
 
+def AnyPoly_wrap_TaskComposerDataStorage(data_storage: TaskComposerDataStorage) -> AnyPoly:
+    """Wrap a TaskComposerDataStorage shared_ptr into an AnyPoly"""
+
 def AnyPoly_as_CompositeInstruction(any_poly: AnyPoly) -> "tesseract_planning::CompositeInstruction":
     """Extract a CompositeInstruction from an AnyPoly"""
+
+def AnyPoly_as_TaskComposerDataStorage(any_poly: AnyPoly) -> TaskComposerDataStorage:
+    """Extract a TaskComposerDataStorage from an AnyPoly"""

--- a/src/tesseract_robotics/tesseract_task_composer/_tesseract_task_composer.pyi
+++ b/src/tesseract_robotics/tesseract_task_composer/_tesseract_task_composer.pyi
@@ -35,6 +35,9 @@ class TaskComposerDataStorage:
 
     def getData(self, key: str) -> AnyPoly: ...
 
+    def getAllData(self) -> dict[str, AnyPoly]:
+        """Return every entry as a dict {key: AnyPoly}."""
+
     def removeData(self, key: str) -> None: ...
 
 def createTaskComposerDataStorage() -> TaskComposerDataStorage:

--- a/src/tesseract_robotics/tesseract_task_composer/_tesseract_task_composer.pyi
+++ b/src/tesseract_robotics/tesseract_task_composer/_tesseract_task_composer.pyi
@@ -223,3 +223,12 @@ def AnyPoly_as_CompositeInstruction(any_poly: AnyPoly) -> "tesseract_planning::C
 
 def AnyPoly_as_TaskComposerDataStorage(any_poly: AnyPoly) -> TaskComposerDataStorage:
     """Extract a TaskComposerDataStorage from an AnyPoly"""
+
+def AnyPoly_as_ContactResultMapVector(
+    any_poly: AnyPoly,
+) -> list["tesseract_collision::ContactResultMap"]:
+    """Extract a std::vector<ContactResultMap> from an AnyPoly.
+
+    DiscreteContactCheckTask saves its per-step contact results under the
+    'contact_results' key on its node info's data_storage in this form.
+    """

--- a/src/tesseract_robotics/tesseract_task_composer/_tesseract_task_composer.pyi
+++ b/src/tesseract_robotics/tesseract_task_composer/_tesseract_task_composer.pyi
@@ -35,8 +35,7 @@ class TaskComposerDataStorage:
 
     def getData(self, key: str) -> AnyPoly: ...
 
-    def getAllData(self) -> dict[str, AnyPoly]:
-        """Return every entry as a dict {key: AnyPoly}."""
+    def getAllData(self) -> dict[str, AnyPoly]: ...
 
     def removeData(self, key: str) -> None: ...
 

--- a/src/tesseract_task_composer/tesseract_task_composer_bindings.cpp
+++ b/src/tesseract_task_composer/tesseract_task_composer_bindings.cpp
@@ -399,8 +399,16 @@ NB_MODULE(_tesseract_task_composer, m) {
         return tc::AnyPoly(env);
     }, "environment"_a, "Wrap a const Environment shared_ptr into an AnyPoly");
 
+    m.def("AnyPoly_wrap_TaskComposerDataStorage", [](std::shared_ptr<tp::TaskComposerDataStorage> ds) {
+        return tc::AnyPoly(ds);
+    }, "data_storage"_a, "Wrap a TaskComposerDataStorage shared_ptr into an AnyPoly");
+
     // ========== AnyPoly unwrap functions ==========
     m.def("AnyPoly_as_CompositeInstruction", [](const tc::AnyPoly& ap) -> tp::CompositeInstruction {
         return ap.as<tp::CompositeInstruction>();
     }, "any_poly"_a, "Extract a CompositeInstruction from an AnyPoly");
+
+    m.def("AnyPoly_as_TaskComposerDataStorage", [](const tc::AnyPoly& ap) {
+        return ap.as<tp::TaskComposerDataStorage::Ptr>();
+    }, "any_poly"_a, "Extract a TaskComposerDataStorage from an AnyPoly");
 }

--- a/src/tesseract_task_composer/tesseract_task_composer_bindings.cpp
+++ b/src/tesseract_task_composer/tesseract_task_composer_bindings.cpp
@@ -137,6 +137,8 @@ NB_MODULE(_tesseract_task_composer, m) {
         .def("hasKey", &tp::TaskComposerDataStorage::hasKey, "key"_a)
         .def("setData", &tp::TaskComposerDataStorage::setData, "key"_a, "data"_a)
         .def("getData", nb::overload_cast<const std::string&>(&tp::TaskComposerDataStorage::getData, nb::const_), "key"_a)
+        .def("getAllData", nb::overload_cast<>(&tp::TaskComposerDataStorage::getData, nb::const_),
+             "Return every entry as a dict {key: AnyPoly}.")
         .def("removeData", &tp::TaskComposerDataStorage::removeData, "key"_a);
 
     // Factory function that returns shared_ptr (useful when passing to executor.run)

--- a/src/tesseract_task_composer/tesseract_task_composer_bindings.cpp
+++ b/src/tesseract_task_composer/tesseract_task_composer_bindings.cpp
@@ -137,8 +137,7 @@ NB_MODULE(_tesseract_task_composer, m) {
         .def("hasKey", &tp::TaskComposerDataStorage::hasKey, "key"_a)
         .def("setData", &tp::TaskComposerDataStorage::setData, "key"_a, "data"_a)
         .def("getData", nb::overload_cast<const std::string&>(&tp::TaskComposerDataStorage::getData, nb::const_), "key"_a)
-        .def("getAllData", nb::overload_cast<>(&tp::TaskComposerDataStorage::getData, nb::const_),
-             "Return every entry as a dict {key: AnyPoly}.")
+        .def("getAllData", nb::overload_cast<>(&tp::TaskComposerDataStorage::getData, nb::const_))
         .def("removeData", &tp::TaskComposerDataStorage::removeData, "key"_a);
 
     // Factory function that returns shared_ptr (useful when passing to executor.run)

--- a/src/tesseract_task_composer/tesseract_task_composer_bindings.cpp
+++ b/src/tesseract_task_composer/tesseract_task_composer_bindings.cpp
@@ -5,6 +5,7 @@
 
 #include "tesseract_nb.h"
 #include <nanobind/stl/unordered_map.h>
+#include <nanobind/stl/vector.h>
 #include <nanobind/stl/chrono.h>
 #include <nanobind/stl/optional.h>
 
@@ -37,6 +38,10 @@
 #include <tesseract_command_language/composite_instruction.h>
 // Note: ProfileDictionary moved to tesseract_common in 0.33
 #include <tesseract_common/profile_dictionary.h>
+
+// tesseract_collision for ContactResultMap (DiscreteContactCheckTask saves
+// std::vector<ContactResultMap> on its node info's data_storage)
+#include <tesseract_collision/core/types.h>
 
 // console_bridge for log output visible alongside the rest of tesseract's logging
 #include <console_bridge/console.h>
@@ -171,6 +176,7 @@ NB_MODULE(_tesseract_task_composer, m) {
             result["status_code"] = info->status_code;
             result["status_message"] = info->status_message;
             result["elapsed_time"] = info->elapsed_time;
+            result["data_storage"] = info->data_storage;
             return result;
         })
         .def("getAllInfos", [](const tp::TaskComposerNodeInfoContainer& self) -> nb::list {
@@ -184,6 +190,7 @@ NB_MODULE(_tesseract_task_composer, m) {
                 d["status_code"] = info.status_code;
                 d["status_message"] = info.status_message;
                 d["elapsed_time"] = info.elapsed_time;
+                d["data_storage"] = info.data_storage;
                 result.append(d);
             }
             return result;
@@ -412,4 +419,12 @@ NB_MODULE(_tesseract_task_composer, m) {
     m.def("AnyPoly_as_TaskComposerDataStorage", [](const tc::AnyPoly& ap) {
         return ap.as<tp::TaskComposerDataStorage::Ptr>();
     }, "any_poly"_a, "Extract a TaskComposerDataStorage from an AnyPoly");
+
+    m.def("AnyPoly_as_ContactResultMapVector",
+          [](const tc::AnyPoly& ap) -> std::vector<tesseract_collision::ContactResultMap> {
+        return ap.as<std::vector<tesseract_collision::ContactResultMap>>();
+    }, "any_poly"_a,
+       "Extract a std::vector<ContactResultMap> from an AnyPoly. "
+       "DiscreteContactCheckTask saves its per-step contact results under "
+       "the 'contact_results' key on its node info's data_storage in this form.");
 }

--- a/tests/tesseract_task_composer/test_tesseract_task_composer.py
+++ b/tests/tesseract_task_composer/test_tesseract_task_composer.py
@@ -246,3 +246,81 @@ class TestDotgraph:
         ok = node.saveDotgraph(str(bad))
         assert ok is False
         assert not bad.exists()
+
+
+class TestAnyPolyDataStorage:
+    """AnyPoly_wrap/as_TaskComposerDataStorage — used to navigate sub-task storages
+    that the framework nests under a parent's data_storage keyed by node UUID."""
+
+    def test_anypoly_wrap_data_storage_not_null(self):
+        from tesseract_robotics.tesseract_task_composer import (
+            AnyPoly_wrap_TaskComposerDataStorage,
+            createTaskComposerDataStorage,
+        )
+
+        ds = createTaskComposerDataStorage()
+        any_poly = AnyPoly_wrap_TaskComposerDataStorage(ds)
+        assert any_poly is not None
+        assert not any_poly.isNull()
+
+    def test_anypoly_roundtrip_data_storage(self):
+        """Wrap a DataStorage in AnyPoly, unwrap, confirm we got the same instance back."""
+        from tesseract_robotics.tesseract_task_composer import (
+            AnyPoly_as_TaskComposerDataStorage,
+            AnyPoly_wrap_TaskComposerDataStorage,
+            createTaskComposerDataStorage,
+        )
+
+        ds = createTaskComposerDataStorage()
+        ds.setName("sub_storage")
+
+        recovered = AnyPoly_as_TaskComposerDataStorage(
+            AnyPoly_wrap_TaskComposerDataStorage(ds)
+        )
+        assert recovered is not None
+        assert recovered.getName() == "sub_storage"
+
+        # Mutate via the recovered handle; original sees it -> shared_ptr semantics preserved.
+        recovered.setName("mutated")
+        assert ds.getName() == "mutated"
+
+    def test_navigate_nested_sub_task_storage(self):
+        """Mirror the real pattern: parent stores a sub-storage as AnyPoly under a
+        UUID key; navigate parent.getData(uuid) -> as_TaskComposerDataStorage ->
+        getData('input_data') to recover the mid-pipeline AnyPoly that the
+        framework would have placed there (e.g. RasterSimple's densified output)."""
+        from tesseract_robotics.tesseract_command_language import (
+            CompositeInstruction,
+        )
+        from tesseract_robotics.tesseract_task_composer import (
+            AnyPoly_as_CompositeInstruction,
+            AnyPoly_as_TaskComposerDataStorage,
+            AnyPoly_wrap_CompositeInstruction,
+            AnyPoly_wrap_TaskComposerDataStorage,
+            createTaskComposerDataStorage,
+        )
+
+        sub_storage = createTaskComposerDataStorage()
+        program = CompositeInstruction("DENSIFIED")
+        sub_storage.setData("input_data", AnyPoly_wrap_CompositeInstruction(program))
+
+        parent = createTaskComposerDataStorage()
+        fake_uuid = "deadbeef" * 4
+        parent.setData(fake_uuid, AnyPoly_wrap_TaskComposerDataStorage(sub_storage))
+
+        recovered_sub = AnyPoly_as_TaskComposerDataStorage(parent.getData(fake_uuid))
+        recovered_program = AnyPoly_as_CompositeInstruction(
+            recovered_sub.getData("input_data")
+        )
+        assert recovered_program.getProfile() == "DENSIFIED"
+
+    def test_unwrap_null_anypoly_raises(self):
+        """A null AnyPoly cannot be unwrapped — verify the binding surfaces the error
+        rather than returning a silently-null shared_ptr."""
+        from tesseract_robotics.tesseract_task_composer import (
+            AnyPoly,
+            AnyPoly_as_TaskComposerDataStorage,
+        )
+
+        with pytest.raises(Exception):
+            AnyPoly_as_TaskComposerDataStorage(AnyPoly())

--- a/tests/tesseract_task_composer/test_tesseract_task_composer.py
+++ b/tests/tesseract_task_composer/test_tesseract_task_composer.py
@@ -324,3 +324,205 @@ class TestAnyPolyDataStorage:
 
         with pytest.raises(Exception):
             AnyPoly_as_TaskComposerDataStorage(AnyPoly())
+
+
+class TestGetAllData:
+    """TaskComposerDataStorage.getAllData() — no-arg overload returning the full
+    {key: AnyPoly} map of stored entries."""
+
+    def test_empty_storage_returns_empty_dict(self):
+        from tesseract_robotics.tesseract_task_composer import (
+            createTaskComposerDataStorage,
+        )
+
+        ds = createTaskComposerDataStorage()
+        assert ds.getAllData() == {}
+
+    def test_returns_all_keys_set(self):
+        from tesseract_robotics.tesseract_command_language import CompositeInstruction
+        from tesseract_robotics.tesseract_task_composer import (
+            AnyPoly_wrap_CompositeInstruction,
+            createTaskComposerDataStorage,
+        )
+
+        ds = createTaskComposerDataStorage()
+        ds.setData("a", AnyPoly_wrap_CompositeInstruction(CompositeInstruction("A")))
+        ds.setData("b", AnyPoly_wrap_CompositeInstruction(CompositeInstruction("B")))
+        ds.setData("c", AnyPoly_wrap_CompositeInstruction(CompositeInstruction("C")))
+
+        all_data = ds.getAllData()
+        assert set(all_data.keys()) == {"a", "b", "c"}
+
+    def test_values_roundtrip_through_anypoly(self):
+        """Values returned by getAllData are AnyPolys with intact payloads."""
+        from tesseract_robotics.tesseract_command_language import CompositeInstruction
+        from tesseract_robotics.tesseract_task_composer import (
+            AnyPoly_as_CompositeInstruction,
+            AnyPoly_wrap_CompositeInstruction,
+            createTaskComposerDataStorage,
+        )
+
+        ds = createTaskComposerDataStorage()
+        ds.setData("foo", AnyPoly_wrap_CompositeInstruction(CompositeInstruction("FOO")))
+
+        recovered = AnyPoly_as_CompositeInstruction(ds.getAllData()["foo"])
+        assert recovered.getProfile() == "FOO"
+
+
+class TestAnyPolyAsContactResultMapVector:
+    """AnyPoly_as_ContactResultMapVector — extracts std::vector<ContactResultMap>.
+    No wrap counterpart exists (only DiscreteContactCheckTask produces these);
+    here we cover the negative cases. Positive coverage is in the integration
+    test below."""
+
+    def test_wrong_typed_anypoly_raises(self):
+        from tesseract_robotics.tesseract_command_language import CompositeInstruction
+        from tesseract_robotics.tesseract_task_composer import (
+            AnyPoly_as_ContactResultMapVector,
+            AnyPoly_wrap_CompositeInstruction,
+        )
+
+        ap = AnyPoly_wrap_CompositeInstruction(CompositeInstruction("WRONG"))
+        with pytest.raises(Exception):
+            AnyPoly_as_ContactResultMapVector(ap)
+
+    def test_null_anypoly_raises(self):
+        from tesseract_robotics.tesseract_task_composer import (
+            AnyPoly,
+            AnyPoly_as_ContactResultMapVector,
+        )
+
+        with pytest.raises(Exception):
+            AnyPoly_as_ContactResultMapVector(AnyPoly())
+
+
+class TestPipelineDataStorageExposure:
+    """End-to-end coverage for the data_storage exposure + contact_results
+    extraction path: run FreespacePipeline (which contains DiscreteContactCheckTask),
+    then read per-node data_storage out of getAllInfos and unwrap the contact
+    results vector via AnyPoly_as_ContactResultMapVector."""
+
+    @pytest.fixture(scope="class")
+    def pipeline_run(self):
+        """Run FreespacePipeline with a contact-check profile rigged to flag the
+        path as colliding (1.5m default margin) so DiscreteContactCheckTask
+        populates 'contact_results' on its node info data_storage. Mirrors the
+        upstream gtest at tesseract_task_composer/test/
+        tesseract_task_composer_planning_unit.cpp::TaskComposerDiscreteContactCheckTaskTests
+        ('Failure collision' case)."""
+        np = pytest.importorskip("numpy")
+        pytest.importorskip("tesseract_robotics.planning")
+
+        config_file = _resolve_task_composer_config()
+        if not config_file:
+            pytest.skip("No task composer config found")
+
+        from tesseract_robotics.planning import (
+            JointTarget,
+            MotionProgram,
+            Robot,
+            TaskComposer,
+        )
+        from tesseract_robotics.planning.profiles import (
+            create_freespace_pipeline_profiles,
+        )
+        from tesseract_robotics.tesseract_collision import (
+            CollisionEvaluatorType,
+            ContactManagerConfig,
+        )
+        from tesseract_robotics.tesseract_motion_planners import (
+            assignCurrentStateAsSeed,
+        )
+        from tesseract_robotics.tesseract_task_composer import (
+            AnyPoly_wrap_CompositeInstruction,
+            AnyPoly_wrap_EnvironmentConst,
+            AnyPoly_wrap_ProfileDictionary,
+            TaskComposerDataStorage,
+        )
+        from tesseract_robotics.tesseract_task_composer_planning import (
+            ContactCheckProfile,
+        )
+
+        robot = Robot.from_tesseract_support("lbr_iiwa_14_r820")
+        joint_names = robot.get_joint_names("manipulator")
+        j_start = np.array([-0.4, 0.2762, 0.0, -1.3348, 0.0, 1.4959, 0.0])
+        j_end = np.array([0.4, 0.2762, 0.0, -1.3348, 0.0, 1.4959, 0.0])
+        robot.set_joints(j_start, joint_names=joint_names)
+
+        program = (
+            MotionProgram("manipulator", tcp_frame="tool0")
+            .set_joint_names(joint_names)
+            .move_to(JointTarget(j_start))
+            .move_to(JointTarget(j_end))
+        )
+        profiles = create_freespace_pipeline_profiles(planning_time=2.0)
+
+        # 1.5m default margin → every link counts as in collision with everything
+        # else, guaranteeing DiscreteContactCheckTask flags the trajectory and
+        # writes the per-step contact_results vector to its info data_storage.
+        forcing = ContactCheckProfile()
+        forcing.contact_manager_config = ContactManagerConfig(1.5)
+        forcing.collision_check_config.type = CollisionEvaluatorType.LVS_DISCRETE
+        for profile_name in ("FREESPACE", "DEFAULT"):
+            profiles.addProfile("DiscreteContactCheckTask", profile_name, forcing)
+
+        composer = TaskComposer.from_config(config_path=config_file)
+        composite = program.to_composite_instruction(joint_names, "tool0")
+        assignCurrentStateAsSeed(composite, robot.env)
+
+        task = composer.factory.createTaskComposerNode("FreespacePipeline")
+        input_key = task.getInputKeys().get("planning_input")
+
+        task_data = TaskComposerDataStorage()
+        task_data.setData(input_key, AnyPoly_wrap_CompositeInstruction(composite))
+        task_data.setData("environment", AnyPoly_wrap_EnvironmentConst(robot.env))
+        task_data.setData("profiles", AnyPoly_wrap_ProfileDictionary(profiles))
+
+        future = composer.executor.run(task, task_data)
+        future.wait()
+        infos = future.context.task_infos.getAllInfos()
+
+        yield infos
+
+        del future
+        del task_data
+        del task
+        del composer
+        gc.collect()
+
+    def test_node_info_dict_exposes_data_storage(self, pipeline_run):
+        """Every node info dict from getAllInfos should carry a 'data_storage'
+        entry — the binding that 994bee3 added."""
+        infos = pipeline_run
+        assert len(infos) > 0, "Pipeline produced no node infos"
+        for info in infos:
+            assert "data_storage" in info, (
+                f"Node {info.get('name')!r} info dict missing 'data_storage' key"
+            )
+
+    def test_discrete_contact_check_data_storage_yields_contact_results(
+        self, pipeline_run
+    ):
+        """DiscreteContactCheckTask, on a colliding trajectory, stores the per-step
+        results under 'contact_results' on its node info's data_storage;
+        AnyPoly_as_ContactResultMapVector unwraps that to list[ContactResultMap]."""
+        from tesseract_robotics.tesseract_task_composer import (
+            AnyPoly_as_ContactResultMapVector,
+        )
+
+        infos = pipeline_run
+        contact_check_infos = [
+            i for i in infos if "DiscreteContactCheck" in (i.get("name") or "")
+        ]
+        assert contact_check_infos, "DiscreteContactCheckTask did not run"
+
+        ds = contact_check_infos[0]["data_storage"]
+        assert ds is not None
+        all_data = ds.getAllData()
+        assert "contact_results" in all_data, (
+            "Forcing-collision profile should have caused DiscreteContactCheckTask "
+            "to write 'contact_results' to its info's data_storage"
+        )
+        contact_results = AnyPoly_as_ContactResultMapVector(all_data["contact_results"])
+        assert isinstance(contact_results, list)
+        assert len(contact_results) > 0


### PR DESCRIPTION
We're trying to debug our pipeline now, and having this helper is useful to dig into the storage to see what the state is after each node in the DAG