### PR TITLE
fix(tesseract_srdf): expose KinematicsInformation.group_tcps to Python

### DIFF
--- a/src/tesseract_srdf/tesseract_srdf_bindings.cpp
+++ b/src/tesseract_srdf/tesseract_srdf_bindings.cpp
@@ -27,7 +27,37 @@ NB_MODULE(_tesseract_srdf, m) {
         .def_rw("joint_groups", &ts::KinematicsInformation::joint_groups)
         .def_rw("link_groups", &ts::KinematicsInformation::link_groups)
         .def_rw("group_states", &ts::KinematicsInformation::group_states)
-        .def_rw("group_tcps", &ts::KinematicsInformation::group_tcps)
+        // group_tcps: the C++ field is nested unordered_map keyed on string with
+        // Eigen::aligned_allocator on the inner map (Isometry3d alignment). nanobind's
+        // default stl/unordered_map caster does not pattern-match against that allocator
+        // template arg, so a raw def_rw exposes a Python attribute whose getter raises
+        // TypeError on access. The fix is a def_prop_rw that copies through to a
+        // default-allocator nested map at the binding boundary; values (Isometry3d) round-trip
+        // via their existing nanobind class binding.
+        .def_prop_rw(
+            "group_tcps",
+            [](const ts::KinematicsInformation& self) {
+                std::unordered_map<std::string,
+                                   std::unordered_map<std::string, Eigen::Isometry3d>> out;
+                for (const auto& [group_name, tcps] : self.group_tcps) {
+                    std::unordered_map<std::string, Eigen::Isometry3d> inner;
+                    for (const auto& [tcp_name, tcp] : tcps) {
+                        inner.emplace(tcp_name, tcp);
+                    }
+                    out.emplace(group_name, std::move(inner));
+                }
+                return out;
+            },
+            [](ts::KinematicsInformation& self,
+               const std::unordered_map<std::string,
+                                        std::unordered_map<std::string, Eigen::Isometry3d>>& value) {
+                self.group_tcps.clear();
+                for (const auto& [group_name, tcps] : value) {
+                    for (const auto& [tcp_name, tcp] : tcps) {
+                        self.group_tcps[group_name][tcp_name] = tcp;
+                    }
+                }
+            })
         .def("insert", &ts::KinematicsInformation::insert, "other"_a)
         .def("clear", &ts::KinematicsInformation::clear)
         .def("hasGroup", &ts::KinematicsInformation::hasGroup, "group_name"_a)

--- a/tests/tesseract_srdf/test_kinematics_information_group_tcps.py
+++ b/tests/tesseract_srdf/test_kinematics_information_group_tcps.py
@@ -1,0 +1,72 @@
+"""Regression tests for KinematicsInformation.group_tcps Python accessor.
+
+The underlying C++ field is unordered_map<string, unordered_map<string, Isometry3d,
+Eigen::aligned_allocator<...>>>. A raw def_rw exposed a Python attribute whose getter
+raised TypeError on access because nanobind's default stl/unordered_map caster does
+not pattern-match against the aligned_allocator template arg. The binding now exposes
+it via def_prop_rw with explicit lambdas that copy through default-allocator nested
+maps at the boundary.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from tesseract_robotics.tesseract_common import Isometry3d, Quaterniond
+from tesseract_robotics.tesseract_srdf import KinematicsInformation
+
+
+def test_group_tcps_empty_on_default_construction() -> None:
+    ki = KinematicsInformation()
+    assert ki.group_tcps == {}
+
+
+def test_group_tcps_read_after_add_group_tcp_method() -> None:
+    ki = KinematicsInformation()
+    tcp = Isometry3d(np.array([0.1, 0.2, 0.3]), Quaterniond.Identity())
+    ki.addGroupTCP("arm", "tool0", tcp)
+
+    tcps = ki.group_tcps
+    assert set(tcps.keys()) == {"arm"}
+    assert set(tcps["arm"].keys()) == {"tool0"}
+    np.testing.assert_allclose(tcps["arm"]["tool0"].translation, [0.1, 0.2, 0.3])
+
+
+def test_group_tcps_setter_round_trip() -> None:
+    ki = KinematicsInformation()
+    tcp_a = Isometry3d(np.array([1.0, 0.0, 0.0]), Quaterniond.Identity())
+    tcp_b = Isometry3d(np.array([0.0, 2.0, 0.0]), Quaterniond.Identity())
+
+    ki.group_tcps = {"arm": {"tool0": tcp_a, "weld_tip": tcp_b}}
+
+    assert ki.hasGroupTCP("arm", "tool0")
+    assert ki.hasGroupTCP("arm", "weld_tip")
+    np.testing.assert_allclose(ki.group_tcps["arm"]["tool0"].translation, [1.0, 0.0, 0.0])
+    np.testing.assert_allclose(ki.group_tcps["arm"]["weld_tip"].translation, [0.0, 2.0, 0.0])
+
+
+def test_group_tcps_setter_replaces_prior_content() -> None:
+    ki = KinematicsInformation()
+    ki.addGroupTCP("arm", "tool0", Isometry3d())
+    ki.addGroupTCP("positioner", "centerpiece", Isometry3d())
+    assert set(ki.group_tcps.keys()) == {"arm", "positioner"}
+
+    replacement_tcp = Isometry3d(np.array([7.0, 8.0, 9.0]), Quaterniond.Identity())
+    ki.group_tcps = {"new_group": {"new_tcp": replacement_tcp}}
+
+    assert set(ki.group_tcps.keys()) == {"new_group"}
+    np.testing.assert_allclose(ki.group_tcps["new_group"]["new_tcp"].translation, [7.0, 8.0, 9.0])
+
+
+def test_group_tcps_multiple_groups() -> None:
+    ki = KinematicsInformation()
+    ki.addGroupTCP("arm", "tool0", Isometry3d(np.array([1.0, 0.0, 0.0]), Quaterniond.Identity()))
+    ki.addGroupTCP("arm", "flange", Isometry3d(np.array([0.0, 1.0, 0.0]), Quaterniond.Identity()))
+    ki.addGroupTCP(
+        "positioner", "fixture", Isometry3d(np.array([0.0, 0.0, 1.0]), Quaterniond.Identity())
+    )
+
+    tcps = ki.group_tcps
+    assert set(tcps.keys()) == {"arm", "positioner"}
+    assert set(tcps["arm"].keys()) == {"tool0", "flange"}
+    assert set(tcps["positioner"].keys()) == {"fixture"}


### PR DESCRIPTION
## Summary

`KinematicsInformation.group_tcps` was bound via `def_rw` against a field whose type is

```cpp
std::unordered_map<std::string,
  std::unordered_map<std::string, Eigen::Isometry3d,
                     std::hash<std::string>, std::equal_to<std::string>,
                     Eigen::aligned_allocator<...>>>
```

nanobind's default `stl/unordered_map` caster does not pattern-match against the `Eigen::aligned_allocator` template arg on the inner map, so the bound attribute's *getter* raised:

```
TypeError: Unable to convert function return value to a Python type! The signature was
  (self) -> std::__1::unordered_map<std::__1::basic_string<...>, ..., Eigen::aligned_allocator<...>>
```

This made per-group TCPs invisible to Python even though the setter side (`addGroupTCP` / `removeGroupTCP` / `hasGroupTCP`) worked.

## Fix

Replace the raw `def_rw` with `def_prop_rw` carrying two lambdas that copy through default-allocator `unordered_map<string, unordered_map<string, Isometry3d>>` at the binding boundary. Values (`Isometry3d`) round-trip via the existing nanobind class binding in `tesseract_common`.

Local + visible at the call site — no new type caster, no header changes — and the conversion cost is one copy on a read-mostly metadata dict whose cardinality is groups × TCPs per group (typically <10×<10).

## Test plan

New `tests/tesseract_srdf/test_kinematics_information_group_tcps.py` (5 cases):

- [x] Empty default state returns `{}` (was: `TypeError`)
- [x] Read after `addGroupTCP(...)` returns the value via the property
- [x] Setter round-trip — assign a `{group: {tcp_name: Isometry3d}}` dict, read it back equivalent
- [x] Setter replaces prior content (clears and rewrites)
- [x] Multiple groups with multiple TCPs each
- [x] No regression in `tests/tesseract_environment/` (48 tests still pass)

Run locally: `pixi run -- pytest tests/tesseract_srdf/ tests/tesseract_environment/`