### PR TITLE
fix(task_composer): make TaskComposerNodeInfoContainer return TaskComposerNodeInfo

### DIFF
--- a/src/tesseract_robotics/planning/composer.py
+++ b/src/tesseract_robotics/planning/composer.py
@@ -513,13 +513,13 @@ class TaskComposer:
                     if task_infos:
                         # Try aborting node first — most useful diagnostic
                         aborting = task_infos.getAbortingNodeInfo()
-                        if aborting and aborting.get("status_message"):
-                            msg = f"{aborting['name']}: {aborting['status_message']}"
+                        if aborting and aborting.status_message:
+                            msg = f"{aborting.name}: {aborting.status_message}"
                         else:
                             # Scan all node infos for first non-empty status_message
                             for info in task_infos.getAllInfos():
-                                if info.get("status_message"):
-                                    msg = f"{info['name']}: {info['status_message']}"
+                                if info.status_message:
+                                    msg = f"{info.name}: {info.status_message}"
                                     break
                 except (AttributeError, TypeError):
                     pass

--- a/src/tesseract_robotics/tesseract_task_composer/_tesseract_task_composer.pyi
+++ b/src/tesseract_robotics/tesseract_task_composer/_tesseract_task_composer.pyi
@@ -44,6 +44,12 @@ def createTaskComposerDataStorage() -> TaskComposerDataStorage:
 
 class TaskComposerNodeInfo:
     @property
+    def uuid(self) -> str: ...
+
+    @property
+    def parent_uuid(self) -> str: ...
+
+    @property
     def name(self) -> str: ...
 
     @property
@@ -59,14 +65,17 @@ class TaskComposerNodeInfo:
     def elapsed_time(self) -> float: ...
 
     @property
+    def data_storage(self) -> TaskComposerDataStorage: ...
+
+    @property
     def dotgraph(self) -> str: ...
 
 class TaskComposerNodeInfoContainer:
     def __init__(self) -> None: ...
 
-    def getAbortingNodeInfo(self) -> dict[str, object] | None: ...
+    def getAbortingNodeInfo(self) -> TaskComposerNodeInfo | None: ...
 
-    def getAllInfos(self) -> list[dict[str, object]]: ...
+    def getAllInfos(self) -> list[TaskComposerNodeInfo]: ...
 
 class TaskComposerContext:
     @property
@@ -224,11 +233,7 @@ def AnyPoly_as_CompositeInstruction(any_poly: AnyPoly) -> "tesseract_planning::C
 def AnyPoly_as_TaskComposerDataStorage(any_poly: AnyPoly) -> TaskComposerDataStorage:
     """Extract a TaskComposerDataStorage from an AnyPoly"""
 
