### PR TITLE
feat(descartes): add ability to create custom evaluators/sampler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - contributed by [@Joelkang]
 
   - `Octree` geometry bindings (plus `octomap::OcTree`, `OctreeSubType`, `PointCloud`, `createOctree`) and the remaining `tesseract_geometry` utilities (`isIdentical`, `extractVertices`, `toTriangleMesh`).
+  - **Python-subclassable Descartes evaluators/sampler/profile** for `tesseract_motion_planners_descartes`. New bindings for `DescartesStateD`, `DescartesStateSampleD`, `DescartesEdgeEvaluatorD`, `DescartesWaypointSamplerD`, `DescartesStateEvaluatorD`, and a now-subclassable `DescartesMoveProfileD` let users override `createWaypointSampler` / `createEdgeEvaluator` / `createStateEvaluator` from Python.
 
 ## [0.34.1.7] - 2026-05-09 — command_language I/O instructions + TaskComposer introspection
 

--- a/docs/user-guide/planning.md
+++ b/docs/user-guide/planning.md
@@ -325,6 +325,99 @@ profiles = create_descartes_default_profiles(
 result = plan_cartesian(robot, program, profiles=profiles)
 ```
 
+### Custom Edge / State Evaluators in Python
+
+When the default cost function (joint-space distance) does not fully satisfy your
+requirements, you can subclass the evaluator interfaces directly in Python to
+tweak how Descartes picks the right IK branch. Examples include penalizing wrist
+flips, weighting specific joints, or scoring edges using an external signal.
+
+The three extension points are:
+
+| Class | Override | When it runs |
+|-------|----------|--------------|
+| `DescartesWaypointSamplerD` | `sample() -> list[DescartesStateSampleD]` | Generating IK candidates for a waypoint |
+| `DescartesEdgeEvaluatorD` | `evaluate(start, end) -> (valid, cost)` | Edge between two graph states |
+| `DescartesStateEvaluatorD` | `evaluate(state) -> (valid, cost)` | Per-state cost |
+
+To inject them into the planner, subclass `DescartesMoveProfileD` and
+return your custom objects from the three factory methods. Delegate the
+ones you don't want to customize to an inner `DescartesDefaultMoveProfileD`:
+
+```python
+import numpy as np
+from tesseract_robotics.tesseract_motion_planners_descartes import (
+    DescartesDefaultMoveProfileD,
+    DescartesEdgeEvaluatorD,
+    DescartesMoveProfileD,
+    cast_DescartesMoveProfileD,
+)
+
+class WristFlipPenaltyEvaluator(DescartesEdgeEvaluatorD):
+    """Cost = L2 joint delta + large penalty for >90 deg wrist swing."""
+
+    def evaluate(self, start, end):
+        delta = end.values - start.values
+        cost = float(np.linalg.norm(delta))
+        if abs(delta[-1]) > np.pi / 2:   # wrist joint flip
+            return (False, cost)         # reject this edge
+        return (True, cost)
+
+
+class MyMoveProfile(DescartesMoveProfileD):
+    def __init__(self):
+        super().__init__()
+        self._inner = DescartesDefaultMoveProfileD()
+        # Hold evaluators on self so the planner sees the same instance
+        # across all edge evaluations.
+        self._edge_evaluator = WristFlipPenaltyEvaluator()
+
+    def createWaypointSampler(self, move_instruction, composite_manip_info, env):
+        return self._inner.createWaypointSampler(move_instruction, composite_manip_info, env)
+
+    def createEdgeEvaluator(self, move_instruction, composite_manip_info, env):
+        return self._edge_evaluator
+
+    def createStateEvaluator(self, move_instruction, composite_manip_info, env):
+        return self._inner.createStateEvaluator(move_instruction, composite_manip_info, env)
+```
+
+The `start` and `end` arguments to `evaluate` are `DescartesStateD`
+objects with a `.values` attribute that is a 1-D numpy array of joint
+positions in the manipulator's joint order.
+
+Then, register the profile in the `ProfileDictionary` the same way you would a
+C++ profile, using `cast_DescartesMoveProfileD` to coerce it to the
+base `Profile` type:
+
+```python
+from tesseract_robotics.tesseract_command_language import ProfileDictionary
+
+profiles = ProfileDictionary()
+profiles.addProfile(
+    "DescartesMotionPlannerTask",          # namespace
+    "MY_PROFILE",                          # profile name (referenced by MoveInstruction)
+    cast_DescartesMoveProfileD(MyMoveProfile()),
+)
+```
+
+
+
+!!! warning "Threading and the GIL"
+    Each call back into Python acquires the GIL, so OpenMP-parallel
+    edge evaluation inside Descartes is serialized through your Python
+    evaluator. If you set `num_threads > 1`, the cost computation
+    itself runs single-threaded — only IK sampling parallelizes. Keep
+    the Python evaluate body tight (numpy ops, no allocations) for best
+    throughput.
+
+!!! tip "Use for joint-continuity across rasters"
+    A custom edge evaluator is the cleanest way to globally enforce
+    IK-branch consistency across an entire raster program — the raster
+    pipeline itself does **not** backtrack on a downstream transition
+    failure, so picking compatible IK solutions during Descartes is the
+    only reliable solution.
+
 ## Motion Types
 
 Motion type is set via the `MotionProgram` builder methods:

--- a/src/tesseract_motion_planners_descartes/tesseract_motion_planners_descartes_bindings.cpp
+++ b/src/tesseract_motion_planners_descartes/tesseract_motion_planners_descartes_bindings.cpp
@@ -23,11 +23,159 @@
 #include <tesseract_motion_planners/descartes/profile/descartes_default_move_profile.h>
 #include <tesseract_motion_planners/descartes/profile/descartes_ladder_graph_solver_profile.h>
 
+// descartes_light core types (needed for Python-side subclassing)
+#include <descartes_light/types.h>
+#include <descartes_light/core/edge_evaluator.h>
+#include <descartes_light/core/waypoint_sampler.h>
+#include <descartes_light/core/state_evaluator.h>
+
+// tesseract dependencies referenced by profile method signatures
+#include <tesseract_command_language/poly/move_instruction_poly.h>
+#include <tesseract_common/manipulator_info.h>
+#include <tesseract_environment/environment.h>
+
 // tesseract_collision for CollisionCheckConfig
 #include <tesseract_collision/core/types.h>
 
 namespace tp = tesseract_planning;
 namespace tc = tesseract_common;
+namespace dl = descartes_light;
+
+// ------------------------------------------------------------------
+// Trampolines so Python can subclass the descartes_light interfaces.
+// ------------------------------------------------------------------
+
+class PyEdgeEvaluatorD : public dl::EdgeEvaluator<double> {
+public:
+    NB_TRAMPOLINE(dl::EdgeEvaluator<double>, 1);
+
+    std::pair<bool, double>
+    evaluate(const dl::State<double>& start, const dl::State<double>& end) const override {
+        NB_OVERRIDE_PURE(evaluate, start, end);
+    }
+};
+
+class PyWaypointSamplerD : public dl::WaypointSampler<double> {
+public:
+    NB_TRAMPOLINE(dl::WaypointSampler<double>, 1);
+
+    std::vector<dl::StateSample<double>> sample() const override {
+        NB_OVERRIDE_PURE(sample);
+    }
+};
+
+class PyStateEvaluatorD : public dl::StateEvaluator<double> {
+public:
+    NB_TRAMPOLINE(dl::StateEvaluator<double>, 1);
+
+    std::pair<bool, double> evaluate(const dl::State<double>& solution) const override {
+        NB_OVERRIDE(evaluate, solution);
+    }
+};
+
+// Shim C++ EdgeEvaluator/WaypointSampler/StateEvaluator that hold a Python
+// reference and forward calls. These exist so that when a Python-side
+// DescartesMoveProfileD subclass returns a Python object from createXxx,
+// we can hand back a `std::unique_ptr<...>` to C++ without trying to
+// transfer ownership of a Python-allocated instance (which nanobind cannot
+// do with the default deleter).
+class PyHeldEdgeEvaluatorD : public dl::EdgeEvaluator<double> {
+public:
+    explicit PyHeldEdgeEvaluatorD(nb::object obj) : obj_(std::move(obj)) {}
+    ~PyHeldEdgeEvaluatorD() override {
+        nb::gil_scoped_acquire gil;
+        obj_.reset();
+    }
+
+    std::pair<bool, double>
+    evaluate(const dl::State<double>& start, const dl::State<double>& end) const override {
+        nb::gil_scoped_acquire gil;
+        return nb::cast<std::pair<bool, double>>(
+            obj_.attr("evaluate")(nb::cast(&start, nb::rv_policy::reference),
+                                  nb::cast(&end, nb::rv_policy::reference)));
+    }
+
+private:
+    nb::object obj_;
+};
+
+class PyHeldWaypointSamplerD : public dl::WaypointSampler<double> {
+public:
+    explicit PyHeldWaypointSamplerD(nb::object obj) : obj_(std::move(obj)) {}
+    ~PyHeldWaypointSamplerD() override {
+        nb::gil_scoped_acquire gil;
+        obj_.reset();
+    }
+
+    std::vector<dl::StateSample<double>> sample() const override {
+        nb::gil_scoped_acquire gil;
+        return nb::cast<std::vector<dl::StateSample<double>>>(obj_.attr("sample")());
+    }
+
+private:
+    nb::object obj_;
+};
+
+class PyHeldStateEvaluatorD : public dl::StateEvaluator<double> {
+public:
+    explicit PyHeldStateEvaluatorD(nb::object obj) : obj_(std::move(obj)) {}
+    ~PyHeldStateEvaluatorD() override {
+        nb::gil_scoped_acquire gil;
+        obj_.reset();
+    }
+
+    std::pair<bool, double> evaluate(const dl::State<double>& solution) const override {
+        nb::gil_scoped_acquire gil;
+        return nb::cast<std::pair<bool, double>>(
+            obj_.attr("evaluate")(nb::cast(&solution, nb::rv_policy::reference)));
+    }
+
+private:
+    nb::object obj_;
+};
+
+// Trampoline for the move profile itself - lets Python supply custom
+// waypoint samplers / edge evaluators / state evaluators via subclassing.
+// All three create* overrides wrap the Python return value in a C++ shim.
+// This handles both cases uniformly:
+//   - Python returns a Python subclass instance (Python owns the C++ obj)
+//   - Python returns a C++-origin wrapper (e.g. delegated to a default profile)
+// In the second case the shim's dispatch goes Python -> nanobind -> C++ as
+// a normal virtual call, which is a one-time extra hop per shim call.
+class PyDescartesMoveProfileD : public tp::DescartesMoveProfile<double> {
+public:
+    NB_TRAMPOLINE(tp::DescartesMoveProfile<double>, 3);
+
+    std::unique_ptr<dl::WaypointSampler<double>>
+    createWaypointSampler(const tp::MoveInstructionPoly& move_instruction,
+                          const tc::ManipulatorInfo& composite_manip_info,
+                          const std::shared_ptr<const tesseract_environment::Environment>& env) const override {
+        nb::detail::ticket t(nb_trampoline, "createWaypointSampler", true);
+        nb::object py_result = nb::borrow<nb::object>(
+            nb_trampoline.base().attr(t.key)(move_instruction, composite_manip_info, env));
+        return std::make_unique<PyHeldWaypointSamplerD>(std::move(py_result));
+    }
+
+    std::unique_ptr<dl::EdgeEvaluator<double>>
+    createEdgeEvaluator(const tp::MoveInstructionPoly& move_instruction,
+                        const tc::ManipulatorInfo& composite_manip_info,
+                        const std::shared_ptr<const tesseract_environment::Environment>& env) const override {
+        nb::detail::ticket t(nb_trampoline, "createEdgeEvaluator", true);
+        nb::object py_result = nb::borrow<nb::object>(
+            nb_trampoline.base().attr(t.key)(move_instruction, composite_manip_info, env));
+        return std::make_unique<PyHeldEdgeEvaluatorD>(std::move(py_result));
+    }
+
+    std::unique_ptr<dl::StateEvaluator<double>>
+    createStateEvaluator(const tp::MoveInstructionPoly& move_instruction,
+                         const tc::ManipulatorInfo& composite_manip_info,
+                         const std::shared_ptr<const tesseract_environment::Environment>& env) const override {
+        nb::detail::ticket t(nb_trampoline, "createStateEvaluator", true);
+        nb::object py_result = nb::borrow<nb::object>(
+            nb_trampoline.base().attr(t.key)(move_instruction, composite_manip_info, env));
+        return std::make_unique<PyHeldStateEvaluatorD>(std::move(py_result));
+    }
+};
 
 NB_MODULE(_tesseract_motion_planners_descartes, m) {
     m.doc() = "tesseract_motion_planners_descartes Python bindings";
@@ -40,6 +188,42 @@ NB_MODULE(_tesseract_motion_planners_descartes, m) {
 
     // Import MotionPlanner base type for clone() return type
     nb::module_::import_("tesseract_robotics.tesseract_motion_planners._tesseract_motion_planners");
+
+    // ========== descartes_light::State<double> ==========
+    // Python-readable view of a Descartes state. Constructable from a numpy
+    // vector so Python-side StateEvaluator/WaypointSampler subclasses can
+    // produce one.
+    nb::class_<dl::State<double>>(m, "DescartesStateD")
+        .def(nb::init<>())
+        .def("__init__", [](dl::State<double>* self, const Eigen::Ref<const Eigen::VectorXd>& v) {
+            new (self) dl::State<double>(v);
+        }, "values"_a)
+        .def_rw("values", &dl::State<double>::values);
+
+    // ========== descartes_light::StateSample<double> ==========
+    nb::class_<dl::StateSample<double>>(m, "DescartesStateSampleD")
+        .def(nb::init<>())
+        .def(nb::init<std::shared_ptr<const dl::State<double>>, double>(), "state"_a, "cost"_a)
+        .def_rw("state", &dl::StateSample<double>::state)
+        .def_rw("cost", &dl::StateSample<double>::cost);
+
+    // ========== descartes_light::EdgeEvaluator<double> ==========
+    nb::class_<dl::EdgeEvaluator<double>, PyEdgeEvaluatorD>(m, "DescartesEdgeEvaluatorD")
+        .def(nb::init<>())
+        .def("evaluate", &dl::EdgeEvaluator<double>::evaluate, "start"_a, "end"_a,
+             "Returns (is_valid, cost) for the edge between two states");
+
+    // ========== descartes_light::WaypointSampler<double> ==========
+    nb::class_<dl::WaypointSampler<double>, PyWaypointSamplerD>(m, "DescartesWaypointSamplerD")
+        .def(nb::init<>())
+        .def("sample", &dl::WaypointSampler<double>::sample,
+             "Return the list of valid state samples for this waypoint");
+
+    // ========== descartes_light::StateEvaluator<double> ==========
+    nb::class_<dl::StateEvaluator<double>, PyStateEvaluatorD>(m, "DescartesStateEvaluatorD")
+        .def(nb::init<>())
+        .def("evaluate", &dl::StateEvaluator<double>::evaluate, "solution"_a,
+             "Returns (is_valid, cost) for a state");
 
     // ========== DescartesSolverProfile<double> (base for solver profiles) ==========
     nb::class_<tp::DescartesSolverProfile<double>, tc::Profile>(m, "DescartesSolverProfileD")
@@ -58,8 +242,24 @@ NB_MODULE(_tesseract_motion_planners_descartes, m) {
     "Cast DescartesLadderGraphSolverProfileD to Profile for use with ProfileDictionary");
 
     // ========== DescartesMoveProfile<double> (base, was DescartesPlanProfile) ==========
-    nb::class_<tp::DescartesMoveProfile<double>, tc::Profile>(m, "DescartesMoveProfileD")
-        .def("getKey", &tp::DescartesMoveProfile<double>::getKey);
+    // Python users may subclass this and override createWaypointSampler/
+    // createEdgeEvaluator/createStateEvaluator to plug in custom logic.
+    nb::class_<tp::DescartesMoveProfile<double>, tc::Profile, PyDescartesMoveProfileD>(m, "DescartesMoveProfileD")
+        .def(nb::init<>())
+        .def("getKey", &tp::DescartesMoveProfile<double>::getKey)
+        .def("createWaypointSampler", &tp::DescartesMoveProfile<double>::createWaypointSampler,
+             "move_instruction"_a, "composite_manip_info"_a, "env"_a)
+        .def("createEdgeEvaluator", &tp::DescartesMoveProfile<double>::createEdgeEvaluator,
+             "move_instruction"_a, "composite_manip_info"_a, "env"_a)
+        .def("createStateEvaluator", &tp::DescartesMoveProfile<double>::createStateEvaluator,
+             "move_instruction"_a, "composite_manip_info"_a, "env"_a);
+
+    // Helper to cast a Python (or C++) DescartesMoveProfileD subclass to Profile
+    // for ProfileDictionary insertion.
+    m.def("cast_DescartesMoveProfileD", [](std::shared_ptr<tp::DescartesMoveProfile<double>> profile) {
+        return std::static_pointer_cast<tc::Profile>(profile);
+    }, "profile"_a,
+    "Cast a DescartesMoveProfileD (including Python subclasses) to Profile for use with ProfileDictionary");
 
     // SWIG-compatible alias
     m.attr("DescartesPlanProfileD") = m.attr("DescartesMoveProfileD");
@@ -84,17 +284,11 @@ NB_MODULE(_tesseract_motion_planners_descartes, m) {
     // SWIG-compatible alias
     m.attr("DescartesDefaultPlanProfileD") = m.attr("DescartesDefaultMoveProfileD");
 
-    // Helper to cast DescartesDefaultMoveProfileD to Profile
-    m.def("cast_DescartesMoveProfileD", [](std::shared_ptr<tp::DescartesDefaultMoveProfile<double>> profile) {
+    // Legacy alias for cast_DescartesMoveProfileD
+    m.def("cast_DescartesPlanProfileD", [](std::shared_ptr<tp::DescartesMoveProfile<double>> profile) {
         return std::static_pointer_cast<tc::Profile>(profile);
     }, "profile"_a,
-    "Cast DescartesDefaultMoveProfileD to Profile for use with ProfileDictionary");
-
-    // Legacy alias
-    m.def("cast_DescartesPlanProfileD", [](std::shared_ptr<tp::DescartesDefaultMoveProfile<double>> profile) {
-        return std::static_pointer_cast<tc::Profile>(profile);
-    }, "profile"_a,
-    "Cast DescartesDefaultPlanProfileD to Profile (legacy alias)");
+    "Cast a DescartesMoveProfileD to Profile (legacy alias of cast_DescartesMoveProfileD)");
 
     // ========== DescartesMotionPlanner<double> ==========
     nb::class_<tp::DescartesMotionPlanner<double>>(m, "DescartesMotionPlannerD")

--- a/src/tesseract_robotics/tesseract_motion_planners_descartes/__init__.py
+++ b/src/tesseract_robotics/tesseract_motion_planners_descartes/__init__.py
@@ -2,11 +2,19 @@
 from ._tesseract_motion_planners_descartes import *
 
 __all__ = [
+    "DescartesDefaultMoveProfileD",
     "DescartesDefaultPlanProfileD",
+    "DescartesEdgeEvaluatorD",
     "DescartesLadderGraphSolverProfileD",
     "DescartesMotionPlannerD",
+    "DescartesMoveProfileD",
     "DescartesPlanProfileD",
     "DescartesSolverProfileD",
+    "DescartesStateD",
+    "DescartesStateEvaluatorD",
+    "DescartesStateSampleD",
+    "DescartesWaypointSamplerD",
+    "cast_DescartesMoveProfileD",
     "cast_DescartesPlanProfileD",
     "cast_DescartesSolverProfileD",
 ]

--- a/src/tesseract_robotics/tesseract_motion_planners_descartes/_tesseract_motion_planners_descartes.pyi
+++ b/src/tesseract_robotics/tesseract_motion_planners_descartes/_tesseract_motion_planners_descartes.pyi
@@ -1,12 +1,65 @@
-from typing import Annotated, TypeAlias
+"""tesseract_motion_planners_descartes Python bindings"""
+
+from typing import Annotated, TypeAlias, overload
 
 import numpy
 from numpy.typing import NDArray
 
 import tesseract_robotics.tesseract_collision._tesseract_collision
 import tesseract_robotics.tesseract_command_language._tesseract_command_language
+import tesseract_robotics.tesseract_common._tesseract_common
 import tesseract_robotics.tesseract_motion_planners._tesseract_motion_planners
 
+
+class DescartesStateD:
+    @overload
+    def __init__(self) -> None: ...
+
+    @overload
+    def __init__(self, values: Annotated[NDArray[numpy.float64], dict(shape=(None,), writable=False)]) -> None: ...
+
+    @property
+    def values(self) -> Annotated[NDArray[numpy.float64], dict(shape=(None,), order='C')]: ...
+
+    @values.setter
+    def values(self, arg: Annotated[NDArray[numpy.float64], dict(shape=(None,), order='C')], /) -> None: ...
+
+class DescartesStateSampleD:
+    @overload
+    def __init__(self) -> None: ...
+
+    @overload
+    def __init__(self, state: DescartesStateD, cost: float) -> None: ...
+
+    @property
+    def state(self) -> DescartesStateD: ...
+
+    @state.setter
+    def state(self, arg: DescartesStateD, /) -> None: ...
+
+    @property
+    def cost(self) -> float: ...
+
+    @cost.setter
+    def cost(self, arg: float, /) -> None: ...
+
+class DescartesEdgeEvaluatorD:
+    def __init__(self) -> None: ...
+
+    def evaluate(self, start: DescartesStateD, end: DescartesStateD) -> tuple[bool, float]:
+        """Returns (is_valid, cost) for the edge between two states"""
+
+class DescartesWaypointSamplerD:
+    def __init__(self) -> None: ...
+
+    def sample(self) -> list[DescartesStateSampleD]:
+        """Return the list of valid state samples for this waypoint"""
+
+class DescartesStateEvaluatorD:
+    def __init__(self) -> None: ...
+
+    def evaluate(self, solution: DescartesStateD) -> tuple[bool, float]:
+        """Returns (is_valid, cost) for a state"""
 
 class DescartesSolverProfileD(tesseract_robotics.tesseract_command_language._tesseract_command_language.Profile):
     def getKey(self) -> int: ...
@@ -27,7 +80,20 @@ def cast_DescartesSolverProfileD(profile: DescartesLadderGraphSolverProfileD) ->
     """
 
 class DescartesMoveProfileD(tesseract_robotics.tesseract_command_language._tesseract_command_language.Profile):
+    def __init__(self) -> None: ...
+
     def getKey(self) -> int: ...
+
+    def createWaypointSampler(self, move_instruction: tesseract_robotics.tesseract_command_language._tesseract_command_language.MoveInstructionPoly, composite_manip_info: tesseract_robotics.tesseract_common._tesseract_common.ManipulatorInfo, env: "tesseract_environment::Environment") -> DescartesWaypointSamplerD: ...
+
+    def createEdgeEvaluator(self, move_instruction: tesseract_robotics.tesseract_command_language._tesseract_command_language.MoveInstructionPoly, composite_manip_info: tesseract_robotics.tesseract_common._tesseract_common.ManipulatorInfo, env: "tesseract_environment::Environment") -> DescartesEdgeEvaluatorD: ...
+
+    def createStateEvaluator(self, move_instruction: tesseract_robotics.tesseract_command_language._tesseract_command_language.MoveInstructionPoly, composite_manip_info: tesseract_robotics.tesseract_common._tesseract_common.ManipulatorInfo, env: "tesseract_environment::Environment") -> DescartesStateEvaluatorD: ...
+
+def cast_DescartesMoveProfileD(profile: DescartesMoveProfileD) -> tesseract_robotics.tesseract_command_language._tesseract_command_language.Profile:
+    """
+    Cast a DescartesMoveProfileD (including Python subclasses) to Profile for use with ProfileDictionary
+    """
 
 DescartesPlanProfileD: TypeAlias = DescartesMoveProfileD
 
@@ -114,13 +180,10 @@ class DescartesDefaultMoveProfileD(DescartesMoveProfileD):
 
 DescartesDefaultPlanProfileD: TypeAlias = DescartesDefaultMoveProfileD
 
-def cast_DescartesMoveProfileD(profile: DescartesDefaultMoveProfileD) -> tesseract_robotics.tesseract_command_language._tesseract_command_language.Profile:
+def cast_DescartesPlanProfileD(profile: DescartesMoveProfileD) -> tesseract_robotics.tesseract_command_language._tesseract_command_language.Profile:
     """
-    Cast DescartesDefaultMoveProfileD to Profile for use with ProfileDictionary
+    Cast a DescartesMoveProfileD to Profile (legacy alias of cast_DescartesMoveProfileD)
     """
-
-def cast_DescartesPlanProfileD(profile: DescartesDefaultMoveProfileD) -> tesseract_robotics.tesseract_command_language._tesseract_command_language.Profile:
-    """Cast DescartesDefaultPlanProfileD to Profile (legacy alias)"""
 
 class DescartesMotionPlannerD:
     def __init__(self, name: str) -> None: ...

--- a/tests/tesseract_motion_planners/test_descartes_planner.py
+++ b/tests/tesseract_motion_planners/test_descartes_planner.py
@@ -29,8 +29,12 @@ from tesseract_robotics.tesseract_motion_planners_simple import generateInterpol
 # Descartes imports - skip tests if not available
 try:
     from tesseract_robotics.tesseract_motion_planners_descartes import (
+        DescartesDefaultMoveProfileD,
         DescartesDefaultPlanProfileD,
+        DescartesEdgeEvaluatorD,
         DescartesMotionPlannerD,
+        DescartesMoveProfileD,
+        cast_DescartesMoveProfileD,
         cast_DescartesPlanProfileD,
     )
 
@@ -200,3 +204,95 @@ class TestDescartesPlanning:
                     assert len(state_wp.getPosition()) == 6
                 count += 1
         assert count > 0, "Expected at least one move instruction in results"
+
+
+class TestPythonEdgeEvaluator:
+    """End-to-end test of a Python-side custom EdgeEvaluator plugged into a
+    Python-side DescartesMoveProfileD subclass."""
+
+    def test_custom_python_edge_evaluator_is_called(self, abb_irb2400_environment):
+        env, manip_info, _ = abb_irb2400_environment
+
+        # Counter visible across all instances; cheap way to prove the C++
+        # planner called back into our Python evaluate() during the solve.
+        call_counter = {"n": 0}
+
+        class JointDistanceEdgeEvaluator(DescartesEdgeEvaluatorD):
+            """Cost = L2 norm of joint-space delta; always valid."""
+
+            def evaluate(self, start, end):
+                call_counter["n"] += 1
+                delta = end.values - start.values
+                cost = float(np.linalg.norm(delta))
+                return (True, cost)
+
+        class PythonMoveProfile(DescartesMoveProfileD):
+            """Delegates sampling/state-evaluation to the default profile,
+            but supplies a Python EdgeEvaluator."""
+
+            def __init__(self):
+                super().__init__()
+                self._inner = DescartesDefaultMoveProfileD()
+                # Keep evaluators alive on the profile so the planner sees
+                # the same Python instance for every edge it evaluates.
+                self._edge_evaluator = JointDistanceEdgeEvaluator()
+
+            def createWaypointSampler(self, move_instruction, composite_manip_info, env):
+                return self._inner.createWaypointSampler(move_instruction, composite_manip_info, env)
+
+            def createEdgeEvaluator(self, move_instruction, composite_manip_info, env):
+                return self._edge_evaluator
+
+            def createStateEvaluator(self, move_instruction, composite_manip_info, env):
+                return self._inner.createStateEvaluator(move_instruction, composite_manip_info, env)
+
+        # Build the same fixed-pose program as the default-profile test.
+        wp1 = CartesianWaypoint(
+            Isometry3d.Identity()
+            * Translation3d(0.8, -0.2, 0.8)
+            * Quaterniond.from_xyzw(0, -1.0, 0, 0)
+        )
+        wp2 = CartesianWaypoint(
+            Isometry3d.Identity()
+            * Translation3d(0.8, 0.2, 0.8)
+            * Quaterniond.from_xyzw(0, -1.0, 0, 0)
+        )
+
+        start_instruction = MoveInstruction(
+            CartesianWaypointPoly_wrap_CartesianWaypoint(wp1),
+            MoveInstructionType_LINEAR,
+            "PY_EDGE_PROFILE",
+        )
+        start_instruction.setManipulatorInfo(manip_info)
+
+        plan_f1 = MoveInstruction(
+            CartesianWaypointPoly_wrap_CartesianWaypoint(wp2),
+            MoveInstructionType_LINEAR,
+            "PY_EDGE_PROFILE",
+        )
+        plan_f1.setManipulatorInfo(manip_info)
+
+        program = CompositeInstruction()
+        program.setManipulatorInfo(manip_info)
+        program.appendMoveInstruction(MoveInstructionPoly_wrap_MoveInstruction(start_instruction))
+        program.appendMoveInstruction(MoveInstructionPoly_wrap_MoveInstruction(plan_f1))
+
+        interpolated_program = generateInterpolatedProgram(program, env, 3.14, 1.0, 3.14, 10)
+
+        py_profile = PythonMoveProfile()
+        profiles = ProfileDictionary()
+        profiles.addProfile(
+            DESCARTES_DEFAULT_NAMESPACE,
+            "PY_EDGE_PROFILE",
+            cast_DescartesMoveProfileD(py_profile),
+        )
+
+        planner = DescartesMotionPlannerD(DESCARTES_DEFAULT_NAMESPACE)
+        request = PlannerRequest()
+        request.instructions = interpolated_program
+        request.env = env
+        request.profiles = profiles
+
+        response = planner.solve(request)
+        assert response.successful, f"Descartes planning failed: {response.message}"
+        assert call_counter["n"] > 0, "Python EdgeEvaluator.evaluate() was never called by the planner"


### PR DESCRIPTION
I believe the shim is required because a user may only replace one but not all of the evaluators/sampler so some might be in python while others might be in C++