-def AnyPoly_as_ContactResultMapVector(
-    any_poly: AnyPoly,
-) -> list["tesseract_collision::ContactResultMap"]:
-    """Extract a std::vector<ContactResultMap> from an AnyPoly.
-
-    DiscreteContactCheckTask saves its per-step contact results under the
-    'contact_results' key on its node info's data_storage in this form.
+def AnyPoly_as_ContactResultMapVector(any_poly: AnyPoly) -> list["tesseract_collision::ContactResultMap"]:
+    """
+    Extract a std::vector<ContactResultMap> from an AnyPoly. DiscreteContactCheckTask saves its per-step contact results under the 'contact_results' key on its node info's data_storage in this form.
     """

--- a/src/tesseract_task_composer/tesseract_task_composer_bindings.cpp
+++ b/src/tesseract_task_composer/tesseract_task_composer_bindings.cpp
@@ -9,6 +9,8 @@
 #include <nanobind/stl/chrono.h>
 #include <nanobind/stl/optional.h>
 
+#include <boost/uuid/uuid_io.hpp>
+
 #include <fstream>
 #include <sstream>
 
@@ -152,47 +154,31 @@ NB_MODULE(_tesseract_task_composer, m) {
 
     // ========== TaskComposerNodeInfo ==========
     nb::class_<tp::TaskComposerNodeInfo>(m, "TaskComposerNodeInfo")
+        .def_prop_ro("uuid", [](const tp::TaskComposerNodeInfo& self) { return boost::uuids::to_string(self.uuid); })
+        .def_prop_ro("parent_uuid", [](const tp::TaskComposerNodeInfo& self) { return boost::uuids::to_string(self.parent_uuid); })
         .def_prop_ro("name", [](const tp::TaskComposerNodeInfo& self) { return self.name; })
         .def_prop_ro("return_value", [](const tp::TaskComposerNodeInfo& self) { return self.return_value; })
         .def_prop_ro("status_code", [](const tp::TaskComposerNodeInfo& self) { return self.status_code; })
         .def_prop_ro("status_message", [](const tp::TaskComposerNodeInfo& self) { return self.status_message; })
         .def_prop_ro("elapsed_time", [](const tp::TaskComposerNodeInfo& self) { return self.elapsed_time; })
+        .def_prop_ro("data_storage", [](const tp::TaskComposerNodeInfo& self) { return self.data_storage; })
         .def_prop_ro("dotgraph", [](const tp::TaskComposerNodeInfo& self) { return self.dotgraph; });
 
     // ========== TaskComposerNodeInfoContainer ==========
     nb::class_<tp::TaskComposerNodeInfoContainer>(m, "TaskComposerNodeInfoContainer")
         .def(nb::init<>())
-        .def("getAbortingNodeInfo", [](const tp::TaskComposerNodeInfoContainer& self) -> nb::object {
+        .def("getAbortingNodeInfo", [](const tp::TaskComposerNodeInfoContainer& self) -> std::optional<tp::TaskComposerNodeInfo> {
             auto uuid = self.getAbortingNode();
             if (uuid.is_nil())
-                return nb::none();
-            auto info = self.getInfo(uuid);
-            if (!info.has_value())
-                return nb::none();
-            // Return a dict with the info (0.33: getInfo returns optional<value> not pointer)
-            nb::dict result;
-            result["name"] = info->name;
-            result["return_value"] = info->return_value;
-            result["status_code"] = info->status_code;
-            result["status_message"] = info->status_message;
-            result["elapsed_time"] = info->elapsed_time;
-            result["data_storage"] = info->data_storage;
-            return result;
+                return std::nullopt;
+            return self.getInfo(uuid);
         })
-        .def("getAllInfos", [](const tp::TaskComposerNodeInfoContainer& self) -> nb::list {
-            nb::list result;
+        .def("getAllInfos", [](const tp::TaskComposerNodeInfoContainer& self) -> std::vector<tp::TaskComposerNodeInfo> {
             auto info_map = self.getInfoMap();
-            // 0.33: getInfoMap returns map of values, not pointers
-            for (const auto& [uuid, info] : info_map) {
-                nb::dict d;
-                d["name"] = info.name;
-                d["return_value"] = info.return_value;
-                d["status_code"] = info.status_code;
-                d["status_message"] = info.status_message;
-                d["elapsed_time"] = info.elapsed_time;
-                d["data_storage"] = info.data_storage;
-                result.append(d);
-            }
+            std::vector<tp::TaskComposerNodeInfo> result;
+            result.reserve(info_map.size());
+            for (auto& [uuid, info] : info_map)
+                result.push_back(std::move(info));
             return result;
         });
 

--- a/tests/tesseract_task_composer/test_tesseract_task_composer.py
+++ b/tests/tesseract_task_composer/test_tesseract_task_composer.py
@@ -9,6 +9,7 @@ import pytest
 import tesseract_robotics
 from tesseract_robotics.tesseract_common import FilesystemPath, GeneralResourceLocator
 from tesseract_robotics.tesseract_task_composer import (
+    TaskComposerNodeInfo,
     TaskComposerNodeInfoContainer,
     TaskComposerPluginFactory,
 )
@@ -490,16 +491,6 @@ class TestPipelineDataStorageExposure:
         del composer
         gc.collect()
 
-    def test_node_info_dict_exposes_data_storage(self, pipeline_run):
-        """Every node info dict from getAllInfos should carry a 'data_storage'
-        entry — the binding that 994bee3 added."""
-        infos = pipeline_run
-        assert len(infos) > 0, "Pipeline produced no node infos"
-        for info in infos:
-            assert "data_storage" in info, (
-                f"Node {info.get('name')!r} info dict missing 'data_storage' key"
-            )
-
     def test_discrete_contact_check_data_storage_yields_contact_results(
         self, pipeline_run
     ):
@@ -510,13 +501,11 @@ class TestPipelineDataStorageExposure:
             AnyPoly_as_ContactResultMapVector,
         )
 
-        infos = pipeline_run
-        contact_check_infos = [
-            i for i in infos if "DiscreteContactCheck" in (i.get("name") or "")
-        ]
+        infos: list[TaskComposerNodeInfo] = pipeline_run
+        contact_check_infos = [i for i in infos if "DiscreteContactCheck" in (i.name or "")]
         assert contact_check_infos, "DiscreteContactCheckTask did not run"
 
-        ds = contact_check_infos[0]["data_storage"]
+        ds = contact_check_infos[0].data_storage
         assert ds is not None
         all_data = ds.getAllData()
         assert "contact_results" in all_data, (


### PR DESCRIPTION
BREAKING_CHANGE: this returns properly typed TaskComposerNodeInfo objects instead of dicts. Callsites will need to update to use property access syntax instead of dict-keys syntax