### PR TITLE
deps: update to tesseract 0.35.0

### DIFF
--- a/.github/workflows/wheels-linux.yml
+++ b/.github/workflows/wheels-linux.yml
@@ -137,7 +137,7 @@ jobs:
         PLUGINS=(
           libtesseract_collision_bullet_factories.so
           libtesseract_collision_fcl_factories.so
-          libtesseract_kinematics_core_factories.so
+          libtesseract_kinematics_factories.so
           libtesseract_kinematics_kdl_factories.so
           libtesseract_kinematics_opw_factory.so
           libtesseract_kinematics_ur_factory.so

--- a/.github/workflows/wheels-linux.yml
+++ b/.github/workflows/wheels-linux.yml
@@ -164,7 +164,7 @@ jobs:
 
         # Remove search_paths from robot YAMLs (forces use of env vars set by __init__.py)
         echo "Removing hardcoded search_paths from robot YAMLs..."
-        find "$WHEEL_DIR/tesseract_robotics/data/tesseract_support" -name "*.yaml" -type f | while read yaml_file; do
+        find "$WHEEL_DIR/tesseract_robotics/data/tesseract/support" -name "*.yaml" -type f | while read yaml_file; do
           if grep -q 'search_paths:' "$yaml_file"; then
             sed -i '/search_paths:/d; /^[[:space:]]*- \/.*$/d' "$yaml_file"
             echo "  Removed search_paths from: $(basename $yaml_file)"

--- a/.github/workflows/wheels-linux.yml
+++ b/.github/workflows/wheels-linux.yml
@@ -72,14 +72,22 @@ jobs:
     - name: patch upstream missing includes
       working-directory: ws/src
       run: |
-        # tesseract_planning 0.34.0 uses std::runtime_error without #include <stdexcept>
-        # Works on macOS (transitive include) but fails on Linux GCC
-        find tesseract_planning -name '*.h' -path '*/poly/*' | xargs grep -l 'std::runtime_error' | while read f; do
-          if ! grep -q '#include <stdexcept>' "$f"; then
-            sed -i '/#include <string>/a #include <stdexcept>' "$f"
-            echo "  patched: $f"
-          fi
-        done
+        # 0.35 consolidation moved std::runtime_error usages into many more
+        # files (now in tesseract/common/any_poly.h plus 70+ .cpp files across
+        # tesseract_planning). macOS/MSVC pull <stdexcept> in transitively;
+        # Linux GCC is stricter and fails. The 0.34-era patch anchored on
+        # `#include <string>` which no longer matches — switch to inserting
+        # after the FIRST existing #include <...> line, which every affected
+        # file has.
+        find tesseract tesseract_planning \( -name '*.h' -o -name '*.hpp' -o -name '*.cpp' \) -print0 \
+          | xargs -0 grep -l 'std::runtime_error' \
+          | while read f; do
+              if ! grep -q '#include <stdexcept>' "$f"; then
+                awk 'BEGIN{added=0} /^#include </ && !added {print; print "#include <stdexcept>"; added=1; next} {print}' "$f" > "$f.new"
+                mv "$f.new" "$f"
+                echo "  patched: $f"
+              fi
+            done
     - name: cache colcon build
       uses: actions/cache@v4
       id: colcon-cache

--- a/.github/workflows/wheels-linux.yml
+++ b/.github/workflows/wheels-linux.yml
@@ -65,10 +65,10 @@ jobs:
           ws/src/descartes_light
           ws/src/opw_kinematics
           ws/src/ruckig
-        key: vcs-${{ hashFiles('ws/src/tesseract_nanobind/dependencies.rosinstall') }}
+        key: vcs-${{ hashFiles('ws/src/tesseract_nanobind/dependencies.repos') }}
     - name: vcs import
       working-directory: ws/src
-      run: vcs import --input tesseract_nanobind/dependencies.rosinstall --skip-existing
+      run: vcs import --input tesseract_nanobind/dependencies.repos --skip-existing
     - name: patch upstream missing includes
       working-directory: ws/src
       run: |
@@ -85,7 +85,7 @@ jobs:
       id: colcon-cache
       with:
         path: ws/install
-        key: colcon-linux-v11-py${{ matrix.python }}-${{ hashFiles('ws/src/tesseract_nanobind/dependencies.rosinstall', 'ws/src/tesseract_nanobind/pyproject.toml') }}
+        key: colcon-linux-v11-py${{ matrix.python }}-${{ hashFiles('ws/src/tesseract_nanobind/dependencies.repos', 'ws/src/tesseract_nanobind/pyproject.toml') }}
     - name: colcon build C++ deps
       if: steps.colcon-cache.outputs.cache-hit != 'true'
       working-directory: ws

--- a/.github/workflows/wheels-macos.yml
+++ b/.github/workflows/wheels-macos.yml
@@ -69,16 +69,16 @@ jobs:
           ws/src/descartes_light
           ws/src/opw_kinematics
           ws/src/ruckig
-        key: vcs-${{ hashFiles('ws/src/tesseract_nanobind/dependencies.rosinstall') }}
+        key: vcs-${{ hashFiles('ws/src/tesseract_nanobind/dependencies.repos') }}
     - name: vcs import
       working-directory: ws/src
-      run: vcs import --input tesseract_nanobind/dependencies.rosinstall --skip-existing
+      run: vcs import --input tesseract_nanobind/dependencies.repos --skip-existing
     - name: cache colcon build
       uses: actions/cache@v4
       id: colcon-cache
       with:
         path: ws/install
-        key: colcon-macos-v1-py${{ matrix.python }}-${{ hashFiles('ws/src/tesseract_nanobind/dependencies.rosinstall', 'ws/src/tesseract_nanobind/pyproject.toml') }}
+        key: colcon-macos-v1-py${{ matrix.python }}-${{ hashFiles('ws/src/tesseract_nanobind/dependencies.repos', 'ws/src/tesseract_nanobind/pyproject.toml') }}
     - name: build C++ deps
       if: steps.colcon-cache.outputs.cache-hit != 'true'
       working-directory: ws/src/tesseract_nanobind

--- a/.github/workflows/wheels-windows.yml
+++ b/.github/workflows/wheels-windows.yml
@@ -311,7 +311,7 @@ jobs:
         for plugin in \
           tesseract_collision_bullet_factories \
           tesseract_collision_fcl_factories \
-          tesseract_kinematics_core_factories \
+          tesseract_kinematics_factories \
           tesseract_kinematics_kdl_factories \
           tesseract_kinematics_opw_factory \
           tesseract_kinematics_ur_factory \

--- a/.github/workflows/wheels-windows.yml
+++ b/.github/workflows/wheels-windows.yml
@@ -342,7 +342,7 @@ jobs:
         done
 
         echo "=== Stripping search_paths from tesseract_support YAMLs ==="
-        find "$PKG_DIR/data/tesseract_support" -name "*.yaml" -type f 2>/dev/null | while read yaml_file; do
+        find "$PKG_DIR/data/tesseract/support" -name "*.yaml" -type f 2>/dev/null | while read yaml_file; do
           if grep -q 'search_paths:' "$yaml_file"; then
             sed -i '/search_paths:/d; /^[[:space:]]*- \/.*$/d' "$yaml_file"
             echo "  Stripped: $(basename "$yaml_file")"

--- a/.github/workflows/wheels-windows.yml
+++ b/.github/workflows/wheels-windows.yml
@@ -89,11 +89,11 @@ jobs:
           ws/src/ruckig
           ws/src/boost_plugin_loader
           ws/src/ros_industrial_cmake_boilerplate
-        key: vcs-win-${{ hashFiles('ws/src/tesseract_nanobind/dependencies.rosinstall') }}
+        key: vcs-win-${{ hashFiles('ws/src/tesseract_nanobind/dependencies.repos') }}
 
     - name: vcs import
       working-directory: ws/src
-      run: vcs import --input tesseract_nanobind/dependencies.rosinstall --skip-existing
+      run: vcs import --input tesseract_nanobind/dependencies.repos --skip-existing
 
     - name: patch upstream missing includes
       working-directory: ws/src
@@ -149,7 +149,7 @@ jobs:
       uses: actions/cache/restore@v4
       with:
         path: ws/install
-        key: colcon-win-pixi-exported-symbols-py${{ matrix.python }}-${{ hashFiles('ws/src/tesseract_nanobind/dependencies.rosinstall', 'ws/src/tesseract_nanobind/pyproject.toml') }}
+        key: colcon-win-pixi-exported-symbols-py${{ matrix.python }}-${{ hashFiles('ws/src/tesseract_nanobind/dependencies.repos', 'ws/src/tesseract_nanobind/pyproject.toml') }}
 
     - name: colcon build C++ deps
       if: steps.colcon-cache.outputs.cache-hit != 'true'
@@ -189,7 +189,7 @@ jobs:
       uses: actions/cache/save@v4
       with:
         path: ws/install
-        key: colcon-win-pixi-exported-symbols-py${{ matrix.python }}-${{ hashFiles('ws/src/tesseract_nanobind/dependencies.rosinstall', 'ws/src/tesseract_nanobind/pyproject.toml') }}
+        key: colcon-win-pixi-exported-symbols-py${{ matrix.python }}-${{ hashFiles('ws/src/tesseract_nanobind/dependencies.repos', 'ws/src/tesseract_nanobind/pyproject.toml') }}
 
     # Plugin-factory export verification is preserved as a commented recipe.
     # Used during gh-40 iteration to fail fast when MSVC stripped factory
@@ -267,7 +267,7 @@ jobs:
       uses: actions/cache/restore@v4
       with:
         path: ws/src/tesseract_nanobind/build
-        key: nanobind-wheel-build-win-pixi-py${{ matrix.python }}-${{ hashFiles('ws/src/tesseract_nanobind/CMakeLists.txt', 'ws/src/tesseract_nanobind/pyproject.toml', 'ws/src/tesseract_nanobind/dependencies.rosinstall', 'ws/src/tesseract_nanobind/src/**/*.cpp', 'ws/src/tesseract_nanobind/src/**/*.h', 'ws/src/tesseract_nanobind/src/**/*.hpp') }}
+        key: nanobind-wheel-build-win-pixi-py${{ matrix.python }}-${{ hashFiles('ws/src/tesseract_nanobind/CMakeLists.txt', 'ws/src/tesseract_nanobind/pyproject.toml', 'ws/src/tesseract_nanobind/dependencies.repos', 'ws/src/tesseract_nanobind/src/**/*.cpp', 'ws/src/tesseract_nanobind/src/**/*.h', 'ws/src/tesseract_nanobind/src/**/*.hpp') }}
 
     - name: build nanobind wheel
       working-directory: ws/src/tesseract_nanobind
@@ -296,7 +296,7 @@ jobs:
       uses: actions/cache/save@v4
       with:
         path: ws/src/tesseract_nanobind/build
-        key: nanobind-wheel-build-win-pixi-py${{ matrix.python }}-${{ hashFiles('ws/src/tesseract_nanobind/CMakeLists.txt', 'ws/src/tesseract_nanobind/pyproject.toml', 'ws/src/tesseract_nanobind/dependencies.rosinstall', 'ws/src/tesseract_nanobind/src/**/*.cpp', 'ws/src/tesseract_nanobind/src/**/*.h', 'ws/src/tesseract_nanobind/src/**/*.hpp') }}
+        key: nanobind-wheel-build-win-pixi-py${{ matrix.python }}-${{ hashFiles('ws/src/tesseract_nanobind/CMakeLists.txt', 'ws/src/tesseract_nanobind/pyproject.toml', 'ws/src/tesseract_nanobind/dependencies.repos', 'ws/src/tesseract_nanobind/src/**/*.cpp', 'ws/src/tesseract_nanobind/src/**/*.h', 'ws/src/tesseract_nanobind/src/**/*.hpp') }}
 
     - name: bundle plugins then delvewheel repair
       working-directory: ws/src/tesseract_nanobind

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -410,7 +410,7 @@ endif()
 if(EXISTS "${TESSERACT_SUPPORT_SRC}")
   message(STATUS "Installing tesseract_support from: ${TESSERACT_SUPPORT_SRC}")
   install(DIRECTORY "${TESSERACT_SUPPORT_SRC}/"
-    DESTINATION tesseract_robotics/data/tesseract_support
+    DESTINATION tesseract_robotics/data/tesseract/support
     FILES_MATCHING
     PATTERN "*.urdf" PATTERN "*.srdf" PATTERN "*.yaml" PATTERN "*.xacro"
     PATTERN "*.stl" PATTERN "*.STL" PATTERN "*.dae" PATTERN "*.ply" PATTERN "*.obj" PATTERN "*.csv"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,16 +49,16 @@ if(DEFINED ENV{CONDA_PREFIX})
 endif()
 
 # Find tesseract C++ libraries
-find_package(tesseract_common REQUIRED)
-find_package(tesseract_geometry REQUIRED)
-find_package(tesseract_scene_graph REQUIRED)
-find_package(tesseract_srdf REQUIRED)
-find_package(tesseract_urdf REQUIRED)
-find_package(tesseract_collision REQUIRED)
-find_package(tesseract_state_solver REQUIRED)
-find_package(tesseract_kinematics REQUIRED)
-find_package(tesseract_environment REQUIRED)
-find_package(tesseract_command_language REQUIRED)
+find_package(tesseract REQUIRED COMPONENTS common)
+find_package(tesseract REQUIRED COMPONENTS geometry)
+find_package(tesseract REQUIRED COMPONENTS scene_graph)
+find_package(tesseract REQUIRED COMPONENTS srdf)
+find_package(tesseract REQUIRED COMPONENTS urdf)
+find_package(tesseract REQUIRED COMPONENTS collision)
+find_package(tesseract REQUIRED COMPONENTS state_solver)
+find_package(tesseract REQUIRED COMPONENTS kinematics)
+find_package(tesseract REQUIRED COMPONENTS environment)
+find_package(tesseract_planning REQUIRED COMPONENTS command_language)
 find_package(console_bridge REQUIRED)
 
 # Define reusable function for nanobind extensions
@@ -97,7 +97,7 @@ endfunction()
 add_tesseract_nanobind_extension(
   tesseract_common
   src/tesseract_common/tesseract_common_bindings.cpp
-  tesseract::tesseract_common
+  tesseract::common
   console_bridge::console_bridge
 )
 
@@ -105,130 +105,130 @@ add_tesseract_nanobind_extension(
 add_tesseract_nanobind_extension(
   tesseract_geometry
   src/tesseract_geometry/tesseract_geometry_bindings.cpp
-  tesseract::tesseract_geometry
-  tesseract::tesseract_common
+  tesseract::geometry
+  tesseract::common
 )
 
 # Add tesseract_scene_graph module
 add_tesseract_nanobind_extension(
   tesseract_scene_graph
   src/tesseract_scene_graph/tesseract_scene_graph_bindings.cpp
-  tesseract::tesseract_scene_graph
-  tesseract::tesseract_geometry
-  tesseract::tesseract_common
+  tesseract::scene_graph
+  tesseract::geometry
+  tesseract::common
 )
 
 # Add tesseract_srdf module
 add_tesseract_nanobind_extension(
   tesseract_srdf
   src/tesseract_srdf/tesseract_srdf_bindings.cpp
-  tesseract::tesseract_srdf
-  tesseract::tesseract_scene_graph
-  tesseract::tesseract_common
+  tesseract::srdf
+  tesseract::scene_graph
+  tesseract::common
 )
 
 # Add tesseract_urdf module
 add_tesseract_nanobind_extension(
   tesseract_urdf
   src/tesseract_urdf/tesseract_urdf_bindings.cpp
-  tesseract::tesseract_urdf
-  tesseract::tesseract_scene_graph
-  tesseract::tesseract_common
+  tesseract::urdf
+  tesseract::scene_graph
+  tesseract::common
 )
 
 # Add tesseract_collision module
 add_tesseract_nanobind_extension(
   tesseract_collision
   src/tesseract_collision/tesseract_collision_bindings.cpp
-  tesseract::tesseract_collision_core
-  tesseract::tesseract_collision_bullet
-  tesseract::tesseract_geometry
-  tesseract::tesseract_common
+  tesseract::collision
+  tesseract::collision_bullet
+  tesseract::geometry
+  tesseract::common
 )
 
 # Add tesseract_state_solver module
 add_tesseract_nanobind_extension(
   tesseract_state_solver
   src/tesseract_state_solver/tesseract_state_solver_bindings.cpp
-  tesseract::tesseract_state_solver_kdl
-  tesseract::tesseract_state_solver_ofkt
-  tesseract::tesseract_scene_graph
-  tesseract::tesseract_common
+  tesseract::state_solver_kdl
+  tesseract::state_solver_ofkt
+  tesseract::scene_graph
+  tesseract::common
 )
 
 # Add tesseract_kinematics module
 add_tesseract_nanobind_extension(
   tesseract_kinematics
   src/tesseract_kinematics/tesseract_kinematics_bindings.cpp
-  tesseract::tesseract_kinematics_core
-  tesseract::tesseract_scene_graph
-  tesseract::tesseract_state_solver_kdl
-  tesseract::tesseract_common
+  tesseract::kinematics
+  tesseract::scene_graph
+  tesseract::state_solver_kdl
+  tesseract::common
 )
 
 # Add tesseract_environment module
 add_tesseract_nanobind_extension(
   tesseract_environment
   src/tesseract_environment/tesseract_environment_bindings.cpp
-  tesseract::tesseract_environment
-  tesseract::tesseract_kinematics_core
-  tesseract::tesseract_collision_core
-  tesseract::tesseract_srdf
-  tesseract::tesseract_scene_graph
-  tesseract::tesseract_common
+  tesseract::environment
+  tesseract::kinematics
+  tesseract::collision
+  tesseract::srdf
+  tesseract::scene_graph
+  tesseract::common
 )
 
 # Add tesseract_command_language module
 add_tesseract_nanobind_extension(
   tesseract_command_language
   src/tesseract_command_language/tesseract_command_language_bindings.cpp
-  tesseract::tesseract_command_language
-  tesseract::tesseract_common
+  tesseract::command_language
+  tesseract::common
 )
 
 # Add tesseract_serialization module (XML/binary serialization for root types)
 add_tesseract_nanobind_extension(
   tesseract_serialization
   src/tesseract_serialization/tesseract_serialization_bindings.cpp
-  tesseract::tesseract_command_language
-  tesseract::tesseract_environment
-  tesseract::tesseract_scene_graph
-  tesseract::tesseract_common
+  tesseract::command_language
+  tesseract::environment
+  tesseract::scene_graph
+  tesseract::common
 )
 
 # Find motion planners
-find_package(tesseract_motion_planners REQUIRED COMPONENTS core simple ompl)
+find_package(tesseract_planning REQUIRED COMPONENTS motion_planners motion_planners_simple motion_planners_ompl)
 
 # Add tesseract_motion_planners module
 add_tesseract_nanobind_extension(
   tesseract_motion_planners
   src/tesseract_motion_planners/tesseract_motion_planners_bindings.cpp
-  tesseract::tesseract_motion_planners_core
-  tesseract::tesseract_environment
-  tesseract::tesseract_command_language
-  tesseract::tesseract_common
+  tesseract::motion_planners
+  tesseract::environment
+  tesseract::command_language
+  tesseract::common
 )
 
 # Add tesseract_motion_planners_simple module
 add_tesseract_nanobind_extension(
   tesseract_motion_planners_simple
   src/tesseract_motion_planners_simple/tesseract_motion_planners_simple_bindings.cpp
-  tesseract::tesseract_motion_planners_simple
-  tesseract::tesseract_motion_planners_core
-  tesseract::tesseract_environment
-  tesseract::tesseract_command_language
-  tesseract::tesseract_common
+  tesseract::motion_planners_simple
+  tesseract::motion_planners
+  tesseract::environment
+  tesseract::command_language
+  tesseract::common
 )
 
 # Add tesseract_motion_planners_ompl module
 add_tesseract_nanobind_extension(
   tesseract_motion_planners_ompl
   src/tesseract_motion_planners_ompl/tesseract_motion_planners_ompl_bindings.cpp
-  tesseract::tesseract_motion_planners_ompl
-  tesseract::tesseract_motion_planners_core
-  tesseract::tesseract_environment
-  tesseract::tesseract_command_language
-  tesseract::tesseract_common
+  tesseract::motion_planners_ompl
+  tesseract::motion_planners
+  tesseract::environment
+  tesseract::command_language
+  tesseract::common
 )
 
 # Add ompl_base module (SE2, Reeds-Shepp, Dubins state spaces)
@@ -252,37 +252,37 @@ set_target_properties(_ompl_base PROPERTIES
 install(TARGETS _ompl_base LIBRARY DESTINATION tesseract_robotics/ompl_base)
 
 # Add tesseract_motion_planners_descartes module (optional - only if descartes component was built)
-find_package(tesseract_motion_planners QUIET COMPONENTS descartes)
+find_package(tesseract_planning QUIET COMPONENTS motion_planners_descartes)
 find_package(descartes_light QUIET)
-if(tesseract_motion_planners_descartes_FOUND AND descartes_light_FOUND)
+if(tesseract_planning_motion_planners_descartes_FOUND AND descartes_light_FOUND)
   message(STATUS "tesseract_motion_planners descartes component found - building bindings")
   add_tesseract_nanobind_extension(
     tesseract_motion_planners_descartes
     src/tesseract_motion_planners_descartes/tesseract_motion_planners_descartes_bindings.cpp
-    tesseract::tesseract_motion_planners_descartes
-    tesseract::tesseract_motion_planners_core
-    tesseract::tesseract_environment
-    tesseract::tesseract_command_language
-    tesseract::tesseract_collision_core
-    tesseract::tesseract_common
+    tesseract::motion_planners_descartes
+    tesseract::motion_planners
+    tesseract::environment
+    tesseract::command_language
+    tesseract::collision
+    tesseract::common
   )
 else()
   message(STATUS "tesseract_motion_planners descartes component not found - skipping bindings")
 endif()
 
 # Add tesseract_motion_planners_trajopt module (optional - only if trajopt component was built)
-find_package(tesseract_motion_planners QUIET COMPONENTS trajopt)
+find_package(tesseract_planning QUIET COMPONENTS motion_planners_trajopt)
 find_package(trajopt QUIET)
-if(tesseract_motion_planners_trajopt_FOUND AND trajopt_FOUND)
+if(tesseract_planning_motion_planners_trajopt_FOUND AND trajopt_FOUND)
   message(STATUS "tesseract_motion_planners trajopt component found - building bindings")
   add_tesseract_nanobind_extension(
     tesseract_motion_planners_trajopt
     src/tesseract_motion_planners_trajopt/tesseract_motion_planners_trajopt_bindings.cpp
-    tesseract::tesseract_motion_planners_trajopt
-    tesseract::tesseract_motion_planners_core
-    tesseract::tesseract_environment
-    tesseract::tesseract_command_language
-    tesseract::tesseract_common
+    tesseract::motion_planners_trajopt
+    tesseract::motion_planners
+    tesseract::environment
+    tesseract::command_language
+    tesseract::common
     trajopt::trajopt
   )
 else()
@@ -290,20 +290,20 @@ else()
 endif()
 
 # Add tesseract_motion_planners_trajopt_ifopt module (optional - only if trajopt_ifopt component was built)
-find_package(tesseract_motion_planners QUIET COMPONENTS trajopt_ifopt)
+find_package(tesseract_planning QUIET COMPONENTS motion_planners_trajopt_ifopt)
 find_package(trajopt_ifopt QUIET)
 find_package(trajopt_sqp QUIET)
 find_package(trajopt_common QUIET)
-if(tesseract_motion_planners_trajopt_ifopt_FOUND AND trajopt_ifopt_FOUND AND trajopt_sqp_FOUND)
+if(tesseract_planning_motion_planners_trajopt_ifopt_FOUND AND trajopt_ifopt_FOUND AND trajopt_sqp_FOUND)
   message(STATUS "tesseract_motion_planners trajopt_ifopt component found - building bindings")
   add_tesseract_nanobind_extension(
     tesseract_motion_planners_trajopt_ifopt
     src/tesseract_motion_planners_trajopt_ifopt/tesseract_motion_planners_trajopt_ifopt_bindings.cpp
-    tesseract::tesseract_motion_planners_trajopt_ifopt
-    tesseract::tesseract_motion_planners_core
-    tesseract::tesseract_environment
-    tesseract::tesseract_command_language
-    tesseract::tesseract_common
+    tesseract::motion_planners_trajopt_ifopt
+    tesseract::motion_planners
+    tesseract::environment
+    tesseract::command_language
+    tesseract::common
     trajopt::trajopt_ifopt
     trajopt::trajopt_sqp
   )
@@ -320,10 +320,10 @@ if(trajopt_ifopt_FOUND AND trajopt_common_FOUND)
     src/trajopt_ifopt/trajopt_ifopt_bindings.cpp
     trajopt::trajopt_ifopt
     trajopt::trajopt_common
-    tesseract::tesseract_kinematics_core
-    tesseract::tesseract_environment
-    tesseract::tesseract_collision_core
-    tesseract::tesseract_common
+    tesseract::kinematics
+    tesseract::environment
+    tesseract::collision
+    tesseract::common
   )
 else()
   message(STATUS "trajopt_ifopt/trajopt_common not found - skipping bindings")
@@ -337,49 +337,49 @@ if(trajopt_sqp_FOUND)
     src/trajopt_sqp/trajopt_sqp_bindings.cpp
     trajopt::trajopt_sqp
     trajopt::trajopt_ifopt
-    tesseract::tesseract_common
+    tesseract::common
   )
 else()
   message(STATUS "trajopt_sqp not found - skipping bindings")
 endif()
 
 # Find and add tesseract_time_parameterization
-find_package(tesseract_time_parameterization REQUIRED)
+find_package(tesseract_planning REQUIRED COMPONENTS time_parameterization time_parameterization_isp time_parameterization_totg time_parameterization_kdl)
 
 add_tesseract_nanobind_extension(
   tesseract_time_parameterization
   src/tesseract_time_parameterization/tesseract_time_parameterization_bindings.cpp
-  tesseract::tesseract_time_parameterization_isp
-  tesseract::tesseract_time_parameterization_totg
-  tesseract::tesseract_time_parameterization_kdl
-  tesseract::tesseract_time_parameterization_core
-  tesseract::tesseract_command_language
-  tesseract::tesseract_common
+  tesseract::time_parameterization_isp
+  tesseract::time_parameterization_totg
+  tesseract::time_parameterization_kdl
+  tesseract::time_parameterization
+  tesseract::command_language
+  tesseract::common
 )
 
 # Find and add tesseract_task_composer
-find_package(tesseract_task_composer REQUIRED COMPONENTS core taskflow planning)
+find_package(tesseract_planning REQUIRED COMPONENTS task_composer task_composer_taskflow task_composer_planning)
 
 add_tesseract_nanobind_extension(
   tesseract_task_composer
   src/tesseract_task_composer/tesseract_task_composer_bindings.cpp
-  tesseract::tesseract_task_composer
-  tesseract::tesseract_task_composer_taskflow
-  tesseract::tesseract_environment
-  tesseract::tesseract_command_language
-  tesseract::tesseract_collision_core
-  tesseract::tesseract_common
+  tesseract::task_composer
+  tesseract::task_composer_taskflow
+  tesseract::environment
+  tesseract::command_language
+  tesseract::collision
+  tesseract::common
 )
 
 add_tesseract_nanobind_extension(
   tesseract_task_composer_planning
   src/tesseract_task_composer_planning/tesseract_task_composer_planning_bindings.cpp
-  tesseract::tesseract_task_composer_planning_nodes
-  tesseract::tesseract_task_composer
-  tesseract::tesseract_motion_planners_trajopt
-  tesseract::tesseract_collision_core
-  tesseract::tesseract_command_language
-  tesseract::tesseract_common
+  tesseract::task_composer_planning_nodes
+  tesseract::task_composer
+  tesseract::motion_planners_trajopt
+  tesseract::collision
+  tesseract::command_language
+  tesseract::common
 )
 
 message(STATUS "============= Build Configuration =============")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -416,6 +416,13 @@ if(EXISTS "${TESSERACT_SUPPORT_SRC}")
     PATTERN "*.stl" PATTERN "*.STL" PATTERN "*.dae" PATTERN "*.ply" PATTERN "*.obj" PATTERN "*.csv"
     PATTERN "*.xml" PATTERN "*.png" PATTERN "*.jpg" PATTERN "*.jpeg"
     PATTERN ".git" EXCLUDE PATTERN "__pycache__" EXCLUDE)
+  # Install package.xml alongside support data so GeneralResourceLocator
+  # registers `tesseract` as a package when scanning TESSERACT_RESOURCE_PATH.
+  # The locator skips directories without package.xml (ROS convention).
+  get_filename_component(TESSERACT_PKG_XML "${TESSERACT_SUPPORT_SRC}/../package.xml" ABSOLUTE)
+  if(EXISTS "${TESSERACT_PKG_XML}")
+    install(FILES "${TESSERACT_PKG_XML}" DESTINATION tesseract_robotics/data/tesseract)
+  endif()
 else()
   message(WARNING "tesseract_support not found at ${TESSERACT_SUPPORT_SRC}")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -395,16 +395,16 @@ message(STATUS "===============================================")
 #   - Local dev: ws/src/tesseract/... (flat repo layout)
 #   - CI layout: ../tesseract/... (repo cloned to ws/src/tesseract_nanobind)
 
-set(TESSERACT_SUPPORT_SRC "${CMAKE_CURRENT_SOURCE_DIR}/ws/src/tesseract/tesseract_support")
+set(TESSERACT_SUPPORT_SRC "${CMAKE_CURRENT_SOURCE_DIR}/ws/src/tesseract/support")
 if(NOT EXISTS "${TESSERACT_SUPPORT_SRC}")
   # CI layout: repo at ws/src/tesseract_nanobind, deps at ws/src/tesseract
-  set(TESSERACT_SUPPORT_SRC "${CMAKE_CURRENT_SOURCE_DIR}/../tesseract/tesseract_support")
+  set(TESSERACT_SUPPORT_SRC "${CMAKE_CURRENT_SOURCE_DIR}/../tesseract/support")
 endif()
 
-set(TASK_COMPOSER_CFG_SRC "${CMAKE_CURRENT_SOURCE_DIR}/ws/src/tesseract_planning/tesseract_task_composer/config")
+set(TASK_COMPOSER_CFG_SRC "${CMAKE_CURRENT_SOURCE_DIR}/ws/src/tesseract_planning/task_composer/config")
 if(NOT EXISTS "${TASK_COMPOSER_CFG_SRC}")
   # CI layout
-  set(TASK_COMPOSER_CFG_SRC "${CMAKE_CURRENT_SOURCE_DIR}/../tesseract_planning/tesseract_task_composer/config")
+  set(TASK_COMPOSER_CFG_SRC "${CMAKE_CURRENT_SOURCE_DIR}/../tesseract_planning/task_composer/config")
 endif()
 
 if(EXISTS "${TESSERACT_SUPPORT_SRC}")

--- a/dependencies.repos
+++ b/dependencies.repos
@@ -9,28 +9,28 @@
 - git:
     local-name: tesseract
     uri: https://github.com/tesseract-robotics/tesseract.git
-    version: 0.34.1
+    version: 0.35.0
 - git:
     local-name: tesseract_planning
     uri: https://github.com/tesseract-robotics/tesseract_planning.git
-    version: 0.34.0
+    version: 0.35.0
 - git:
     local-name: trajopt
     uri: https://github.com/tesseract-robotics/trajopt.git
-    version: 0.34.4
+    version: 0.35.0
 - git:
     local-name: descartes_light
     uri: https://github.com/swri-robotics/descartes_light.git
-    version: 0.4.9
+    version: 0.4.10
 - git:
     local-name: opw_kinematics
     uri: https://github.com/Jmeyer1292/opw_kinematics.git
-    version: 0.5.2
+    version: 0.5.3
 - git:
     local-name: ifopt
     uri: https://github.com/ethz-adrl/ifopt.git
     version: 2.1.4
 - git:
     local-name: ruckig
-    uri: https://github.com/pantor/ruckig.git
-    version: v0.15.3
+    uri: https://github.com/Levi-Armstrong/ruckig.git
+    version: cpack-v0.9.2

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1,3 +1,87 @@
+# API Changes: 0.34 → 0.35
+
+## C++ Dependency Versions
+
+| Package | 0.34 | 0.35 |
+|---------|------|------|
+| tesseract | 0.34.1 | 0.35.0 |
+| tesseract_planning | 0.34.0 | 0.35.0 |
+| trajopt | 0.34.4 | 0.35.0 |
+| descartes_light | 0.4.9 | 0.4.10 |
+| opw_kinematics | 0.5.2 | 0.5.3 |
+| ruckig | `pantor/ruckig @ v0.15.3` | `Levi-Armstrong/ruckig @ cpack-v0.9.2` |
+
+`ros_industrial_cmake_boilerplate` (0.7.4), `boost_plugin_loader` (0.4.3), and `ifopt` (2.1.4) were already at latest.
+
+## Upstream Structural Changes
+
+Both `tesseract` and `tesseract_planning` consolidated their many small CMake packages into single multi-component packages. The upstream `MIGRATION.md` files (in each repo at tag `0.35.0`) document the full mapping; below are the highlights this binding repo has to absorb.
+
+### Include path remap
+
+| Old | New |
+|-----|-----|
+| `<tesseract_common/X.h>` | `<tesseract/common/X.h>` |
+| `<tesseract_collision/core/X.h>` | `<tesseract/collision/X.h>` (`core/` flattened) |
+| `<tesseract_kinematics/core/X.h>` | `<tesseract/kinematics/X.h>` (`core/` flattened) |
+| `<tesseract_motion_planners/core/X.h>` | `<tesseract/motion_planners/X.h>` (`core/` flattened) |
+| `<tesseract_task_composer/core/X.h>` | `<tesseract/task_composer/X.h>` (`core/` flattened) |
+
+The full set of subpackages (`geometry`, `scene_graph`, `state_solver`, `srdf`, `urdf`, `environment`, `visualization`, `support`, `command_language`, `time_parameterization`, `examples`) all move under `tesseract/`.
+
+### C++ namespace remap
+
+| Old | New |
+|-----|-----|
+| `tesseract_common::Foo` | `tesseract::common::Foo` |
+| `tesseract_collision::Foo` | `tesseract::collision::Foo` |
+| ... (every `tesseract_<name>::` becomes `tesseract::<name>::`) | |
+
+### CMake target rename
+
+`tesseract::tesseract_<name>` → `tesseract::<name>` across the board.
+
+### find_package consolidation
+
+```cmake
+# 0.34
+find_package(tesseract_common REQUIRED)
+find_package(tesseract_collision REQUIRED COMPONENTS core bullet)
+find_package(tesseract_kinematics REQUIRED COMPONENTS core kdl)
+
+# 0.35
+find_package(tesseract REQUIRED
+             COMPONENTS common collision collision_bullet kinematics kinematics_kdl)
+```
+
+Same pattern for `tesseract_planning`: one `find_package(tesseract_planning REQUIRED COMPONENTS ...)` replaces all the per-subpackage calls.
+
+### dependencies file rename
+
+`dependencies.rosinstall` → `dependencies.repos` (matches upstream's ros2 vcs-tool convention). File format unchanged (YAML, `vcs import` reads both extensions).
+
+### ruckig: switch to Levi-Armstrong fork
+
+`tesseract_planning` 0.35.0 pins ruckig at `Levi-Armstrong/ruckig.git @ cpack-v0.9.2` (a fork with a cpack patch). We had been diverging on upstream `pantor/ruckig @ v0.15.3`; this release brings us back in line with what upstream CI builds against.
+
+## Python API Changes
+
+_TBD — populated as bindings are rebuilt and API breaks surface._
+
+## Migration Checklist
+
+- [x] Bump versions in `dependencies.repos`
+- [x] Switch to `Levi-Armstrong/ruckig` fork
+- [x] Rename `dependencies.rosinstall` → `dependencies.repos`
+- [x] Update build script + CI workflows to reference new filename
+- [ ] Apply upstream sed scripts (tesseract + tesseract_planning `MIGRATION.md`) to `src/` and `CMakeLists.txt`
+- [ ] Manual sweep for nanobind-specific cases the sed misses (`nb::module_::import_(...)` paths, cross-module type registration)
+- [ ] Rebuild C++ workspace (`pixi run build-cpp`)
+- [ ] Rebuild bindings
+- [ ] Run test suite; document Python API breaks as they surface
+
+---
+
 # API Changes: 0.33 → 0.34
 
 ## C++ Dependency Versions

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -66,7 +66,45 @@ Same pattern for `tesseract_planning`: one `find_package(tesseract_planning REQU
 
 ## Python API Changes
 
-_TBD — populated as bindings are rebuilt and API breaks surface._
+Surface-level Python API is unchanged. The breaks below are infrastructure/resource-resolution, not user-facing types.
+
+### URDF/SRDF resource URI scheme
+
+`package://tesseract_support/` → `package://tesseract/support/` everywhere.
+
+In 0.34, `tesseract_support` was its own ROS-style package (with its own `package.xml`). In 0.35, the support data is a subdirectory of the unified `tesseract` package, so the URI prefix changed. Affects every URDF/SRDF reference in tests/examples (25 files in this repo). Upstream's own URDFs at `ws/install/share/tesseract/support/urdf/` already use the new URI.
+
+### Dev-workspace directory renames
+
+Resource paths used by `tesseract_robotics/__init__.py` (editable-install fallback) and `scripts/env.sh`:
+
+| 0.34 path | 0.35 path |
+|-----------|-----------|
+| `ws/src/tesseract/tesseract_support/` | `ws/src/tesseract/support/` |
+| `ws/src/tesseract_planning/tesseract_task_composer/` | `ws/src/tesseract_planning/task_composer/` |
+
+The internal wheel-data layout (`tesseract_robotics/data/tesseract_support/`) is unchanged — that's our naming, not upstream's.
+
+### Cereal serialization registry — consumer-side workaround obsoleted
+
+In 0.34, the `tesseract_serialization_bindings.cpp` had a hand-rolled mirror of upstream's `CEREAL_REGISTER_TYPE` / `CEREAL_REGISTER_POLYMORPHIC_RELATION` macros to populate the Windows .pyd's per-DLL cereal registry. In 0.35, `<tesseract/command_language/cereal_serialization.h>` transitively includes a new `cereal_serialization_impl.hpp` registration-only header. Every consumer TU that includes the .h now gets the registrations automatically — including Windows .pyd consumers. The consumer-side mirror is now actively harmful (triggers `redefinition of binding_name<...>` errors); we deleted it.
+
+### namespace aliases — `tesseract_planning` umbrella is gone
+
+`namespace tesseract_planning` (the 0.34 umbrella for command_language + motion_planners + task_composer + time_parameterization types) has no 0.35 equivalent — each subpackage has its own nested `tesseract::<X>` namespace. Binding files that used `namespace tp = tesseract_planning;` have been remapped per-file to whichever sub-namespace dominates:
+
+- `tesseract_command_language_bindings.cpp` → `tesseract::command_language`
+- `tesseract_motion_planners*_bindings.cpp` → `tesseract::motion_planners`
+- `tesseract_task_composer*_bindings.cpp` → `tesseract::task_composer`
+- `tesseract_time_parameterization_bindings.cpp` → `tesseract::time_parameterization`
+
+Three files (simple/task_composer/time_param) reference `CompositeInstruction` (lives in command_language) — they additionally get a `tcl = tesseract::command_language` alias.
+
+### Test suite status (macOS arm64)
+
+Post-upgrade: **560 passed, 7 failed, 14 skipped** (vs pre-upgrade: 352 passed, 95 failed, 92 errors on first build, before any Python-side fixes).
+
+The 7 remaining failures are all `tests/benchmarks/test_parallel_scaling.py` "harder problem" stress cases throwing `Planning failed: ErrorTask: Error (Abort Triggered)`. Likely an algorithmic-tolerance change in 0.35's task composer rather than a binding-layer break. Out of scope for the upgrade milestone.
 
 ## Migration Checklist
 
@@ -74,11 +112,16 @@ _TBD — populated as bindings are rebuilt and API breaks surface._
 - [x] Switch to `Levi-Armstrong/ruckig` fork
 - [x] Rename `dependencies.rosinstall` → `dependencies.repos`
 - [x] Update build script + CI workflows to reference new filename
-- [ ] Apply upstream sed scripts (tesseract + tesseract_planning `MIGRATION.md`) to `src/` and `CMakeLists.txt`
-- [ ] Manual sweep for nanobind-specific cases the sed misses (`nb::module_::import_(...)` paths, cross-module type registration)
-- [ ] Rebuild C++ workspace (`pixi run build-cpp`)
-- [ ] Rebuild bindings
-- [ ] Run test suite; document Python API breaks as they surface
+- [x] Apply upstream sed scripts (tesseract + tesseract_planning `MIGRATION.md`) to `src/` and `CMakeLists.txt`
+- [x] Manual sweep for nanobind-specific cases sed misses (namespace aliases, redundant cereal registrations)
+- [x] Rebuild C++ workspace (`pixi run build-cpp`)
+- [x] Rebuild bindings — all 23 modules import clean
+- [x] Update resource paths (`__init__.py`, `env.sh`, CMakeLists)
+- [x] Rewrite `package://tesseract_support/` URIs across tests/examples
+- [x] Run test suite; document Python-side breaks
+- [ ] Triage 7 `parallel_scaling` benchmark regressions (likely tolerance change, not binding break)
+- [ ] Verify Linux + Windows wheel builds
+- [ ] Update CLAUDE.md re: cereal Windows-DLL workaround (now obsoleted by upstream)
 
 ---
 

--- a/docs/developer/index.md
+++ b/docs/developer/index.md
@@ -56,7 +56,7 @@ If you modify a C++ binding file (`src/*_bindings.cpp`):
 pixi run install
 ```
 
-If you modify upstream C++ sources or `dependencies.rosinstall`:
+If you modify upstream C++ sources or `dependencies.repos`:
 
 ```bash
 # Full C++ rebuild + reinstall
@@ -175,7 +175,7 @@ tesseract_nanobind/
 ├── pyproject.toml             # pixi workspace + package config
 ├── pixi.lock                  # locked deps (~200 packages)
 ├── CMakeLists.txt             # nanobind module build
-├── dependencies.rosinstall    # C++ source versions (vcstool)
+├── dependencies.repos    # C++ source versions (vcstool)
 ├── src/
 │   ├── tesseract_robotics/    # Python package
 │   │   ├── planning/          # High-level API (pure Python)

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -79,7 +79,7 @@ pixi install
 
 ## C++ Dependencies
 
-The build fetches 9 repositories via `vcs import` from `ws/src/dependencies.rosinstall`:
+The build fetches 9 repositories via `vcs import` from `ws/src/dependencies.repos`:
 
 | Repository | Version | What it provides |
 | ---------- | ------- | ---------------- |

--- a/scripts/build_tesseract_cpp.sh
+++ b/scripts/build_tesseract_cpp.sh
@@ -63,13 +63,13 @@ if [ -d "$PROJECT_ROOT/tesseract_python" ]; then
     fi
 fi
 
-# Copy dependencies.rosinstall to workspace
-echo "Copying dependencies.rosinstall..."
-if [ ! -f "$PROJECT_ROOT/dependencies.rosinstall" ]; then
-    echo "❌ dependencies.rosinstall not found at: $PROJECT_ROOT/dependencies.rosinstall"
+# Copy dependencies.repos to workspace
+echo "Copying dependencies.repos..."
+if [ ! -f "$PROJECT_ROOT/dependencies.repos" ]; then
+    echo "❌ dependencies.repos not found at: $PROJECT_ROOT/dependencies.repos"
     exit 1
 fi
-cp "$PROJECT_ROOT/dependencies.rosinstall" "$WORKSPACE_DIR/src/"
+cp "$PROJECT_ROOT/dependencies.repos" "$WORKSPACE_DIR/src/"
 
 # Import dependencies using vcstool
 echo ""
@@ -78,8 +78,8 @@ echo "Importing Dependencies (vcstool)"
 echo "=========================================="
 cd "$WORKSPACE_DIR/src"
 
-echo "Running: vcs import --shallow --input dependencies.rosinstall"
-vcs import --shallow --input dependencies.rosinstall
+echo "Running: vcs import --shallow --input dependencies.repos"
+vcs import --shallow --input dependencies.repos
 
 echo ""
 echo "Workspace contents:"

--- a/scripts/build_wheel.sh
+++ b/scripts/build_wheel.sh
@@ -75,7 +75,7 @@ unzip -q "$WHEEL_FILE" -d "$WHEEL_DIR"
 PLUGINS=(
     libtesseract_collision_bullet_factories.dylib
     libtesseract_collision_fcl_factories.dylib
-    libtesseract_kinematics_core_factories.dylib
+    libtesseract_kinematics_factories.dylib
     libtesseract_kinematics_kdl_factories.dylib
     libtesseract_kinematics_opw_factory.dylib
     libtesseract_kinematics_ur_factory.dylib

--- a/scripts/build_wheel.sh
+++ b/scripts/build_wheel.sh
@@ -192,7 +192,7 @@ done
 
 # Remove search_paths from robot YAMLs (forces use of env vars set by __init__.py)
 echo "Removing hardcoded search_paths from robot YAMLs..."
-find "$WHEEL_DIR/tesseract_robotics/data/tesseract_support" -name "*.yaml" -type f | while read yaml_file; do
+find "$WHEEL_DIR/tesseract_robotics/data/tesseract/support" -name "*.yaml" -type f | while read yaml_file; do
     if grep -q 'search_paths:' "$yaml_file"; then
         # Remove search_paths: line and following lines with - /path
         sed -i '' '/search_paths:/d; /^[[:space:]]*- \/.*$/d' "$yaml_file"

--- a/scripts/env.sh
+++ b/scripts/env.sh
@@ -22,11 +22,11 @@ export QT_HOST_PATH=$CONDA_PREFIX
 export DYLD_LIBRARY_PATH="$SCRIPT_DIR/ws/install/lib:$DYLD_LIBRARY_PATH"
 
 # Tesseract resource paths
-export TESSERACT_SUPPORT_DIR="$SCRIPT_DIR/ws/src/tesseract/tesseract_support"
+export TESSERACT_SUPPORT_DIR="$SCRIPT_DIR/ws/src/tesseract/support"
 export TESSERACT_RESOURCE_PATH="$SCRIPT_DIR/ws/src/tesseract/"
 
 # Task composer config (required for planning examples and tests)
-export TESSERACT_TASK_COMPOSER_DIR="$SCRIPT_DIR/ws/src/tesseract_planning/tesseract_task_composer"
+export TESSERACT_TASK_COMPOSER_DIR="$SCRIPT_DIR/ws/src/tesseract_planning/task_composer"
 export TESSERACT_TASK_COMPOSER_CONFIG_FILE="$TESSERACT_TASK_COMPOSER_DIR/config/task_composer_plugins.yaml"
 # Plugin path for YAML patching (package auto-patches /usr/local/lib -> this path)
 export TESSERACT_PLUGIN_PATH="$SCRIPT_DIR/ws/install/lib"

--- a/src/tesseract_collision/tesseract_collision_bindings.cpp
+++ b/src/tesseract_collision/tesseract_collision_bindings.cpp
@@ -27,9 +27,9 @@
 // bullet convex hull utils
 #include <tesseract/collision/bullet/convex_hull_utils.h>
 
-namespace tc = tesseract_collision;
-namespace tcommon = tesseract_common;
-namespace tg = tesseract_geometry;
+namespace tc = tesseract::collision;
+namespace tcommon = tesseract::common;
+namespace tg = tesseract::geometry;
 
 // Disable type caster for ContactResultVector so we can bind it as a class
 NB_MAKE_OPAQUE(tc::ContactResultVector);

--- a/src/tesseract_collision/tesseract_collision_bindings.cpp
+++ b/src/tesseract_collision/tesseract_collision_bindings.cpp
@@ -7,25 +7,25 @@
 #include <nanobind/stl/map.h>
 
 // tesseract_collision core
-#include <tesseract_collision/core/types.h>
-#include <tesseract_collision/core/discrete_contact_manager.h>
-#include <tesseract_collision/core/continuous_contact_manager.h>
-#include <tesseract_collision/core/contact_managers_plugin_factory.h>
+#include <tesseract/collision/types.h>
+#include <tesseract/collision/discrete_contact_manager.h>
+#include <tesseract/collision/continuous_contact_manager.h>
+#include <tesseract/collision/contact_managers_plugin_factory.h>
 
 // tesseract_common for types
-#include <tesseract_common/allowed_collision_matrix.h>
-#include <tesseract_common/collision_margin_data.h>
-#include <tesseract_common/resource_locator.h>
+#include <tesseract/common/allowed_collision_matrix.h>
+#include <tesseract/common/collision_margin_data.h>
+#include <tesseract/common/resource_locator.h>
 #include <filesystem>
-#include <tesseract_common/types.h>
+#include <tesseract/common/types.h>
 
 // tesseract_geometry for collision objects
-#include <tesseract_geometry/geometry.h>
-#include <tesseract_geometry/impl/mesh.h>
-#include <tesseract_geometry/impl/convex_mesh.h>
+#include <tesseract/geometry/geometry.h>
+#include <tesseract/geometry/impl/mesh.h>
+#include <tesseract/geometry/impl/convex_mesh.h>
 
 // bullet convex hull utils
-#include <tesseract_collision/bullet/convex_hull_utils.h>
+#include <tesseract/collision/bullet/convex_hull_utils.h>
 
 namespace tc = tesseract_collision;
 namespace tcommon = tesseract_common;

--- a/src/tesseract_command_language/tesseract_command_language_bindings.cpp
+++ b/src/tesseract_command_language/tesseract_command_language_bindings.cpp
@@ -37,8 +37,8 @@
 #include <tesseract/common/manipulator_info.h>
 #include <tesseract/common/joint_state.h>
 
-namespace tp = tesseract_planning;
-namespace tc = tesseract_common;
+namespace tp = tesseract::command_language;
+namespace tc = tesseract::common;
 
 NB_MODULE(_tesseract_command_language, m) {
     m.doc() = "tesseract_command_language Python bindings";

--- a/src/tesseract_command_language/tesseract_command_language_bindings.cpp
+++ b/src/tesseract_command_language/tesseract_command_language_bindings.cpp
@@ -10,32 +10,32 @@
 #include <nanobind/stl/function.h>
 
 // tesseract_command_language - concrete types
-#include <tesseract_command_language/joint_waypoint.h>
-#include <tesseract_command_language/cartesian_waypoint.h>
-#include <tesseract_command_language/state_waypoint.h>
-#include <tesseract_command_language/move_instruction.h>
-#include <tesseract_command_language/composite_instruction.h>
-#include <tesseract_command_language/wait_instruction.h>
-#include <tesseract_command_language/timer_instruction.h>
-#include <tesseract_command_language/set_analog_instruction.h>
-#include <tesseract_command_language/set_digital_instruction.h>
-#include <tesseract_command_language/set_tool_instruction.h>
-#include <tesseract_command_language/instruction_type.h>
-#include <tesseract_common/profile.h>
-#include <tesseract_common/profile_dictionary.h>
-#include <tesseract_command_language/constants.h>
+#include <tesseract/command_language/joint_waypoint.h>
+#include <tesseract/command_language/cartesian_waypoint.h>
+#include <tesseract/command_language/state_waypoint.h>
+#include <tesseract/command_language/move_instruction.h>
+#include <tesseract/command_language/composite_instruction.h>
+#include <tesseract/command_language/wait_instruction.h>
+#include <tesseract/command_language/timer_instruction.h>
+#include <tesseract/command_language/set_analog_instruction.h>
+#include <tesseract/command_language/set_digital_instruction.h>
+#include <tesseract/command_language/set_tool_instruction.h>
+#include <tesseract/command_language/instruction_type.h>
+#include <tesseract/common/profile.h>
+#include <tesseract/common/profile_dictionary.h>
+#include <tesseract/command_language/constants.h>
 
 // tesseract_command_language - Poly types
-#include <tesseract_command_language/poly/waypoint_poly.h>
-#include <tesseract_command_language/poly/cartesian_waypoint_poly.h>
-#include <tesseract_command_language/poly/joint_waypoint_poly.h>
-#include <tesseract_command_language/poly/state_waypoint_poly.h>
-#include <tesseract_command_language/poly/move_instruction_poly.h>
-#include <tesseract_command_language/poly/instruction_poly.h>
+#include <tesseract/command_language/poly/waypoint_poly.h>
+#include <tesseract/command_language/poly/cartesian_waypoint_poly.h>
+#include <tesseract/command_language/poly/joint_waypoint_poly.h>
+#include <tesseract/command_language/poly/state_waypoint_poly.h>
+#include <tesseract/command_language/poly/move_instruction_poly.h>
+#include <tesseract/command_language/poly/instruction_poly.h>
 
 // tesseract_common
-#include <tesseract_common/manipulator_info.h>
-#include <tesseract_common/joint_state.h>
+#include <tesseract/common/manipulator_info.h>
+#include <tesseract/common/joint_state.h>
 
 namespace tp = tesseract_planning;
 namespace tc = tesseract_common;

--- a/src/tesseract_common/tesseract_common_bindings.cpp
+++ b/src/tesseract_common/tesseract_common_bindings.cpp
@@ -1,21 +1,21 @@
 #include "tesseract_nb.h"
 
 // tesseract_common headers (need eigen_types.h before opaque declarations)
-#include <tesseract_common/eigen_types.h>
-#include <tesseract_common/types.h>
+#include <tesseract/common/eigen_types.h>
+#include <tesseract/common/types.h>
 
 // Opaque declarations for vector types we want to bind as classes
-using VectorVector3d = tesseract_common::VectorVector3d;  // std::vector<Eigen::Vector3d>
-using VectorIsometry3d = tesseract_common::VectorIsometry3d;  // std::vector<Eigen::Isometry3d>
+using VectorVector3d = tesseract::common::VectorVector3d;  // std::vector<Eigen::Vector3d>
+using VectorIsometry3d = tesseract::common::VectorIsometry3d;  // std::vector<Eigen::Isometry3d>
 NB_MAKE_OPAQUE(VectorVector3d)
 NB_MAKE_OPAQUE(VectorIsometry3d)
-#include <tesseract_common/resource_locator.h>
-#include <tesseract_common/manipulator_info.h>
-#include <tesseract_common/joint_state.h>
-#include <tesseract_common/collision_margin_data.h>
-#include <tesseract_common/allowed_collision_matrix.h>
-#include <tesseract_common/kinematic_limits.h>
-#include <tesseract_common/plugin_info.h>
+#include <tesseract/common/resource_locator.h>
+#include <tesseract/common/manipulator_info.h>
+#include <tesseract/common/joint_state.h>
+#include <tesseract/common/collision_margin_data.h>
+#include <tesseract/common/allowed_collision_matrix.h>
+#include <tesseract/common/kinematic_limits.h>
+#include <tesseract/common/plugin_info.h>
 #include <algorithm>
 #include <cmath>
 #include <filesystem>
@@ -25,11 +25,11 @@ NB_MAKE_OPAQUE(VectorIsometry3d)
 #include <console_bridge/console.h>
 
 // Trampoline class for ResourceLocator
-class PyResourceLocator : public tesseract_common::ResourceLocator {
+class PyResourceLocator : public tesseract::common::ResourceLocator {
 public:
-    NB_TRAMPOLINE(tesseract_common::ResourceLocator, 1);
+    NB_TRAMPOLINE(tesseract::common::ResourceLocator, 1);
 
-    std::shared_ptr<tesseract_common::Resource> locateResource(const std::string& url) const override {
+    std::shared_ptr<tesseract::common::Resource> locateResource(const std::string& url) const override {
         NB_OVERRIDE_PURE(locateResource, url);
     }
 };
@@ -52,7 +52,7 @@ NB_MODULE(_tesseract_common, m) {
     // (constexpr, returns 1e-12); we re-export so Python tests + helpers
     // can reference one value instead of duplicating `1e-12` literals.
     // Used by: planning/transforms.py (_NORMALISE_DENOM_FLOOR),
-    // tests/tesseract_common/test_eigen_geometry.py (DEFAULT_PREC),
+    // tests/tesseract/common/test_eigen_geometry.py (DEFAULT_PREC),
     // tests/tesseract_planning/test_planning_api.py (EIGEN_DEFAULT_PREC),
     // and the C++ `kDegenerateGeometryEps` constexpr further down.
     m.attr("EIGEN_DEFAULT_PREC") = Eigen::NumTraits<double>::dummy_precision();
@@ -728,133 +728,133 @@ NB_MODULE(_tesseract_common, m) {
 
     // ========== Resource Types ==========
     // Note: In nanobind 2.x, shared_ptr holder is automatic - don't specify it
-    nb::class_<tesseract_common::Resource>(m, "Resource")
-        .def("isFile", &tesseract_common::Resource::isFile)
-        .def("getUrl", &tesseract_common::Resource::getUrl)
-        .def("getFilePath", &tesseract_common::Resource::getFilePath)
-        .def("getResourceContents", [](tesseract_common::Resource& self) {
+    nb::class_<tesseract::common::Resource>(m, "Resource")
+        .def("isFile", &tesseract::common::Resource::isFile)
+        .def("getUrl", &tesseract::common::Resource::getUrl)
+        .def("getFilePath", &tesseract::common::Resource::getFilePath)
+        .def("getResourceContents", [](tesseract::common::Resource& self) {
             std::vector<uint8_t> data = self.getResourceContents();
             return nb::bytes(reinterpret_cast<const char*>(data.data()), data.size());
         })
-        .def("getResourceContentStream", &tesseract_common::Resource::getResourceContentStream);
+        .def("getResourceContentStream", &tesseract::common::Resource::getResourceContentStream);
 
-    nb::class_<tesseract_common::BytesResource, tesseract_common::Resource>(m, "BytesResource")
+    nb::class_<tesseract::common::BytesResource, tesseract::common::Resource>(m, "BytesResource")
         .def(nb::init<const std::string&, const std::vector<uint8_t>&>())
-        .def("__init__", [](tesseract_common::BytesResource* self, const std::string& url, nb::bytes data) {
+        .def("__init__", [](tesseract::common::BytesResource* self, const std::string& url, nb::bytes data) {
             std::vector<uint8_t> vec(data.size());
             std::memcpy(vec.data(), data.c_str(), data.size());
-            new (self) tesseract_common::BytesResource(url, vec);
+            new (self) tesseract::common::BytesResource(url, vec);
         });
 
-    nb::class_<tesseract_common::SimpleLocatedResource, tesseract_common::Resource>(m, "SimpleLocatedResource")
+    nb::class_<tesseract::common::SimpleLocatedResource, tesseract::common::Resource>(m, "SimpleLocatedResource")
         .def(nb::init<const std::string&, const std::string&>(), "url"_a, "filename"_a)
-        .def(nb::init<const std::string&, const std::string&, std::shared_ptr<tesseract_common::ResourceLocator>>(),
+        .def(nb::init<const std::string&, const std::string&, std::shared_ptr<tesseract::common::ResourceLocator>>(),
              "url"_a, "filename"_a, "parent"_a);
 
     // ========== ResourceLocator Hierarchy ==========
-    nb::class_<tesseract_common::ResourceLocator, PyResourceLocator>(m, "ResourceLocator")
+    nb::class_<tesseract::common::ResourceLocator, PyResourceLocator>(m, "ResourceLocator")
         .def(nb::init<>())
-        .def("locateResource", &tesseract_common::ResourceLocator::locateResource);
+        .def("locateResource", &tesseract::common::ResourceLocator::locateResource);
 
-    nb::class_<tesseract_common::GeneralResourceLocator, tesseract_common::ResourceLocator>(m, "GeneralResourceLocator")
+    nb::class_<tesseract::common::GeneralResourceLocator, tesseract::common::ResourceLocator>(m, "GeneralResourceLocator")
         .def(nb::init<>());
 
     // ========== ManipulatorInfo ==========
-    nb::class_<tesseract_common::ManipulatorInfo>(m, "ManipulatorInfo")
+    nb::class_<tesseract::common::ManipulatorInfo>(m, "ManipulatorInfo")
         .def(nb::init<>())
-        .def_rw("manipulator", &tesseract_common::ManipulatorInfo::manipulator)
-        .def_rw("manipulator_ik_solver", &tesseract_common::ManipulatorInfo::manipulator_ik_solver)
-        .def_rw("working_frame", &tesseract_common::ManipulatorInfo::working_frame)
-        .def_rw("tcp_frame", &tesseract_common::ManipulatorInfo::tcp_frame)
+        .def_rw("manipulator", &tesseract::common::ManipulatorInfo::manipulator)
+        .def_rw("manipulator_ik_solver", &tesseract::common::ManipulatorInfo::manipulator_ik_solver)
+        .def_rw("working_frame", &tesseract::common::ManipulatorInfo::working_frame)
+        .def_rw("tcp_frame", &tesseract::common::ManipulatorInfo::tcp_frame)
         .def_prop_rw("tcp_offset",
-            [](const tesseract_common::ManipulatorInfo& self) -> nb::object {
+            [](const tesseract::common::ManipulatorInfo& self) -> nb::object {
                 if (self.tcp_offset.index() == 0) {
                     return nb::cast(std::get<std::string>(self.tcp_offset));
                 } else {
                     return nb::cast(std::get<Eigen::Isometry3d>(self.tcp_offset));
                 }
             },
-            [](tesseract_common::ManipulatorInfo& self, nb::object value) {
+            [](tesseract::common::ManipulatorInfo& self, nb::object value) {
                 if (nb::isinstance<nb::str>(value)) {
                     self.tcp_offset = nb::cast<std::string>(value);
                 } else {
                     self.tcp_offset = nb::cast<Eigen::Isometry3d>(value);
                 }
             })
-        .def("__repr__", [](const tesseract_common::ManipulatorInfo& self) {
+        .def("__repr__", [](const tesseract::common::ManipulatorInfo& self) {
             return "<ManipulatorInfo manipulator='" + self.manipulator + "'>";
         });
 
     // ========== JointState ==========
-    nb::class_<tesseract_common::JointState>(m, "JointState")
+    nb::class_<tesseract::common::JointState>(m, "JointState")
         .def(nb::init<>())
         .def(nb::init<const std::vector<std::string>&, const Eigen::VectorXd&>())
-        .def_rw("joint_names", &tesseract_common::JointState::joint_names)
-        .def_rw("position", &tesseract_common::JointState::position)
-        .def_rw("velocity", &tesseract_common::JointState::velocity)
-        .def_rw("acceleration", &tesseract_common::JointState::acceleration)
-        .def_rw("effort", &tesseract_common::JointState::effort)
-        .def_rw("time", &tesseract_common::JointState::time);
+        .def_rw("joint_names", &tesseract::common::JointState::joint_names)
+        .def_rw("position", &tesseract::common::JointState::position)
+        .def_rw("velocity", &tesseract::common::JointState::velocity)
+        .def_rw("acceleration", &tesseract::common::JointState::acceleration)
+        .def_rw("effort", &tesseract::common::JointState::effort)
+        .def_rw("time", &tesseract::common::JointState::time);
 
     // ========== AllowedCollisionMatrix ==========
-    nb::class_<tesseract_common::AllowedCollisionMatrix>(m, "AllowedCollisionMatrix")
+    nb::class_<tesseract::common::AllowedCollisionMatrix>(m, "AllowedCollisionMatrix")
         .def(nb::init<>())
         .def("addAllowedCollision",
              nb::overload_cast<const std::string&, const std::string&, const std::string&>(
-                 &tesseract_common::AllowedCollisionMatrix::addAllowedCollision))
+                 &tesseract::common::AllowedCollisionMatrix::addAllowedCollision))
         .def("removeAllowedCollision",
              nb::overload_cast<const std::string&, const std::string&>(
-                 &tesseract_common::AllowedCollisionMatrix::removeAllowedCollision))
-        .def("isCollisionAllowed", &tesseract_common::AllowedCollisionMatrix::isCollisionAllowed)
-        .def("clearAllowedCollisions", &tesseract_common::AllowedCollisionMatrix::clearAllowedCollisions)
-        .def("getAllAllowedCollisions", &tesseract_common::AllowedCollisionMatrix::getAllAllowedCollisions)
-        .def("insertAllowedCollisionMatrix", &tesseract_common::AllowedCollisionMatrix::insertAllowedCollisionMatrix);
+                 &tesseract::common::AllowedCollisionMatrix::removeAllowedCollision))
+        .def("isCollisionAllowed", &tesseract::common::AllowedCollisionMatrix::isCollisionAllowed)
+        .def("clearAllowedCollisions", &tesseract::common::AllowedCollisionMatrix::clearAllowedCollisions)
+        .def("getAllAllowedCollisions", &tesseract::common::AllowedCollisionMatrix::getAllAllowedCollisions)
+        .def("insertAllowedCollisionMatrix", &tesseract::common::AllowedCollisionMatrix::insertAllowedCollisionMatrix);
 
     // ========== CollisionMarginData ==========
     // Note: CollisionMarginOverrideType was renamed to CollisionMarginPairOverrideType in 0.33
     // and reduced to 3 values (NONE, REPLACE, MODIFY)
-    nb::enum_<tesseract_common::CollisionMarginPairOverrideType>(m, "CollisionMarginPairOverrideType")
-        .value("NONE", tesseract_common::CollisionMarginPairOverrideType::NONE)
-        .value("REPLACE", tesseract_common::CollisionMarginPairOverrideType::REPLACE)
-        .value("MODIFY", tesseract_common::CollisionMarginPairOverrideType::MODIFY);
+    nb::enum_<tesseract::common::CollisionMarginPairOverrideType>(m, "CollisionMarginPairOverrideType")
+        .value("NONE", tesseract::common::CollisionMarginPairOverrideType::NONE)
+        .value("REPLACE", tesseract::common::CollisionMarginPairOverrideType::REPLACE)
+        .value("MODIFY", tesseract::common::CollisionMarginPairOverrideType::MODIFY);
 
     // Backwards-compatible alias (old name)
     m.attr("CollisionMarginOverrideType") = m.attr("CollisionMarginPairOverrideType");
 
     // CollisionMarginPairData - new in 0.33
-    nb::class_<tesseract_common::CollisionMarginPairData>(m, "CollisionMarginPairData")
+    nb::class_<tesseract::common::CollisionMarginPairData>(m, "CollisionMarginPairData")
         .def(nb::init<>())
-        .def("setCollisionMargin", &tesseract_common::CollisionMarginPairData::setCollisionMargin)
-        .def("getCollisionMargin", &tesseract_common::CollisionMarginPairData::getCollisionMargin)
-        .def("getCollisionMargins", &tesseract_common::CollisionMarginPairData::getCollisionMargins)
-        .def("empty", &tesseract_common::CollisionMarginPairData::empty)
-        .def("clear", &tesseract_common::CollisionMarginPairData::clear);
+        .def("setCollisionMargin", &tesseract::common::CollisionMarginPairData::setCollisionMargin)
+        .def("getCollisionMargin", &tesseract::common::CollisionMarginPairData::getCollisionMargin)
+        .def("getCollisionMargins", &tesseract::common::CollisionMarginPairData::getCollisionMargins)
+        .def("empty", &tesseract::common::CollisionMarginPairData::empty)
+        .def("clear", &tesseract::common::CollisionMarginPairData::clear);
 
-    nb::class_<tesseract_common::CollisionMarginData>(m, "CollisionMarginData")
+    nb::class_<tesseract::common::CollisionMarginData>(m, "CollisionMarginData")
         .def(nb::init<>())
         .def(nb::init<double>())
-        .def("getDefaultCollisionMargin", &tesseract_common::CollisionMarginData::getDefaultCollisionMargin)
-        .def("setDefaultCollisionMargin", &tesseract_common::CollisionMarginData::setDefaultCollisionMargin)
-        .def("getCollisionMargin", &tesseract_common::CollisionMarginData::getCollisionMargin)
-        .def("setCollisionMargin", &tesseract_common::CollisionMarginData::setCollisionMargin)
-        .def("getCollisionMarginPairData", &tesseract_common::CollisionMarginData::getCollisionMarginPairData)
-        .def("getMaxCollisionMargin", nb::overload_cast<>(&tesseract_common::CollisionMarginData::getMaxCollisionMargin, nb::const_))
+        .def("getDefaultCollisionMargin", &tesseract::common::CollisionMarginData::getDefaultCollisionMargin)
+        .def("setDefaultCollisionMargin", &tesseract::common::CollisionMarginData::setDefaultCollisionMargin)
+        .def("getCollisionMargin", &tesseract::common::CollisionMarginData::getCollisionMargin)
+        .def("setCollisionMargin", &tesseract::common::CollisionMarginData::setCollisionMargin)
+        .def("getCollisionMarginPairData", &tesseract::common::CollisionMarginData::getCollisionMarginPairData)
+        .def("getMaxCollisionMargin", nb::overload_cast<>(&tesseract::common::CollisionMarginData::getMaxCollisionMargin, nb::const_))
         // Backwards compatibility aliases
-        .def("getPairCollisionMargin", &tesseract_common::CollisionMarginData::getCollisionMargin)
-        .def("setPairCollisionMargin", &tesseract_common::CollisionMarginData::setCollisionMargin);
+        .def("getPairCollisionMargin", &tesseract::common::CollisionMarginData::getCollisionMargin)
+        .def("setPairCollisionMargin", &tesseract::common::CollisionMarginData::setCollisionMargin);
 
     // ========== KinematicLimits ==========
-    nb::class_<tesseract_common::KinematicLimits>(m, "KinematicLimits")
+    nb::class_<tesseract::common::KinematicLimits>(m, "KinematicLimits")
         .def(nb::init<>())
-        .def_rw("joint_limits", &tesseract_common::KinematicLimits::joint_limits)
-        .def_rw("velocity_limits", &tesseract_common::KinematicLimits::velocity_limits)
-        .def_rw("acceleration_limits", &tesseract_common::KinematicLimits::acceleration_limits);
+        .def_rw("joint_limits", &tesseract::common::KinematicLimits::joint_limits)
+        .def_rw("velocity_limits", &tesseract::common::KinematicLimits::velocity_limits)
+        .def_rw("acceleration_limits", &tesseract::common::KinematicLimits::acceleration_limits);
 
     // ========== PluginInfo ==========
-    nb::class_<tesseract_common::PluginInfo>(m, "PluginInfo")
+    nb::class_<tesseract::common::PluginInfo>(m, "PluginInfo")
         .def(nb::init<>())
-        .def_rw("class_name", &tesseract_common::PluginInfo::class_name)
-        .def_rw("config", &tesseract_common::PluginInfo::config);
+        .def_rw("class_name", &tesseract::common::PluginInfo::class_name)
+        .def_rw("config", &tesseract::common::PluginInfo::config);
 
     // ========== Console Bridge ==========
     nb::enum_<console_bridge::LogLevel>(m, "LogLevel")

--- a/src/tesseract_environment/tesseract_environment_bindings.cpp
+++ b/src/tesseract_environment/tesseract_environment_bindings.cpp
@@ -10,51 +10,51 @@
 #include <nanobind/stl/set.h>
 
 // tesseract_environment
-#include <tesseract_environment/environment.h>
-#include <tesseract_environment/events.h>
-#include <tesseract_environment/command.h>
-#include <tesseract_environment/commands/add_link_command.h>
-#include <tesseract_environment/commands/add_scene_graph_command.h>
-#include <tesseract_environment/commands/change_collision_margins_command.h>
-#include <tesseract_environment/commands/change_joint_acceleration_limits_command.h>
-#include <tesseract_environment/commands/change_joint_origin_command.h>
-#include <tesseract_environment/commands/change_joint_position_limits_command.h>
-#include <tesseract_environment/commands/change_joint_velocity_limits_command.h>
-#include <tesseract_environment/commands/change_link_collision_enabled_command.h>
-#include <tesseract_environment/commands/change_link_origin_command.h>
-#include <tesseract_environment/commands/change_link_visibility_command.h>
-#include <tesseract_environment/commands/modify_allowed_collisions_command.h>
-#include <tesseract_environment/commands/move_joint_command.h>
-#include <tesseract_environment/commands/move_link_command.h>
-#include <tesseract_environment/commands/remove_allowed_collision_link_command.h>
-#include <tesseract_environment/commands/remove_joint_command.h>
-#include <tesseract_environment/commands/remove_link_command.h>
-#include <tesseract_environment/commands/replace_joint_command.h>
+#include <tesseract/environment/environment.h>
+#include <tesseract/environment/events.h>
+#include <tesseract/environment/command.h>
+#include <tesseract/environment/commands/add_link_command.h>
+#include <tesseract/environment/commands/add_scene_graph_command.h>
+#include <tesseract/environment/commands/change_collision_margins_command.h>
+#include <tesseract/environment/commands/change_joint_acceleration_limits_command.h>
+#include <tesseract/environment/commands/change_joint_origin_command.h>
+#include <tesseract/environment/commands/change_joint_position_limits_command.h>
+#include <tesseract/environment/commands/change_joint_velocity_limits_command.h>
+#include <tesseract/environment/commands/change_link_collision_enabled_command.h>
+#include <tesseract/environment/commands/change_link_origin_command.h>
+#include <tesseract/environment/commands/change_link_visibility_command.h>
+#include <tesseract/environment/commands/modify_allowed_collisions_command.h>
+#include <tesseract/environment/commands/move_joint_command.h>
+#include <tesseract/environment/commands/move_link_command.h>
+#include <tesseract/environment/commands/remove_allowed_collision_link_command.h>
+#include <tesseract/environment/commands/remove_joint_command.h>
+#include <tesseract/environment/commands/remove_link_command.h>
+#include <tesseract/environment/commands/replace_joint_command.h>
 
 // tesseract_scene_graph
-#include <tesseract_scene_graph/graph.h>
-#include <tesseract_scene_graph/scene_state.h>
-#include <tesseract_scene_graph/link.h>
-#include <tesseract_scene_graph/joint.h>
+#include <tesseract/scene_graph/graph.h>
+#include <tesseract/scene_graph/scene_state.h>
+#include <tesseract/scene_graph/link.h>
+#include <tesseract/scene_graph/joint.h>
 
 // tesseract_common
-#include <tesseract_common/resource_locator.h>
-#include <tesseract_common/manipulator_info.h>
+#include <tesseract/common/resource_locator.h>
+#include <tesseract/common/manipulator_info.h>
 #include <filesystem>
 
 // tesseract_srdf
-#include <tesseract_srdf/srdf_model.h>
+#include <tesseract/srdf/srdf_model.h>
 
 // tesseract_kinematics
-#include <tesseract_kinematics/core/joint_group.h>
-#include <tesseract_kinematics/core/kinematic_group.h>
+#include <tesseract/kinematics/joint_group.h>
+#include <tesseract/kinematics/kinematic_group.h>
 
 // tesseract_collision
-#include <tesseract_collision/core/discrete_contact_manager.h>
-#include <tesseract_collision/core/continuous_contact_manager.h>
+#include <tesseract/collision/discrete_contact_manager.h>
+#include <tesseract/collision/continuous_contact_manager.h>
 
 // tesseract_state_solver - need full definition for getStateSolver return type
-#include <tesseract_state_solver/state_solver.h>
+#include <tesseract/state_solver/state_solver.h>
 
 namespace te = tesseract_environment;
 namespace tsg = tesseract_scene_graph;
@@ -242,8 +242,8 @@ NB_MODULE(_tesseract_environment, m) {
         }, "scene_graph"_a)
         // Init with scene_graph + srdf (makes a copy of srdf into shared_ptr)
         .def("init", [](te::Environment& self, const tsg::SceneGraph& scene_graph,
-                        const tesseract_srdf::SRDFModel& srdf) {
-            auto srdf_ptr = std::make_shared<const tesseract_srdf::SRDFModel>(srdf);
+                        const tesseract::srdf::SRDFModel& srdf) {
+            auto srdf_ptr = std::make_shared<const tesseract::srdf::SRDFModel>(srdf);
             return self.init(scene_graph, srdf_ptr);
         }, "scene_graph"_a, "srdf"_a)
         .def("initFromUrdf", [](te::Environment& self, const std::string& urdf_string,

--- a/src/tesseract_environment/tesseract_environment_bindings.cpp
+++ b/src/tesseract_environment/tesseract_environment_bindings.cpp
@@ -56,10 +56,10 @@
 // tesseract_state_solver - need full definition for getStateSolver return type
 #include <tesseract/state_solver/state_solver.h>
 
-namespace te = tesseract_environment;
-namespace tsg = tesseract_scene_graph;
-namespace tc = tesseract_common;
-namespace tk = tesseract_kinematics;
+namespace te = tesseract::environment;
+namespace tsg = tesseract::scene_graph;
+namespace tc = tesseract::common;
+namespace tk = tesseract::kinematics;
 
 // Wrapper for Python event callbacks
 struct PyEventCallbackFn {

--- a/src/tesseract_geometry/tesseract_geometry_bindings.cpp
+++ b/src/tesseract_geometry/tesseract_geometry_bindings.cpp
@@ -6,33 +6,33 @@
 #include "tesseract_nb.h"
 
 // tesseract_geometry
-#include <tesseract_geometry/geometry.h>
-#include <tesseract_geometry/geometries.h>
-#include <tesseract_geometry/impl/box.h>
-#include <tesseract_geometry/impl/sphere.h>
-#include <tesseract_geometry/impl/cylinder.h>
-#include <tesseract_geometry/impl/capsule.h>
-#include <tesseract_geometry/impl/cone.h>
-#include <tesseract_geometry/impl/plane.h>
-#include <tesseract_geometry/impl/polygon_mesh.h>
-#include <tesseract_geometry/impl/mesh.h>
-#include <tesseract_geometry/impl/convex_mesh.h>
-#include <tesseract_geometry/impl/sdf_mesh.h>
-#include <tesseract_geometry/impl/compound_mesh.h>
-#include <tesseract_geometry/impl/mesh_material.h>
-#include <tesseract_geometry/impl/octree.h>
-#include <tesseract_geometry/impl/octree_utils.h>
-#include <tesseract_geometry/mesh_parser.h>
-#include <tesseract_geometry/utils.h>
-#include <tesseract_geometry/conversions.h>
+#include <tesseract/geometry/geometry.h>
+#include <tesseract/geometry/geometries.h>
+#include <tesseract/geometry/impl/box.h>
+#include <tesseract/geometry/impl/sphere.h>
+#include <tesseract/geometry/impl/cylinder.h>
+#include <tesseract/geometry/impl/capsule.h>
+#include <tesseract/geometry/impl/cone.h>
+#include <tesseract/geometry/impl/plane.h>
+#include <tesseract/geometry/impl/polygon_mesh.h>
+#include <tesseract/geometry/impl/mesh.h>
+#include <tesseract/geometry/impl/convex_mesh.h>
+#include <tesseract/geometry/impl/sdf_mesh.h>
+#include <tesseract/geometry/impl/compound_mesh.h>
+#include <tesseract/geometry/impl/mesh_material.h>
+#include <tesseract/geometry/impl/octree.h>
+#include <tesseract/geometry/impl/octree_utils.h>
+#include <tesseract/geometry/mesh_parser.h>
+#include <tesseract/geometry/utils.h>
+#include <tesseract/geometry/conversions.h>
 
 // octomap
 #include <octomap/OcTree.h>
 
 // tesseract_common
-#include <tesseract_common/types.h>
-#include <tesseract_common/eigen_types.h>
-#include <tesseract_common/resource_locator.h>
+#include <tesseract/common/types.h>
+#include <tesseract/common/eigen_types.h>
+#include <tesseract/common/resource_locator.h>
 
 namespace tg = tesseract_geometry;
 namespace tc = tesseract_common;
@@ -252,7 +252,7 @@ NB_MODULE(_tesseract_geometry, m) {
         .def("getScale", &tg::CompoundMesh::getScale, "Get the scale applied to the mesh");
 
     // octomap::OcTree - minimal binding so callers can construct/load and
-    // pass it to tesseract_geometry::Octree
+    // pass it to tesseract::geometry::Octree
     nb::class_<octomap::OcTree>(m, "OcTree")
         .def(nb::init<double>(), "resolution"_a,
              "Create an empty octomap OcTree with the given leaf resolution")

--- a/src/tesseract_geometry/tesseract_geometry_bindings.cpp
+++ b/src/tesseract_geometry/tesseract_geometry_bindings.cpp
@@ -34,8 +34,8 @@
 #include <tesseract/common/eigen_types.h>
 #include <tesseract/common/resource_locator.h>
 
-namespace tg = tesseract_geometry;
-namespace tc = tesseract_common;
+namespace tg = tesseract::geometry;
+namespace tc = tesseract::common;
 
 // Disable type caster for this specific vector type so we can bind it as a class
 NB_MAKE_OPAQUE(std::vector<std::shared_ptr<const tg::Geometry>>);

--- a/src/tesseract_kinematics/tesseract_kinematics_bindings.cpp
+++ b/src/tesseract_kinematics/tesseract_kinematics_bindings.cpp
@@ -29,9 +29,9 @@
 #include <tesseract/common/resource_locator.h>
 #include <filesystem>
 
-namespace tk = tesseract_kinematics;
-namespace tcommon = tesseract_common;
-namespace tsg = tesseract_scene_graph;
+namespace tk = tesseract::kinematics;
+namespace tcommon = tesseract::common;
+namespace tsg = tesseract::scene_graph;
 
 // Make KinGroupIKInputs opaque so we can bind it as a class
 NB_MAKE_OPAQUE(tk::KinGroupIKInputs)

--- a/src/tesseract_kinematics/tesseract_kinematics_bindings.cpp
+++ b/src/tesseract_kinematics/tesseract_kinematics_bindings.cpp
@@ -9,24 +9,24 @@
 #include <nanobind/stl/set.h>
 
 // tesseract_state_solver - need full definition for JointGroup
-#include <tesseract_state_solver/state_solver.h>
+#include <tesseract/state_solver/state_solver.h>
 
 // tesseract_kinematics core
-#include <tesseract_kinematics/core/forward_kinematics.h>
-#include <tesseract_kinematics/core/inverse_kinematics.h>
-#include <tesseract_kinematics/core/joint_group.h>
-#include <tesseract_kinematics/core/kinematic_group.h>
-#include <tesseract_kinematics/core/types.h>
-#include <tesseract_kinematics/core/kinematics_plugin_factory.h>
-#include <tesseract_kinematics/core/utils.h>
+#include <tesseract/kinematics/forward_kinematics.h>
+#include <tesseract/kinematics/inverse_kinematics.h>
+#include <tesseract/kinematics/joint_group.h>
+#include <tesseract/kinematics/kinematic_group.h>
+#include <tesseract/kinematics/types.h>
+#include <tesseract/kinematics/kinematics_plugin_factory.h>
+#include <tesseract/kinematics/utils.h>
 
 // tesseract_scene_graph
-#include <tesseract_scene_graph/graph.h>
-#include <tesseract_scene_graph/scene_state.h>
+#include <tesseract/scene_graph/graph.h>
+#include <tesseract/scene_graph/scene_state.h>
 
 // tesseract_common
-#include <tesseract_common/kinematic_limits.h>
-#include <tesseract_common/resource_locator.h>
+#include <tesseract/common/kinematic_limits.h>
+#include <tesseract/common/resource_locator.h>
 #include <filesystem>
 
 namespace tk = tesseract_kinematics;
@@ -110,7 +110,7 @@ NB_MODULE(_tesseract_kinematics, m) {
                               const std::map<std::string, Eigen::Isometry3d>& tip_link_poses,
                               const Eigen::Ref<const Eigen::VectorXd>& seed) {
             // Convert std::map to TransformMap
-            tesseract_common::TransformMap poses;
+            tesseract::common::TransformMap poses;
             for (const auto& p : tip_link_poses) {
                 poses[p.first] = p.second;
             }

--- a/src/tesseract_motion_planners/tesseract_motion_planners_bindings.cpp
+++ b/src/tesseract_motion_planners/tesseract_motion_planners_bindings.cpp
@@ -7,16 +7,16 @@
 #include <nanobind/stl/unordered_map.h>
 
 // tesseract_motion_planners core
-#include <tesseract_motion_planners/core/planner.h>
-#include <tesseract_motion_planners/core/types.h>
-#include <tesseract_motion_planners/core/utils.h>
+#include <tesseract/motion_planners/planner.h>
+#include <tesseract/motion_planners/types.h>
+#include <tesseract/motion_planners/utils.h>
 
 // tesseract_environment
-#include <tesseract_environment/environment.h>
+#include <tesseract/environment/environment.h>
 
 // tesseract_command_language
-#include <tesseract_command_language/composite_instruction.h>
-#include <tesseract_common/profile_dictionary.h>
+#include <tesseract/command_language/composite_instruction.h>
+#include <tesseract/common/profile_dictionary.h>
 
 namespace tp = tesseract_planning;
 namespace te = tesseract_environment;

--- a/src/tesseract_motion_planners/tesseract_motion_planners_bindings.cpp
+++ b/src/tesseract_motion_planners/tesseract_motion_planners_bindings.cpp
@@ -18,9 +18,9 @@
 #include <tesseract/command_language/composite_instruction.h>
 #include <tesseract/common/profile_dictionary.h>
 
-namespace tp = tesseract_planning;
-namespace te = tesseract_environment;
-namespace tc = tesseract_common;
+namespace tp = tesseract::motion_planners;
+namespace te = tesseract::environment;
+namespace tc = tesseract::common;
 
 NB_MODULE(_tesseract_motion_planners, m) {
     m.doc() = "tesseract_motion_planners Python bindings";

--- a/src/tesseract_motion_planners_descartes/tesseract_motion_planners_descartes_bindings.cpp
+++ b/src/tesseract_motion_planners_descartes/tesseract_motion_planners_descartes_bindings.cpp
@@ -30,14 +30,14 @@
 #include <descartes_light/core/state_evaluator.h>
 
 // tesseract dependencies referenced by profile method signatures
-#include <tesseract_command_language/poly/move_instruction_poly.h>
-#include <tesseract_common/manipulator_info.h>
-#include <tesseract_environment/environment.h>
+#include <tesseract/command_language/poly/move_instruction_poly.h>
+#include <tesseract/common/manipulator_info.h>
+#include <tesseract/environment/environment.h>
 
 // tesseract_collision for CollisionCheckConfig
 #include <tesseract/collision/types.h>
 
-namespace tp = tesseract_planning;
+namespace tp = tesseract::motion_planners;
 namespace tc = tesseract_common;
 namespace dl = descartes_light;
 
@@ -149,7 +149,7 @@ public:
     std::unique_ptr<dl::WaypointSampler<double>>
     createWaypointSampler(const tp::MoveInstructionPoly& move_instruction,
                           const tc::ManipulatorInfo& composite_manip_info,
-                          const std::shared_ptr<const tesseract_environment::Environment>& env) const override {
+                          const std::shared_ptr<const tesseract::environment::Environment>& env) const override {
         nb::detail::ticket t(nb_trampoline, "createWaypointSampler", true);
         nb::object py_result = nb::borrow<nb::object>(
             nb_trampoline.base().attr(t.key)(move_instruction, composite_manip_info, env));
@@ -159,7 +159,7 @@ public:
     std::unique_ptr<dl::EdgeEvaluator<double>>
     createEdgeEvaluator(const tp::MoveInstructionPoly& move_instruction,
                         const tc::ManipulatorInfo& composite_manip_info,
-                        const std::shared_ptr<const tesseract_environment::Environment>& env) const override {
+                        const std::shared_ptr<const tesseract::environment::Environment>& env) const override {
         nb::detail::ticket t(nb_trampoline, "createEdgeEvaluator", true);
         nb::object py_result = nb::borrow<nb::object>(
             nb_trampoline.base().attr(t.key)(move_instruction, composite_manip_info, env));
@@ -169,7 +169,7 @@ public:
     std::unique_ptr<dl::StateEvaluator<double>>
     createStateEvaluator(const tp::MoveInstructionPoly& move_instruction,
                          const tc::ManipulatorInfo& composite_manip_info,
-                         const std::shared_ptr<const tesseract_environment::Environment>& env) const override {
+                         const std::shared_ptr<const tesseract::environment::Environment>& env) const override {
         nb::detail::ticket t(nb_trampoline, "createStateEvaluator", true);
         nb::object py_result = nb::borrow<nb::object>(
             nb_trampoline.base().attr(t.key)(move_instruction, composite_manip_info, env));

--- a/src/tesseract_motion_planners_descartes/tesseract_motion_planners_descartes_bindings.cpp
+++ b/src/tesseract_motion_planners_descartes/tesseract_motion_planners_descartes_bindings.cpp
@@ -11,17 +11,17 @@
 #include "tesseract_nb.h"
 
 // tesseract_motion_planners core (for PlannerRequest/Response)
-#include <tesseract_motion_planners/core/types.h>
+#include <tesseract/motion_planners/types.h>
 
 // tesseract_common (Profile and ProfileDictionary moved here in 0.33)
-#include <tesseract_common/profile.h>
-#include <tesseract_common/profile_dictionary.h>
+#include <tesseract/common/profile.h>
+#include <tesseract/common/profile_dictionary.h>
 
 // tesseract_motion_planners Descartes
-#include <tesseract_motion_planners/descartes/descartes_motion_planner.h>
-#include <tesseract_motion_planners/descartes/profile/descartes_profile.h>
-#include <tesseract_motion_planners/descartes/profile/descartes_default_move_profile.h>
-#include <tesseract_motion_planners/descartes/profile/descartes_ladder_graph_solver_profile.h>
+#include <tesseract/motion_planners/descartes/descartes_motion_planner.h>
+#include <tesseract/motion_planners/descartes/profile/descartes_profile.h>
+#include <tesseract/motion_planners/descartes/profile/descartes_default_move_profile.h>
+#include <tesseract/motion_planners/descartes/profile/descartes_ladder_graph_solver_profile.h>
 
 // descartes_light core types (needed for Python-side subclassing)
 #include <descartes_light/types.h>
@@ -35,7 +35,7 @@
 #include <tesseract_environment/environment.h>
 
 // tesseract_collision for CollisionCheckConfig
-#include <tesseract_collision/core/types.h>
+#include <tesseract/collision/types.h>
 
 namespace tp = tesseract_planning;
 namespace tc = tesseract_common;

--- a/src/tesseract_motion_planners_descartes/tesseract_motion_planners_descartes_bindings.cpp
+++ b/src/tesseract_motion_planners_descartes/tesseract_motion_planners_descartes_bindings.cpp
@@ -38,7 +38,8 @@
 #include <tesseract/collision/types.h>
 
 namespace tp = tesseract::motion_planners;
-namespace tc = tesseract_common;
+namespace tcl = tesseract::command_language;
+namespace tc = tesseract::common;
 namespace dl = descartes_light;
 
 // ------------------------------------------------------------------
@@ -147,7 +148,7 @@ public:
     NB_TRAMPOLINE(tp::DescartesMoveProfile<double>, 3);
 
     std::unique_ptr<dl::WaypointSampler<double>>
-    createWaypointSampler(const tp::MoveInstructionPoly& move_instruction,
+    createWaypointSampler(const tcl::MoveInstructionPoly& move_instruction,
                           const tc::ManipulatorInfo& composite_manip_info,
                           const std::shared_ptr<const tesseract::environment::Environment>& env) const override {
         nb::detail::ticket t(nb_trampoline, "createWaypointSampler", true);
@@ -157,7 +158,7 @@ public:
     }
 
     std::unique_ptr<dl::EdgeEvaluator<double>>
-    createEdgeEvaluator(const tp::MoveInstructionPoly& move_instruction,
+    createEdgeEvaluator(const tcl::MoveInstructionPoly& move_instruction,
                         const tc::ManipulatorInfo& composite_manip_info,
                         const std::shared_ptr<const tesseract::environment::Environment>& env) const override {
         nb::detail::ticket t(nb_trampoline, "createEdgeEvaluator", true);
@@ -167,7 +168,7 @@ public:
     }
 
     std::unique_ptr<dl::StateEvaluator<double>>
-    createStateEvaluator(const tp::MoveInstructionPoly& move_instruction,
+    createStateEvaluator(const tcl::MoveInstructionPoly& move_instruction,
                          const tc::ManipulatorInfo& composite_manip_info,
                          const std::shared_ptr<const tesseract::environment::Environment>& env) const override {
         nb::detail::ticket t(nb_trampoline, "createStateEvaluator", true);

--- a/src/tesseract_motion_planners_ompl/tesseract_motion_planners_ompl_bindings.cpp
+++ b/src/tesseract_motion_planners_ompl/tesseract_motion_planners_ompl_bindings.cpp
@@ -26,8 +26,8 @@
 // tesseract_collision for CollisionCheckConfig
 #include <tesseract/collision/types.h>
 
-namespace tp = tesseract_planning;
-namespace tc = tesseract_common;
+namespace tp = tesseract::motion_planners;
+namespace tc = tesseract::common;
 
 NB_MODULE(_tesseract_motion_planners_ompl, m) {
     m.doc() = "tesseract_motion_planners_ompl Python bindings";

--- a/src/tesseract_motion_planners_ompl/tesseract_motion_planners_ompl_bindings.cpp
+++ b/src/tesseract_motion_planners_ompl/tesseract_motion_planners_ompl_bindings.cpp
@@ -11,20 +11,20 @@
 #include "tesseract_nb.h"
 
 // tesseract_motion_planners core (for PlannerRequest/Response)
-#include <tesseract_motion_planners/core/types.h>
+#include <tesseract/motion_planners/types.h>
 
 // tesseract_common (Profile and ProfileDictionary moved here in 0.33)
-#include <tesseract_common/profile.h>
-#include <tesseract_common/profile_dictionary.h>
+#include <tesseract/common/profile.h>
+#include <tesseract/common/profile_dictionary.h>
 
 // tesseract_motion_planners OMPL
-#include <tesseract_motion_planners/ompl/ompl_motion_planner.h>
-#include <tesseract_motion_planners/ompl/ompl_planner_configurator.h>
-#include <tesseract_motion_planners/ompl/ompl_solver_config.h>
-#include <tesseract_motion_planners/ompl/profile/ompl_real_vector_move_profile.h>
+#include <tesseract/motion_planners/ompl/ompl_motion_planner.h>
+#include <tesseract/motion_planners/ompl/ompl_planner_configurator.h>
+#include <tesseract/motion_planners/ompl/ompl_solver_config.h>
+#include <tesseract/motion_planners/ompl/profile/ompl_real_vector_move_profile.h>
 
 // tesseract_collision for CollisionCheckConfig
-#include <tesseract_collision/core/types.h>
+#include <tesseract/collision/types.h>
 
 namespace tp = tesseract_planning;
 namespace tc = tesseract_common;

--- a/src/tesseract_motion_planners_simple/tesseract_motion_planners_simple_bindings.cpp
+++ b/src/tesseract_motion_planners_simple/tesseract_motion_planners_simple_bindings.cpp
@@ -6,29 +6,29 @@
 #include "tesseract_nb.h"
 
 // tesseract_motion_planners core (for PlannerRequest/Response)
-#include <tesseract_motion_planners/core/types.h>
+#include <tesseract/motion_planners/types.h>
 
 // tesseract_motion_planners simple
-#include <tesseract_motion_planners/simple/interpolation.h>
-#include <tesseract_motion_planners/simple/simple_motion_planner.h>
-#include <tesseract_motion_planners/simple/profile/simple_planner_profile.h>
-#include <tesseract_motion_planners/simple/profile/simple_planner_fixed_size_move_profile.h>
-#include <tesseract_motion_planners/simple/profile/simple_planner_fixed_size_assign_move_profile.h>
-#include <tesseract_motion_planners/simple/profile/simple_planner_fixed_size_assign_no_ik_move_profile.h>
-#include <tesseract_motion_planners/simple/profile/simple_planner_lvs_move_profile.h>
-#include <tesseract_motion_planners/simple/profile/simple_planner_lvs_no_ik_move_profile.h>
-#include <tesseract_motion_planners/simple/profile/simple_planner_lvs_assign_move_profile.h>
-#include <tesseract_motion_planners/simple/profile/simple_planner_lvs_assign_no_ik_move_profile.h>
+#include <tesseract/motion_planners/simple/interpolation.h>
+#include <tesseract/motion_planners/simple/simple_motion_planner.h>
+#include <tesseract/motion_planners/simple/profile/simple_planner_profile.h>
+#include <tesseract/motion_planners/simple/profile/simple_planner_fixed_size_move_profile.h>
+#include <tesseract/motion_planners/simple/profile/simple_planner_fixed_size_assign_move_profile.h>
+#include <tesseract/motion_planners/simple/profile/simple_planner_fixed_size_assign_no_ik_move_profile.h>
+#include <tesseract/motion_planners/simple/profile/simple_planner_lvs_move_profile.h>
+#include <tesseract/motion_planners/simple/profile/simple_planner_lvs_no_ik_move_profile.h>
+#include <tesseract/motion_planners/simple/profile/simple_planner_lvs_assign_move_profile.h>
+#include <tesseract/motion_planners/simple/profile/simple_planner_lvs_assign_no_ik_move_profile.h>
 
 // tesseract_common (Profile/ProfileDictionary moved here in 0.33)
-#include <tesseract_common/profile.h>
-#include <tesseract_common/profile_dictionary.h>
+#include <tesseract/common/profile.h>
+#include <tesseract/common/profile_dictionary.h>
 
 // tesseract_environment
-#include <tesseract_environment/environment.h>
+#include <tesseract/environment/environment.h>
 
 // tesseract_command_language
-#include <tesseract_command_language/composite_instruction.h>
+#include <tesseract/command_language/composite_instruction.h>
 
 namespace tp = tesseract_planning;
 namespace te = tesseract_environment;

--- a/src/tesseract_motion_planners_simple/tesseract_motion_planners_simple_bindings.cpp
+++ b/src/tesseract_motion_planners_simple/tesseract_motion_planners_simple_bindings.cpp
@@ -30,9 +30,10 @@
 // tesseract_command_language
 #include <tesseract/command_language/composite_instruction.h>
 
-namespace tp = tesseract_planning;
-namespace te = tesseract_environment;
-namespace tc = tesseract_common;
+namespace tp = tesseract::motion_planners;
+namespace tcl = tesseract::command_language;
+namespace te = tesseract::environment;
+namespace tc = tesseract::common;
 
 NB_MODULE(_tesseract_motion_planners_simple, m) {
     m.doc() = "tesseract_motion_planners_simple Python bindings";
@@ -55,7 +56,7 @@ NB_MODULE(_tesseract_motion_planners_simple, m) {
 
     // ========== generateInterpolatedProgram ==========
     m.def("generateInterpolatedProgram",
-          [](const tp::CompositeInstruction& instructions,
+          [](const tcl::CompositeInstruction& instructions,
              const std::shared_ptr<const te::Environment>& env,
              double state_lvs,
              double translation_lvs,

--- a/src/tesseract_motion_planners_trajopt/tesseract_motion_planners_trajopt_bindings.cpp
+++ b/src/tesseract_motion_planners_trajopt/tesseract_motion_planners_trajopt_bindings.cpp
@@ -37,8 +37,8 @@
 // tesseract_collision for CollisionEvaluatorType (moved here in 0.33)
 #include <tesseract/collision/types.h>
 
-namespace tp = tesseract_planning;
-namespace tc = tesseract_common;
+namespace tp = tesseract::motion_planners;
+namespace tc = tesseract::common;
 namespace tj = trajopt_common;
 
 NB_MODULE(_tesseract_motion_planners_trajopt, m) {

--- a/src/tesseract_motion_planners_trajopt/tesseract_motion_planners_trajopt_bindings.cpp
+++ b/src/tesseract_motion_planners_trajopt/tesseract_motion_planners_trajopt_bindings.cpp
@@ -14,19 +14,19 @@
 #include "tesseract_nb.h"
 
 // tesseract_motion_planners core (for PlannerRequest/Response)
-#include <tesseract_motion_planners/core/types.h>
+#include <tesseract/motion_planners/types.h>
 
 // tesseract_common (Profile and ProfileDictionary moved here in 0.33)
-#include <tesseract_common/profile.h>
-#include <tesseract_common/profile_dictionary.h>
+#include <tesseract/common/profile.h>
+#include <tesseract/common/profile_dictionary.h>
 
 // tesseract_motion_planners TrajOpt
-#include <tesseract_motion_planners/trajopt/trajopt_motion_planner.h>
-#include <tesseract_motion_planners/trajopt/profile/trajopt_profile.h>
-#include <tesseract_motion_planners/trajopt/profile/trajopt_default_move_profile.h>
-#include <tesseract_motion_planners/trajopt/profile/trajopt_default_composite_profile.h>
-#include <tesseract_motion_planners/trajopt/profile/trajopt_osqp_solver_profile.h>
-#include <tesseract_motion_planners/trajopt/trajopt_waypoint_config.h>
+#include <tesseract/motion_planners/trajopt/trajopt_motion_planner.h>
+#include <tesseract/motion_planners/trajopt/profile/trajopt_profile.h>
+#include <tesseract/motion_planners/trajopt/profile/trajopt_default_move_profile.h>
+#include <tesseract/motion_planners/trajopt/profile/trajopt_default_composite_profile.h>
+#include <tesseract/motion_planners/trajopt/profile/trajopt_osqp_solver_profile.h>
+#include <tesseract/motion_planners/trajopt/trajopt_waypoint_config.h>
 
 // trajopt_sco for optimizer parameters
 #include <trajopt_sco/optimizers.hpp>
@@ -35,7 +35,7 @@
 #include <trajopt_common/collision_types.h>
 
 // tesseract_collision for CollisionEvaluatorType (moved here in 0.33)
-#include <tesseract_collision/core/types.h>
+#include <tesseract/collision/types.h>
 
 namespace tp = tesseract_planning;
 namespace tc = tesseract_common;

--- a/src/tesseract_motion_planners_trajopt_ifopt/tesseract_motion_planners_trajopt_ifopt_bindings.cpp
+++ b/src/tesseract_motion_planners_trajopt_ifopt/tesseract_motion_planners_trajopt_ifopt_bindings.cpp
@@ -11,19 +11,19 @@
 #include "tesseract_nb.h"
 
 // tesseract_motion_planners core (for PlannerRequest/Response)
-#include <tesseract_motion_planners/core/types.h>
+#include <tesseract/motion_planners/types.h>
 
 // tesseract_common (Profile and ProfileDictionary moved here in 0.33)
-#include <tesseract_common/profile.h>
-#include <tesseract_common/profile_dictionary.h>
+#include <tesseract/common/profile.h>
+#include <tesseract/common/profile_dictionary.h>
 
 // tesseract_motion_planners TrajOpt IFOPT
-#include <tesseract_motion_planners/trajopt_ifopt/trajopt_ifopt_motion_planner.h>
-#include <tesseract_motion_planners/trajopt_ifopt/profile/trajopt_ifopt_profile.h>
-#include <tesseract_motion_planners/trajopt_ifopt/profile/trajopt_ifopt_default_move_profile.h>
-#include <tesseract_motion_planners/trajopt_ifopt/profile/trajopt_ifopt_default_composite_profile.h>
-#include <tesseract_motion_planners/trajopt_ifopt/profile/trajopt_ifopt_osqp_solver_profile.h>
-#include <tesseract_motion_planners/trajopt_ifopt/trajopt_ifopt_waypoint_config.h>
+#include <tesseract/motion_planners/trajopt_ifopt/trajopt_ifopt_motion_planner.h>
+#include <tesseract/motion_planners/trajopt_ifopt/profile/trajopt_ifopt_profile.h>
+#include <tesseract/motion_planners/trajopt_ifopt/profile/trajopt_ifopt_default_move_profile.h>
+#include <tesseract/motion_planners/trajopt_ifopt/profile/trajopt_ifopt_default_composite_profile.h>
+#include <tesseract/motion_planners/trajopt_ifopt/profile/trajopt_ifopt_osqp_solver_profile.h>
+#include <tesseract/motion_planners/trajopt_ifopt/trajopt_ifopt_waypoint_config.h>
 
 // trajopt_common for collision config
 #include <trajopt_common/collision_types.h>

--- a/src/tesseract_motion_planners_trajopt_ifopt/tesseract_motion_planners_trajopt_ifopt_bindings.cpp
+++ b/src/tesseract_motion_planners_trajopt_ifopt/tesseract_motion_planners_trajopt_ifopt_bindings.cpp
@@ -28,8 +28,8 @@
 // trajopt_common for collision config
 #include <trajopt_common/collision_types.h>
 
-namespace tp = tesseract_planning;
-namespace tc = tesseract_common;
+namespace tp = tesseract::motion_planners;
+namespace tc = tesseract::common;
 
 NB_MODULE(_tesseract_motion_planners_trajopt_ifopt, m) {
     m.doc() = "tesseract_motion_planners_trajopt_ifopt Python bindings";

--- a/src/tesseract_robotics/__init__.py
+++ b/src/tesseract_robotics/__init__.py
@@ -133,9 +133,9 @@ def _configure_environment():
     # Fallback: dev workspace layout (editable install)
     # pkg_dir = src/tesseract_robotics -> project root is 2 levels up
     project_root = pkg_dir.parent.parent
-    ws_support = project_root / "ws" / "src" / "tesseract" / "tesseract_support"
+    ws_support = project_root / "ws" / "src" / "tesseract" / "support"
     ws_resource = project_root / "ws" / "src" / "tesseract"
-    ws_composer = project_root / "ws" / "src" / "tesseract_planning" / "tesseract_task_composer"
+    ws_composer = project_root / "ws" / "src" / "tesseract_planning" / "task_composer"
     ws_config = ws_composer / "config" / "task_composer_plugins.yaml"
 
     # TESSERACT_SUPPORT_DIR: path to tesseract_support (bundled or dev)

--- a/src/tesseract_robotics/__init__.py
+++ b/src/tesseract_robotics/__init__.py
@@ -127,7 +127,7 @@ def _configure_environment():
 
     # Try bundled data first (installed package)
     data_dir = pkg_dir / "data"
-    support_dir = data_dir / "tesseract_support"
+    support_dir = data_dir / "tesseract" / "support"
     config_dir = data_dir / "task_composer_config"
 
     # Fallback: dev workspace layout (editable install)
@@ -218,7 +218,7 @@ def get_data_path() -> Path:
 
 def get_tesseract_support_path() -> Path:
     """Get path to bundled tesseract_support directory."""
-    return Path(__file__).parent / "data" / "tesseract_support"
+    return Path(__file__).parent / "data" / "tesseract" / "support"
 
 
 def get_task_composer_config_path() -> Path:

--- a/src/tesseract_robotics/__init__.py
+++ b/src/tesseract_robotics/__init__.py
@@ -141,8 +141,11 @@ def _configure_environment():
     # TESSERACT_SUPPORT_DIR: path to tesseract_support (bundled or dev)
     _set_env_if_missing("TESSERACT_SUPPORT_DIR", support_dir, ws_support)
 
-    # TESSERACT_RESOURCE_PATH: parent of support_dir for resource resolution
-    _set_env_if_missing("TESSERACT_RESOURCE_PATH", support_dir, ws_resource, use_parent=True)
+    # TESSERACT_RESOURCE_PATH: directory containing `tesseract` as a subdir
+    # so locator resolves package://tesseract/support/X via `<path>/tesseract/support/X`.
+    # bundled:   data/tesseract/support → use parent's parent (= data)
+    # dev (ws):  ws/src/tesseract       → use parent (= ws/src)
+    _set_env_if_missing("TESSERACT_RESOURCE_PATH", support_dir.parent, ws_resource, use_parent=True)
 
     # Plugin search paths - env var, bundled plugins, or ws/install/lib
     # Linux:   pkg_dir (all deps bundled in package root with $ORIGIN rpath)

--- a/src/tesseract_robotics/examples/abb_irb2400_viewer.py
+++ b/src/tesseract_robotics/examples/abb_irb2400_viewer.py
@@ -70,8 +70,8 @@ def main():
     # --8<-- [start:load_robot]
     # Load robot
     locator = GeneralResourceLocator()
-    abb_irb2400_urdf_package_url = "package://tesseract_support/urdf/abb_irb2400.urdf"
-    abb_irb2400_srdf_package_url = "package://tesseract_support/urdf/abb_irb2400.srdf"
+    abb_irb2400_urdf_package_url = "package://tesseract/support/urdf/abb_irb2400.urdf"
+    abb_irb2400_srdf_package_url = "package://tesseract/support/urdf/abb_irb2400.srdf"
     abb_irb2400_urdf_fname = FilesystemPath(
         locator.locateResource(abb_irb2400_urdf_package_url).getFilePath()
     )

--- a/src/tesseract_robotics/examples/car_seat_example.py
+++ b/src/tesseract_robotics/examples/car_seat_example.py
@@ -214,7 +214,7 @@ def add_seats(robot):
     """
     locator = robot.locator
     visual_resource = locator.locateResource(
-        "package://tesseract_support/meshes/car_seat/visual/seat.dae"
+        "package://tesseract/support/meshes/car_seat/visual/seat.dae"
     )
 
     for i in range(3):
@@ -231,7 +231,7 @@ def add_seats(robot):
 
         # Collision meshes (10 convex hulls)
         for m in range(1, 11):
-            collision_url = f"package://tesseract_support/meshes/car_seat/collision/seat_{m}.stl"
+            collision_url = f"package://tesseract/support/meshes/car_seat/collision/seat_{m}.stl"
             collision_resource = locator.locateResource(collision_url)
             for mesh in createMeshFromResource(collision_resource):
                 collision = Collision()
@@ -357,8 +357,8 @@ def run(pipeline="TrajOptPipeline", num_planners=None):
     # === PHASE 0: LOAD ROBOT ===
     # car_seat_demo: 8-DOF system with linear carriage + 7-axis arm
     robot = Robot.from_urdf(
-        "package://tesseract_support/urdf/car_seat_demo.urdf",
-        "package://tesseract_support/urdf/car_seat_demo.srdf",
+        "package://tesseract/support/urdf/car_seat_demo.urdf",
+        "package://tesseract/support/urdf/car_seat_demo.srdf",
     )
     print(f"Loaded robot: {robot.env.getName()}")
 

--- a/src/tesseract_robotics/examples/lowlevel/car_seat_c_api_example.py
+++ b/src/tesseract_robotics/examples/lowlevel/car_seat_c_api_example.py
@@ -244,7 +244,7 @@ def add_seats(robot):
     # Resolve package:// URI to filesystem path for visual mesh
     # seat.dae contains full visual detail (curves, materials)
     visual_mesh_path = locator.locateResource(
-        "package://tesseract_support/meshes/car_seat/visual/seat.dae"
+        "package://tesseract/support/meshes/car_seat/visual/seat.dae"
     ).getFilePath()
 
     for i in range(3):
@@ -267,7 +267,7 @@ def add_seats(robot):
         # Each STL is a convex piece of the original seat geometry
         for m in range(1, 11):  # seat_1.stl through seat_10.stl
             collision_mesh_url = (
-                f"package://tesseract_support/meshes/car_seat/collision/seat_{m}.stl"
+                f"package://tesseract/support/meshes/car_seat/collision/seat_{m}.stl"
             )
             collision_mesh_path = locator.locateResource(collision_mesh_url).getFilePath()
 
@@ -385,8 +385,8 @@ def run():
     # car_seat_demo: 8-DOF system with linear carriage + 7-axis arm
     # URDF defines kinematic chain, SRDF defines planning groups and ACM
     robot = Robot.from_urdf(
-        "package://tesseract_support/urdf/car_seat_demo.urdf",
-        "package://tesseract_support/urdf/car_seat_demo.srdf",
+        "package://tesseract/support/urdf/car_seat_demo.urdf",
+        "package://tesseract/support/urdf/car_seat_demo.srdf",
     )
     print(f"Loaded robot: {robot.env.getName()}")
 

--- a/src/tesseract_robotics/examples/lowlevel/pick_and_place_c_api_example.py
+++ b/src/tesseract_robotics/examples/lowlevel/pick_and_place_c_api_example.py
@@ -191,8 +191,8 @@ def run():
     #   - workcell_base with table (z=0.772m)
     #   - Shelf structure with placement locations
     robot = Robot.from_urdf(
-        "package://tesseract_support/urdf/pick_and_place_plan.urdf",
-        "package://tesseract_support/urdf/pick_and_place_plan.srdf",
+        "package://tesseract/support/urdf/pick_and_place_plan.urdf",
+        "package://tesseract/support/urdf/pick_and_place_plan.srdf",
     )
     print(f"Loaded robot with {len(robot.get_link_names())} links")
 

--- a/src/tesseract_robotics/examples/lowlevel/puzzle_piece_auxillary_axes_c_api_example.py
+++ b/src/tesseract_robotics/examples/lowlevel/puzzle_piece_auxillary_axes_c_api_example.py
@@ -70,7 +70,7 @@ def make_puzzle_tool_poses(robot):
         - Y-axis: Z x X for right-handed frame
     """
     # Locate CSV via tesseract resource system (resolves package:// URIs)
-    resource = robot.locator.locateResource("package://tesseract_support/urdf/puzzle_bent.csv")
+    resource = robot.locator.locateResource("package://tesseract/support/urdf/puzzle_bent.csv")
     csv_path = resource.getFilePath()
 
     poses = []
@@ -126,8 +126,8 @@ def main():
     """
     # Load puzzle piece workcell - contains KUKA IIWA + 2-DOF positioner
     robot = Robot.from_urdf(
-        "package://tesseract_support/urdf/puzzle_piece_workcell.urdf",
-        "package://tesseract_support/urdf/puzzle_piece_workcell.srdf",
+        "package://tesseract/support/urdf/puzzle_piece_workcell.urdf",
+        "package://tesseract/support/urdf/puzzle_piece_workcell.srdf",
     )
     print(f"Loaded robot with {len(robot.get_link_names())} links")
 

--- a/src/tesseract_robotics/examples/lowlevel/puzzle_piece_c_api_example.py
+++ b/src/tesseract_robotics/examples/lowlevel/puzzle_piece_c_api_example.py
@@ -63,7 +63,7 @@ def make_puzzle_tool_poses(robot):
     4. x-axis = cross(y, z) -> completes right-handed frame
     """
     # Locate CSV via resource locator (respects package:// URIs)
-    resource = robot.locator.locateResource("package://tesseract_support/urdf/puzzle_bent.csv")
+    resource = robot.locator.locateResource("package://tesseract/support/urdf/puzzle_bent.csv")
     csv_path = resource.getFilePath()
 
     poses = []
@@ -115,8 +115,8 @@ def main():
     # Load puzzle_piece_workcell: KUKA IIWA 7-DOF arm with grinder tool
     # URDF defines: part frame (workpiece), grinder_frame (TCP)
     robot = Robot.from_urdf(
-        "package://tesseract_support/urdf/puzzle_piece_workcell.urdf",
-        "package://tesseract_support/urdf/puzzle_piece_workcell.srdf",
+        "package://tesseract/support/urdf/puzzle_piece_workcell.urdf",
+        "package://tesseract/support/urdf/puzzle_piece_workcell.srdf",
     )
     print(f"Loaded robot with {len(robot.get_link_names())} links")
 

--- a/src/tesseract_robotics/examples/lowlevel/scene_graph_c_api_example.py
+++ b/src/tesseract_robotics/examples/lowlevel/scene_graph_c_api_example.py
@@ -54,8 +54,8 @@ def main():
     locator = GeneralResourceLocator()
 
     # Load KUKA IIWA 7-DOF robot
-    urdf_url = "package://tesseract_support/urdf/lbr_iiwa_14_r820.urdf"
-    srdf_url = "package://tesseract_support/urdf/lbr_iiwa_14_r820.srdf"
+    urdf_url = "package://tesseract/support/urdf/lbr_iiwa_14_r820.urdf"
+    srdf_url = "package://tesseract/support/urdf/lbr_iiwa_14_r820.srdf"
     urdf_path = FilesystemPath(locator.locateResource(urdf_url).getFilePath())
     srdf_path = FilesystemPath(locator.locateResource(srdf_url).getFilePath())
 

--- a/src/tesseract_robotics/examples/lowlevel/tesseract_collision_c_api_example.py
+++ b/src/tesseract_robotics/examples/lowlevel/tesseract_collision_c_api_example.py
@@ -146,10 +146,10 @@ def main():
 
     # Locate URDF (robot geometry) and SRDF (semantic info: groups, ACM, plugins)
     urdf_path_str = locator.locateResource(
-        "package://tesseract_support/urdf/abb_irb2400.urdf"
+        "package://tesseract/support/urdf/abb_irb2400.urdf"
     ).getFilePath()
     srdf_path_str = locator.locateResource(
-        "package://tesseract_support/urdf/abb_irb2400.srdf"
+        "package://tesseract/support/urdf/abb_irb2400.srdf"
     ).getFilePath()
 
     # FilesystemPath wraps std::filesystem::path for cross-platform compatibility

--- a/src/tesseract_robotics/examples/lowlevel/tesseract_kinematics_c_api_example.py
+++ b/src/tesseract_robotics/examples/lowlevel/tesseract_kinematics_c_api_example.py
@@ -151,10 +151,10 @@ def main():
     # ABB IRB2400 uses OPW (analytical) kinematics solver
     # Solver is configured in abb_irb2400_plugins.yaml referenced by SRDF
     urdf_path_str = locator.locateResource(
-        "package://tesseract_support/urdf/abb_irb2400.urdf"
+        "package://tesseract/support/urdf/abb_irb2400.urdf"
     ).getFilePath()
     srdf_path_str = locator.locateResource(
-        "package://tesseract_support/urdf/abb_irb2400.srdf"
+        "package://tesseract/support/urdf/abb_irb2400.srdf"
     ).getFilePath()
 
     # FilesystemPath wraps std::filesystem::path for cross-platform compatibility

--- a/src/tesseract_robotics/examples/lowlevel/tesseract_planning_lowlevel_c_api_example.py
+++ b/src/tesseract_robotics/examples/lowlevel/tesseract_planning_lowlevel_c_api_example.py
@@ -69,8 +69,8 @@ TRAJOPT_DEFAULT_NAMESPACE = "TrajOptMotionPlannerTask"
 def main():
     # Initialize the resource locator and environment
     locator = GeneralResourceLocator()
-    abb_irb2400_urdf_package_url = "package://tesseract_support/urdf/abb_irb2400.urdf"
-    abb_irb2400_srdf_package_url = "package://tesseract_support/urdf/abb_irb2400.srdf"
+    abb_irb2400_urdf_package_url = "package://tesseract/support/urdf/abb_irb2400.urdf"
+    abb_irb2400_srdf_package_url = "package://tesseract/support/urdf/abb_irb2400.srdf"
     abb_irb2400_urdf_fname = FilesystemPath(
         locator.locateResource(abb_irb2400_urdf_package_url).getFilePath()
     )

--- a/src/tesseract_robotics/examples/lowlevel/tesseract_planning_lowlevel_trajopt_ifopt_example.py
+++ b/src/tesseract_robotics/examples/lowlevel/tesseract_planning_lowlevel_trajopt_ifopt_example.py
@@ -70,8 +70,8 @@ TRAJOPT_IFOPT_NAMESPACE = "TrajOptIfoptMotionPlannerTask"
 def main():
     # Initialize the resource locator and environment
     locator = GeneralResourceLocator()
-    urdf_url = "package://tesseract_support/urdf/abb_irb2400.urdf"
-    srdf_url = "package://tesseract_support/urdf/abb_irb2400.srdf"
+    urdf_url = "package://tesseract/support/urdf/abb_irb2400.urdf"
+    srdf_url = "package://tesseract/support/urdf/abb_irb2400.srdf"
     urdf_path = FilesystemPath(locator.locateResource(urdf_url).getFilePath())
     srdf_path = FilesystemPath(locator.locateResource(srdf_url).getFilePath())
 

--- a/src/tesseract_robotics/examples/pick_and_place_example.py
+++ b/src/tesseract_robotics/examples/pick_and_place_example.py
@@ -166,8 +166,8 @@ def run(pipeline="TrajOptPipeline", num_planners=None):
     # Load KUKA IIWA workcell from tesseract_support
     # Includes: robot, table (z=0.772m), shelf structure
     robot = Robot.from_urdf(
-        "package://tesseract_support/urdf/pick_and_place_plan.urdf",
-        "package://tesseract_support/urdf/pick_and_place_plan.srdf",
+        "package://tesseract/support/urdf/pick_and_place_plan.urdf",
+        "package://tesseract/support/urdf/pick_and_place_plan.srdf",
     )
     # Set default collision margin (distance for contact reporting)
     robot.set_collision_margin(0.005)  # 5mm

--- a/src/tesseract_robotics/examples/puzzle_piece_auxillary_axes_example.py
+++ b/src/tesseract_robotics/examples/puzzle_piece_auxillary_axes_example.py
@@ -141,7 +141,7 @@ def make_puzzle_tool_poses(robot):
     Returns:
         list[Pose]: ~50 Cartesian waypoints for puzzle piece edge
     """
-    resource = robot.locator.locateResource("package://tesseract_support/urdf/puzzle_bent.csv")
+    resource = robot.locator.locateResource("package://tesseract/support/urdf/puzzle_bent.csv")
     csv_path = resource.getFilePath()
 
     poses = []
@@ -239,8 +239,8 @@ def run(pipeline="TrajOptPipeline", num_planners=None):
     # === LOAD WORKCELL ===
     # puzzle_piece_workcell: KUKA IIWA arm + 2-DOF positioner
     robot = Robot.from_urdf(
-        "package://tesseract_support/urdf/puzzle_piece_workcell.urdf",
-        "package://tesseract_support/urdf/puzzle_piece_workcell.srdf",
+        "package://tesseract/support/urdf/puzzle_piece_workcell.urdf",
+        "package://tesseract/support/urdf/puzzle_piece_workcell.srdf",
     )
 
     # 9 DOF: KUKA IIWA (7) + auxiliary axes (2)

--- a/src/tesseract_robotics/examples/raster_example.py
+++ b/src/tesseract_robotics/examples/raster_example.py
@@ -112,8 +112,8 @@ def run(pipeline="TrajOptPipeline", num_planners=None):
     # === LOAD ROBOT ===
     # ABB IRB2400: 6-DOF industrial manipulator (same as C++ example)
     robot = Robot.from_urdf(
-        "package://tesseract_support/urdf/abb_irb2400.urdf",
-        "package://tesseract_support/urdf/abb_irb2400.srdf",
+        "package://tesseract/support/urdf/abb_irb2400.urdf",
+        "package://tesseract/support/urdf/abb_irb2400.srdf",
     )
     print(f"Loaded robot with {len(robot.get_link_names())} links")
 

--- a/src/tesseract_robotics/examples/tesseract_material_mesh_viewer.py
+++ b/src/tesseract_robotics/examples/tesseract_material_mesh_viewer.py
@@ -13,7 +13,7 @@ shapes_urdf = """
   <link name="mesh_gltf2_link">
     <visual>
       <geometry>
-        <mesh filename="package://tesseract_support/meshes/tesseract_material_mesh.glb"/>
+        <mesh filename="package://tesseract/support/meshes/tesseract_material_mesh.glb"/>
       </geometry>
     </visual>
   </link>
@@ -29,7 +29,7 @@ shapes_urdf = """
   <link name="mesh_dae_link">
     <visual>
       <geometry>
-        <mesh filename="package://tesseract_support/meshes/tesseract_material_mesh.dae"/>
+        <mesh filename="package://tesseract/support/meshes/tesseract_material_mesh.dae"/>
       </geometry>
     </visual>
   </link>

--- a/src/tesseract_robotics/planning/core.py
+++ b/src/tesseract_robotics/planning/core.py
@@ -9,8 +9,8 @@ Example:
 
     # Load from package URLs
     robot = Robot.from_urdf(
-        "package://tesseract_support/urdf/abb_irb2400.urdf",
-        "package://tesseract_support/urdf/abb_irb2400.srdf"
+        "package://tesseract/support/urdf/abb_irb2400.urdf",
+        "package://tesseract/support/urdf/abb_irb2400.srdf"
     )
 
     # Or from file paths
@@ -234,8 +234,8 @@ class Robot:
         Returns:
             Initialized Robot instance
         """
-        urdf_url = f"package://tesseract_support/urdf/{robot_name}.urdf"
-        srdf_url = f"package://tesseract_support/urdf/{robot_name}.srdf"
+        urdf_url = f"package://tesseract/support/urdf/{robot_name}.urdf"
+        srdf_url = f"package://tesseract/support/urdf/{robot_name}.srdf"
         return cls.from_urdf(urdf_url, srdf_url, locator)
 
     def get_state(self, joint_names: list[str] | None = None) -> RobotState:

--- a/src/tesseract_scene_graph/tesseract_scene_graph_bindings.cpp
+++ b/src/tesseract_scene_graph/tesseract_scene_graph_bindings.cpp
@@ -17,8 +17,8 @@
 // tesseract_common for AllowedCollisionMatrix
 #include <tesseract/common/allowed_collision_matrix.h>
 
-namespace tsg = tesseract_scene_graph;
-namespace tg = tesseract_geometry;
+namespace tsg = tesseract::scene_graph;
+namespace tg = tesseract::geometry;
 
 NB_MODULE(_tesseract_scene_graph, m) {
     m.doc() = "tesseract_scene_graph Python bindings";

--- a/src/tesseract_scene_graph/tesseract_scene_graph_bindings.cpp
+++ b/src/tesseract_scene_graph/tesseract_scene_graph_bindings.cpp
@@ -6,16 +6,16 @@
 #include "tesseract_nb.h"
 
 // tesseract_scene_graph
-#include <tesseract_scene_graph/joint.h>
-#include <tesseract_scene_graph/link.h>
-#include <tesseract_scene_graph/graph.h>
-#include <tesseract_scene_graph/scene_state.h>
+#include <tesseract/scene_graph/joint.h>
+#include <tesseract/scene_graph/link.h>
+#include <tesseract/scene_graph/graph.h>
+#include <tesseract/scene_graph/scene_state.h>
 
 // tesseract_geometry for Visual/Collision geometry pointer
-#include <tesseract_geometry/geometry.h>
+#include <tesseract/geometry/geometry.h>
 
 // tesseract_common for AllowedCollisionMatrix
-#include <tesseract_common/allowed_collision_matrix.h>
+#include <tesseract/common/allowed_collision_matrix.h>
 
 namespace tsg = tesseract_scene_graph;
 namespace tg = tesseract_geometry;

--- a/src/tesseract_serialization/tesseract_serialization_bindings.cpp
+++ b/src/tesseract_serialization/tesseract_serialization_bindings.cpp
@@ -25,67 +25,18 @@
 
 namespace nb = nanobind;
 using namespace tesseract::common;
-using namespace tesseract_planning;
+using namespace tesseract::command_language;
 using namespace tesseract::environment;
 using namespace tesseract::scene_graph;
 
-// Cereal polymorphic-type registry on Windows MSVC is per-DLL — class-template
-// statics (StaticObject<InputBindingMap<Archive>>, OutputBindingMap, ...) are
-// instantiated independently in each DLL with no automatic dllexport/dllimport
-// to share them. Upstream tesseract_command_language.dll registers all its
-// polymorphic types into ITS OWN registry; our .pyd's registry stays empty
-// and serialization fails at runtime with "Trying to save an unregistered
-// polymorphic type". Linux and macOS skirt this because their linkers dedupe
-// the template statics across shared libraries.
-//
-// CEREAL_FORCE_DYNAMIC_INIT alone is insufficient — it forces upstream's
-// registration TU to survive in tesseract_command_language.dll, but doesn't
-// bridge the registry gap on the consumer side. To populate our .pyd's
-// registry we have to instantiate the registrar templates in OUR translation
-// unit by re-issuing the registration macros here. These mirror upstream
-// tesseract_command_language/src/cereal_serialization.cpp verbatim.
-//
-// Linux/macOS unaffected: cereal's polymorphic registry tolerates
-// re-registration of the same {type, archive} pair (no-op on duplicates).
-CEREAL_REGISTER_TYPE(tesseract_planning::CartesianWaypointPoly)
-CEREAL_REGISTER_TYPE(tesseract_planning::JointWaypointPoly)
-CEREAL_REGISTER_TYPE(tesseract_planning::StateWaypointPoly)
-CEREAL_REGISTER_TYPE(tesseract_planning::MoveInstructionPoly)
-CEREAL_REGISTER_TYPE(tesseract_planning::CartesianWaypoint)
-CEREAL_REGISTER_TYPE(tesseract_planning::JointWaypoint)
-CEREAL_REGISTER_TYPE(tesseract_planning::StateWaypoint)
-CEREAL_REGISTER_TYPE(tesseract_planning::MoveInstruction)
-CEREAL_REGISTER_TYPE(tesseract_planning::CompositeInstruction)
-CEREAL_REGISTER_TYPE(tesseract_planning::CompositeInstructionAnyPoly)
-CEREAL_REGISTER_TYPE(tesseract_planning::SetAnalogInstruction)
-CEREAL_REGISTER_TYPE(tesseract_planning::SetDigitalInstruction)
-CEREAL_REGISTER_TYPE(tesseract_planning::SetToolInstruction)
-CEREAL_REGISTER_TYPE(tesseract_planning::TimerInstruction)
-CEREAL_REGISTER_TYPE(tesseract_planning::WaitInstruction)
-
-CEREAL_REGISTER_POLYMORPHIC_RELATION(tesseract_planning::WaypointInterface, tesseract_planning::CartesianWaypointPoly)
-CEREAL_REGISTER_POLYMORPHIC_RELATION(tesseract_planning::WaypointInterface, tesseract_planning::JointWaypointPoly)
-CEREAL_REGISTER_POLYMORPHIC_RELATION(tesseract_planning::WaypointInterface, tesseract_planning::StateWaypointPoly)
-CEREAL_REGISTER_POLYMORPHIC_RELATION(tesseract_planning::InstructionInterface, tesseract_planning::MoveInstructionPoly)
-CEREAL_REGISTER_POLYMORPHIC_RELATION(tesseract_planning::CartesianWaypointInterface,
-                                     tesseract_planning::CartesianWaypoint)
-CEREAL_REGISTER_POLYMORPHIC_RELATION(tesseract_planning::JointWaypointInterface, tesseract_planning::JointWaypoint)
-CEREAL_REGISTER_POLYMORPHIC_RELATION(tesseract_planning::StateWaypointInterface, tesseract_planning::StateWaypoint)
-CEREAL_REGISTER_POLYMORPHIC_RELATION(tesseract_planning::MoveInstructionInterface, tesseract_planning::MoveInstruction)
-CEREAL_REGISTER_POLYMORPHIC_RELATION(tesseract_planning::InstructionInterface, tesseract_planning::CompositeInstruction)
-CEREAL_REGISTER_POLYMORPHIC_RELATION(tesseract_planning::InstructionInterface, tesseract_planning::SetAnalogInstruction)
-CEREAL_REGISTER_POLYMORPHIC_RELATION(tesseract_planning::InstructionInterface,
-                                     tesseract_planning::SetDigitalInstruction)
-CEREAL_REGISTER_POLYMORPHIC_RELATION(tesseract_planning::InstructionInterface, tesseract_planning::SetToolInstruction)
-CEREAL_REGISTER_POLYMORPHIC_RELATION(tesseract_planning::InstructionInterface, tesseract_planning::TimerInstruction)
-CEREAL_REGISTER_POLYMORPHIC_RELATION(tesseract_planning::InstructionInterface, tesseract_planning::WaitInstruction)
-
-CEREAL_REGISTER_POLYMORPHIC_RELATION(tesseract::common::AnyInterface, tesseract_planning::CompositeInstructionAnyPoly)
-
-// Belt-and-suspenders: also keep the upstream TU anchored. Harmless if the
-// TU is already alive; the consumer-side registrations above are the actual
-// fix.
-CEREAL_FORCE_DYNAMIC_INIT(tesseract_command_language_cereal)
+// In tesseract 0.35, upstream's <tesseract/command_language/cereal_serialization.h>
+// transitively includes cereal_serialization_impl.hpp, which issues all the
+// CEREAL_REGISTER_TYPE / CEREAL_REGISTER_POLYMORPHIC_RELATION macros for the
+// command_language polymorphic types. Every consumer TU that includes the .h
+// (such as this binding) gets the registrations automatically — including
+// Windows .pyd consumers where cereal's registry is per-DLL. The consumer-side
+// hand-rolled mirror that 0.34 needed is now redundant; re-issuing the macros
+// triggers "redefinition of binding_name<...>" compile errors.
 
 NB_MODULE(_tesseract_serialization, m)
 {

--- a/src/tesseract_serialization/tesseract_serialization_bindings.cpp
+++ b/src/tesseract_serialization/tesseract_serialization_bindings.cpp
@@ -9,13 +9,13 @@
 #include <nanobind/nanobind.h>
 #include <nanobind/stl/string.h>
 #include <nanobind/stl/vector.h>
-#include <tesseract_common/serialization.h>
-#include <tesseract_command_language/composite_instruction.h>
-#include <tesseract_command_language/cereal_serialization.h>
-#include <tesseract_environment/environment.h>
-#include <tesseract_environment/cereal_serialization.h>
-#include <tesseract_scene_graph/scene_state.h>
-#include <tesseract_scene_graph/cereal_serialization.h>
+#include <tesseract/common/serialization.h>
+#include <tesseract/command_language/composite_instruction.h>
+#include <tesseract/command_language/cereal_serialization.h>
+#include <tesseract/environment/environment.h>
+#include <tesseract/environment/cereal_serialization.h>
+#include <tesseract/scene_graph/scene_state.h>
+#include <tesseract/scene_graph/cereal_serialization.h>
 
 // CEREAL_REGISTER_TYPE expansion needs all archive headers visible before the
 // macro fires (so cereal can bind the type to each archive at TU init).
@@ -24,10 +24,10 @@
 #include <cereal/archives/json.hpp>
 
 namespace nb = nanobind;
-using namespace tesseract_common;
+using namespace tesseract::common;
 using namespace tesseract_planning;
-using namespace tesseract_environment;
-using namespace tesseract_scene_graph;
+using namespace tesseract::environment;
+using namespace tesseract::scene_graph;
 
 // Cereal polymorphic-type registry on Windows MSVC is per-DLL — class-template
 // statics (StaticObject<InputBindingMap<Archive>>, OutputBindingMap, ...) are
@@ -80,7 +80,7 @@ CEREAL_REGISTER_POLYMORPHIC_RELATION(tesseract_planning::InstructionInterface, t
 CEREAL_REGISTER_POLYMORPHIC_RELATION(tesseract_planning::InstructionInterface, tesseract_planning::TimerInstruction)
 CEREAL_REGISTER_POLYMORPHIC_RELATION(tesseract_planning::InstructionInterface, tesseract_planning::WaitInstruction)
 
-CEREAL_REGISTER_POLYMORPHIC_RELATION(tesseract_common::AnyInterface, tesseract_planning::CompositeInstructionAnyPoly)
+CEREAL_REGISTER_POLYMORPHIC_RELATION(tesseract::common::AnyInterface, tesseract_planning::CompositeInstructionAnyPoly)
 
 // Belt-and-suspenders: also keep the upstream TU anchored. Harmless if the
 // TU is already alive; the consumer-side registrations above are the actual

--- a/src/tesseract_srdf/tesseract_srdf_bindings.cpp
+++ b/src/tesseract_srdf/tesseract_srdf_bindings.cpp
@@ -14,7 +14,7 @@
 #include <tesseract/common/calibration_info.h>
 #include <tesseract/common/collision_margin_data.h>
 
-namespace ts = tesseract_srdf;
+namespace ts = tesseract::srdf;
 
 NB_MODULE(_tesseract_srdf, m) {
     m.doc() = "tesseract_srdf Python bindings";

--- a/src/tesseract_srdf/tesseract_srdf_bindings.cpp
+++ b/src/tesseract_srdf/tesseract_srdf_bindings.cpp
@@ -5,14 +5,14 @@
 
 #include "tesseract_nb.h"
 
-#include <tesseract_srdf/srdf_model.h>
-#include <tesseract_srdf/kinematics_information.h>
-#include <tesseract_srdf/utils.h>
-#include <tesseract_scene_graph/graph.h>
-#include <tesseract_common/resource_locator.h>
-#include <tesseract_common/allowed_collision_matrix.h>
-#include <tesseract_common/calibration_info.h>
-#include <tesseract_common/collision_margin_data.h>
+#include <tesseract/srdf/srdf_model.h>
+#include <tesseract/srdf/kinematics_information.h>
+#include <tesseract/srdf/utils.h>
+#include <tesseract/scene_graph/graph.h>
+#include <tesseract/common/resource_locator.h>
+#include <tesseract/common/allowed_collision_matrix.h>
+#include <tesseract/common/calibration_info.h>
+#include <tesseract/common/collision_margin_data.h>
 
 namespace ts = tesseract_srdf;
 

--- a/src/tesseract_state_solver/tesseract_state_solver_bindings.cpp
+++ b/src/tesseract_state_solver/tesseract_state_solver_bindings.cpp
@@ -22,8 +22,8 @@
 #include <tesseract/common/kinematic_limits.h>
 #include <tesseract/common/eigen_types.h>
 
-namespace tsg = tesseract_scene_graph;
-namespace tc = tesseract_common;
+namespace tsg = tesseract::scene_graph;
+namespace tc = tesseract::common;
 
 NB_MODULE(_tesseract_state_solver, m) {
     m.doc() = "tesseract_state_solver Python bindings";

--- a/src/tesseract_state_solver/tesseract_state_solver_bindings.cpp
+++ b/src/tesseract_state_solver/tesseract_state_solver_bindings.cpp
@@ -7,20 +7,20 @@
 #include <nanobind/stl/map.h>
 
 // tesseract_state_solver
-#include <tesseract_state_solver/state_solver.h>
-#include <tesseract_state_solver/mutable_state_solver.h>
-#include <tesseract_state_solver/kdl/kdl_state_solver.h>
-#include <tesseract_state_solver/ofkt/ofkt_state_solver.h>
+#include <tesseract/state_solver/state_solver.h>
+#include <tesseract/state_solver/mutable_state_solver.h>
+#include <tesseract/state_solver/kdl/kdl_state_solver.h>
+#include <tesseract/state_solver/ofkt/ofkt_state_solver.h>
 
 // tesseract_scene_graph for SceneState and SceneGraph
-#include <tesseract_scene_graph/scene_state.h>
-#include <tesseract_scene_graph/graph.h>
-#include <tesseract_scene_graph/link.h>
-#include <tesseract_scene_graph/joint.h>
+#include <tesseract/scene_graph/scene_state.h>
+#include <tesseract/scene_graph/graph.h>
+#include <tesseract/scene_graph/link.h>
+#include <tesseract/scene_graph/joint.h>
 
 // tesseract_common
-#include <tesseract_common/kinematic_limits.h>
-#include <tesseract_common/eigen_types.h>
+#include <tesseract/common/kinematic_limits.h>
+#include <tesseract/common/eigen_types.h>
 
 namespace tsg = tesseract_scene_graph;
 namespace tc = tesseract_common;

--- a/src/tesseract_task_composer/tesseract_task_composer_bindings.cpp
+++ b/src/tesseract_task_composer/tesseract_task_composer_bindings.cpp
@@ -15,35 +15,35 @@
 #include <sstream>
 
 // tesseract_task_composer core
-#include <tesseract_task_composer/core/task_composer_context.h>
-#include <tesseract_task_composer/core/task_composer_data_storage.h>
-#include <tesseract_task_composer/core/task_composer_executor.h>
-#include <tesseract_task_composer/core/task_composer_future.h>
-#include <tesseract_task_composer/core/task_composer_node.h>
-#include <tesseract_task_composer/core/task_composer_node_info.h>
-#include <tesseract_task_composer/core/task_composer_keys.h>
-#include <tesseract_task_composer/core/task_composer_plugin_factory.h>
-#include <tesseract_task_composer/core/task_composer_server.h>
+#include <tesseract/task_composer/task_composer_context.h>
+#include <tesseract/task_composer/task_composer_data_storage.h>
+#include <tesseract/task_composer/task_composer_executor.h>
+#include <tesseract/task_composer/task_composer_future.h>
+#include <tesseract/task_composer/task_composer_node.h>
+#include <tesseract/task_composer/task_composer_node_info.h>
+#include <tesseract/task_composer/task_composer_keys.h>
+#include <tesseract/task_composer/task_composer_plugin_factory.h>
+#include <tesseract/task_composer/task_composer_server.h>
 
 // tesseract_task_composer taskflow
-#include <tesseract_task_composer/taskflow/taskflow_task_composer_executor.h>
+#include <tesseract/task_composer/taskflow/taskflow_task_composer_executor.h>
 
 // tesseract_common
-#include <tesseract_common/any_poly.h>
-#include <tesseract_common/resource_locator.h>
+#include <tesseract/common/any_poly.h>
+#include <tesseract/common/resource_locator.h>
 #include <filesystem>
 
 // tesseract_environment for Environment wrapper
-#include <tesseract_environment/environment.h>
+#include <tesseract/environment/environment.h>
 
 // tesseract_command_language for CompositeInstruction
-#include <tesseract_command_language/composite_instruction.h>
+#include <tesseract/command_language/composite_instruction.h>
 // Note: ProfileDictionary moved to tesseract_common in 0.33
-#include <tesseract_common/profile_dictionary.h>
+#include <tesseract/common/profile_dictionary.h>
 
 // tesseract_collision for ContactResultMap (DiscreteContactCheckTask saves
 // std::vector<ContactResultMap> on its node info's data_storage)
-#include <tesseract_collision/core/types.h>
+#include <tesseract/collision/types.h>
 
 // console_bridge for log output visible alongside the rest of tesseract's logging
 #include <console_bridge/console.h>
@@ -407,8 +407,8 @@ NB_MODULE(_tesseract_task_composer, m) {
     }, "any_poly"_a, "Extract a TaskComposerDataStorage from an AnyPoly");
 
     m.def("AnyPoly_as_ContactResultMapVector",
-          [](const tc::AnyPoly& ap) -> std::vector<tesseract_collision::ContactResultMap> {
-        return ap.as<std::vector<tesseract_collision::ContactResultMap>>();
+          [](const tc::AnyPoly& ap) -> std::vector<tesseract::collision::ContactResultMap> {
+        return ap.as<std::vector<tesseract::collision::ContactResultMap>>();
     }, "any_poly"_a,
        "Extract a std::vector<ContactResultMap> from an AnyPoly. "
        "DiscreteContactCheckTask saves its per-step contact results under "

--- a/src/tesseract_task_composer/tesseract_task_composer_bindings.cpp
+++ b/src/tesseract_task_composer/tesseract_task_composer_bindings.cpp
@@ -65,9 +65,10 @@
 #include <unordered_set>
 #endif
 
-namespace tp = tesseract_planning;
-namespace te = tesseract_environment;
-namespace tc = tesseract_common;
+namespace tp = tesseract::task_composer;
+namespace tcl = tesseract::command_language;
+namespace te = tesseract::environment;
+namespace tc = tesseract::common;
 
 #ifdef __APPLE__
 namespace {
@@ -380,7 +381,7 @@ NB_MODULE(_tesseract_task_composer, m) {
     // ========== AnyPoly wrapper functions for common types ==========
     // These wrap specific types into AnyPoly for use with TaskComposerDataStorage.setData()
 
-    m.def("AnyPoly_wrap_CompositeInstruction", [](const tp::CompositeInstruction& ci) {
+    m.def("AnyPoly_wrap_CompositeInstruction", [](const tcl::CompositeInstruction& ci) {
         return tc::AnyPoly(ci);
     }, "instruction"_a, "Wrap a CompositeInstruction into an AnyPoly");
 
@@ -398,8 +399,8 @@ NB_MODULE(_tesseract_task_composer, m) {
     }, "data_storage"_a, "Wrap a TaskComposerDataStorage shared_ptr into an AnyPoly");
 
     // ========== AnyPoly unwrap functions ==========
-    m.def("AnyPoly_as_CompositeInstruction", [](const tc::AnyPoly& ap) -> tp::CompositeInstruction {
-        return ap.as<tp::CompositeInstruction>();
+    m.def("AnyPoly_as_CompositeInstruction", [](const tc::AnyPoly& ap) -> tcl::CompositeInstruction {
+        return ap.as<tcl::CompositeInstruction>();
     }, "any_poly"_a, "Extract a CompositeInstruction from an AnyPoly");
 
     m.def("AnyPoly_as_TaskComposerDataStorage", [](const tc::AnyPoly& ap) {

--- a/src/tesseract_task_composer_planning/tesseract_task_composer_planning_bindings.cpp
+++ b/src/tesseract_task_composer_planning/tesseract_task_composer_planning_bindings.cpp
@@ -26,8 +26,8 @@
 #include <tesseract/task_composer/planning/profiles/profile_switch_profile.h>
 #include <tesseract/task_composer/planning/profiles/upsample_trajectory_profile.h>
 
-namespace tp = tesseract_planning;
-namespace tc = tesseract_common;
+namespace tp = tesseract::task_composer;
+namespace tc = tesseract::common;
 
 NB_MODULE(_tesseract_task_composer_planning, m) {
     m.doc() = "tesseract_task_composer planning-node profile Python bindings";

--- a/src/tesseract_task_composer_planning/tesseract_task_composer_planning_bindings.cpp
+++ b/src/tesseract_task_composer_planning/tesseract_task_composer_planning_bindings.cpp
@@ -16,15 +16,15 @@
 #include "tesseract_nb.h"
 #include <nanobind/stl/vector.h>
 
-#include <tesseract_common/profile.h>
+#include <tesseract/common/profile.h>
 
-#include <tesseract_task_composer/planning/profiles/contact_check_profile.h>
-#include <tesseract_task_composer/planning/profiles/fix_state_bounds_profile.h>
-#include <tesseract_task_composer/planning/profiles/fix_state_collision_profile.h>
-#include <tesseract_task_composer/planning/profiles/kinematic_limits_check_profile.h>
-#include <tesseract_task_composer/planning/profiles/min_length_profile.h>
-#include <tesseract_task_composer/planning/profiles/profile_switch_profile.h>
-#include <tesseract_task_composer/planning/profiles/upsample_trajectory_profile.h>
+#include <tesseract/task_composer/planning/profiles/contact_check_profile.h>
+#include <tesseract/task_composer/planning/profiles/fix_state_bounds_profile.h>
+#include <tesseract/task_composer/planning/profiles/fix_state_collision_profile.h>
+#include <tesseract/task_composer/planning/profiles/kinematic_limits_check_profile.h>
+#include <tesseract/task_composer/planning/profiles/min_length_profile.h>
+#include <tesseract/task_composer/planning/profiles/profile_switch_profile.h>
+#include <tesseract/task_composer/planning/profiles/upsample_trajectory_profile.h>
 
 namespace tp = tesseract_planning;
 namespace tc = tesseract_common;

--- a/src/tesseract_time_parameterization/tesseract_time_parameterization_bindings.cpp
+++ b/src/tesseract_time_parameterization/tesseract_time_parameterization_bindings.cpp
@@ -8,22 +8,22 @@
 #include "tesseract_nb.h"
 
 // tesseract_time_parameterization
-#include <tesseract_time_parameterization/core/time_parameterization.h>
-#include <tesseract_time_parameterization/core/instructions_trajectory.h>
-#include <tesseract_time_parameterization/totg/time_optimal_trajectory_generation.h>
-#include <tesseract_time_parameterization/totg/time_optimal_trajectory_generation_profiles.h>
-#include <tesseract_time_parameterization/isp/iterative_spline_parameterization.h>
-#include <tesseract_time_parameterization/isp/iterative_spline_parameterization_profiles.h>
-#include <tesseract_time_parameterization/kdl/constant_tcp_speed_parameterization.h>
-#include <tesseract_time_parameterization/kdl/constant_tcp_speed_parameterization_profiles.h>
+#include <tesseract/time_parameterization/time_parameterization.h>
+#include <tesseract/time_parameterization/instructions_trajectory.h>
+#include <tesseract/time_parameterization/totg/time_optimal_trajectory_generation.h>
+#include <tesseract/time_parameterization/totg/time_optimal_trajectory_generation_profiles.h>
+#include <tesseract/time_parameterization/isp/iterative_spline_parameterization.h>
+#include <tesseract/time_parameterization/isp/iterative_spline_parameterization_profiles.h>
+#include <tesseract/time_parameterization/kdl/constant_tcp_speed_parameterization.h>
+#include <tesseract/time_parameterization/kdl/constant_tcp_speed_parameterization_profiles.h>
 
 // tesseract_command_language
-#include <tesseract_command_language/composite_instruction.h>
+#include <tesseract/command_language/composite_instruction.h>
 // Note: ProfileDictionary moved to tesseract_common in 0.33
-#include <tesseract_common/profile_dictionary.h>
+#include <tesseract/common/profile_dictionary.h>
 
 // tesseract_environment
-#include <tesseract_environment/environment.h>
+#include <tesseract/environment/environment.h>
 
 namespace tp = tesseract_planning;
 namespace tc = tesseract_common;

--- a/src/tesseract_time_parameterization/tesseract_time_parameterization_bindings.cpp
+++ b/src/tesseract_time_parameterization/tesseract_time_parameterization_bindings.cpp
@@ -25,8 +25,9 @@
 // tesseract_environment
 #include <tesseract/environment/environment.h>
 
-namespace tp = tesseract_planning;
-namespace tc = tesseract_common;
+namespace tp = tesseract::time_parameterization;
+namespace tcl = tesseract::command_language;
+namespace tc = tesseract::common;
 
 NB_MODULE(_tesseract_time_parameterization, m) {
     m.doc() = "tesseract_time_parameterization Python bindings";
@@ -36,7 +37,7 @@ NB_MODULE(_tesseract_time_parameterization, m) {
 
     // ========== InstructionsTrajectory ==========
     nb::class_<tp::InstructionsTrajectory>(m, "InstructionsTrajectory")
-        .def(nb::init<tp::CompositeInstruction&>(), "program"_a)
+        .def(nb::init<tcl::CompositeInstruction&>(), "program"_a)
         .def("getPosition", nb::overload_cast<Eigen::Index>(&tp::InstructionsTrajectory::getPosition, nb::const_), "i"_a)
         .def("getVelocity", nb::overload_cast<Eigen::Index>(&tp::InstructionsTrajectory::getVelocity, nb::const_), "i"_a)
         .def("getAcceleration", nb::overload_cast<Eigen::Index>(&tp::InstructionsTrajectory::getAcceleration, nb::const_), "i"_a)

--- a/src/tesseract_urdf/tesseract_urdf_bindings.cpp
+++ b/src/tesseract_urdf/tesseract_urdf_bindings.cpp
@@ -5,9 +5,9 @@
 
 #include "tesseract_nb.h"
 
-#include <tesseract_urdf/urdf_parser.h>
-#include <tesseract_scene_graph/graph.h>
-#include <tesseract_common/resource_locator.h>
+#include <tesseract/urdf/urdf_parser.h>
+#include <tesseract/scene_graph/graph.h>
+#include <tesseract/common/resource_locator.h>
 
 namespace tu = tesseract_urdf;
 

--- a/src/tesseract_urdf/tesseract_urdf_bindings.cpp
+++ b/src/tesseract_urdf/tesseract_urdf_bindings.cpp
@@ -9,7 +9,7 @@
 #include <tesseract/scene_graph/graph.h>
 #include <tesseract/common/resource_locator.h>
 
-namespace tu = tesseract_urdf;
+namespace tu = tesseract::urdf;
 
 NB_MODULE(_tesseract_urdf, m) {
     m.doc() = "tesseract_urdf Python bindings";

--- a/src/trajopt_ifopt/trajopt_ifopt_bindings.cpp
+++ b/src/trajopt_ifopt/trajopt_ifopt_bindings.cpp
@@ -38,12 +38,12 @@
 #include <trajopt_common/collision_types.h>
 
 // tesseract_collision for CollisionCheckConfig (used by TrajOptCollisionConfig)
-#include <tesseract_collision/core/types.h>
+#include <tesseract/collision/types.h>
 
 // tesseract dependencies
-#include <tesseract_kinematics/core/joint_group.h>
-#include <tesseract_kinematics/core/kinematic_group.h>
-#include <tesseract_environment/environment.h>
+#include <tesseract/kinematics/joint_group.h>
+#include <tesseract/kinematics/kinematic_group.h>
+#include <tesseract/environment/environment.h>
 
 namespace ti = trajopt_ifopt;
 namespace tc = trajopt_common;
@@ -260,7 +260,7 @@ NB_MODULE(_trajopt_ifopt, m) {
     nb::class_<ti::CartPosConstraint, ti::ConstraintSet>(m, "CartPosConstraint")
         .def("__init__", [](ti::CartPosConstraint* self,
                             std::shared_ptr<const ti::Var> position_var,
-                            std::shared_ptr<const tesseract_kinematics::JointGroup> manip,
+                            std::shared_ptr<const tesseract::kinematics::JointGroup> manip,
                             std::string source_frame,
                             std::string target_frame,
                             const Eigen::Isometry3d& source_frame_offset,
@@ -357,8 +357,8 @@ NB_MODULE(_trajopt_ifopt, m) {
     // ========== SingleTimestepCollisionEvaluator ==========
     // CollisionCache parameter removed in 0.34
     nb::class_<ti::SingleTimestepCollisionEvaluator, ti::DiscreteCollisionEvaluator>(m, "SingleTimestepCollisionEvaluator")
-        .def(nb::init<std::shared_ptr<const tesseract_kinematics::JointGroup>,
-                      std::shared_ptr<const tesseract_environment::Environment>,
+        .def(nb::init<std::shared_ptr<const tesseract::kinematics::JointGroup>,
+                      std::shared_ptr<const tesseract::environment::Environment>,
                       const tc::TrajOptCollisionConfig&,
                       bool>(),
              "manip"_a, "env"_a, "collision_config"_a,
@@ -386,8 +386,8 @@ NB_MODULE(_trajopt_ifopt, m) {
     // ========== LVSDiscreteCollisionEvaluator ==========
     // CollisionCache parameter removed in 0.34
     nb::class_<ti::LVSDiscreteCollisionEvaluator, ti::ContinuousCollisionEvaluator>(m, "LVSDiscreteCollisionEvaluator")
-        .def(nb::init<std::shared_ptr<const tesseract_kinematics::JointGroup>,
-                      std::shared_ptr<const tesseract_environment::Environment>,
+        .def(nb::init<std::shared_ptr<const tesseract::kinematics::JointGroup>,
+                      std::shared_ptr<const tesseract::environment::Environment>,
                       const tc::TrajOptCollisionConfig&,
                       bool>(),
              "manip"_a, "env"_a, "collision_config"_a,
@@ -396,8 +396,8 @@ NB_MODULE(_trajopt_ifopt, m) {
     // ========== LVSContinuousCollisionEvaluator ==========
     // CollisionCache parameter removed in 0.34
     nb::class_<ti::LVSContinuousCollisionEvaluator, ti::ContinuousCollisionEvaluator>(m, "LVSContinuousCollisionEvaluator")
-        .def(nb::init<std::shared_ptr<const tesseract_kinematics::JointGroup>,
-                      std::shared_ptr<const tesseract_environment::Environment>,
+        .def(nb::init<std::shared_ptr<const tesseract::kinematics::JointGroup>,
+                      std::shared_ptr<const tesseract::environment::Environment>,
                       const tc::TrajOptCollisionConfig&,
                       bool>(),
              "manip"_a, "env"_a, "collision_config"_a,

--- a/tests/tesseract_environment/test_mesh_material_loading.py
+++ b/tests/tesseract_environment/test_mesh_material_loading.py
@@ -11,7 +11,7 @@ mesh_urdf = """
   <link name="mesh_dae_link">
     <visual>
       <geometry>
-        <mesh filename="package://tesseract_support/meshes/tesseract_material_mesh.dae"/>
+        <mesh filename="package://tesseract/support/meshes/tesseract_material_mesh.dae"/>
       </geometry>
     </visual>
   </link>

--- a/tests/tesseract_motion_planners/test_descartes_planner.py
+++ b/tests/tesseract_motion_planners/test_descartes_planner.py
@@ -51,10 +51,10 @@ def abb_irb2400_environment():
     """Load ABB IRB2400 robot environment for testing (has OPW kinematics)."""
     locator = GeneralResourceLocator()
     urdf_path = FilesystemPath(
-        locator.locateResource("package://tesseract_support/urdf/abb_irb2400.urdf").getFilePath()
+        locator.locateResource("package://tesseract/support/urdf/abb_irb2400.urdf").getFilePath()
     )
     srdf_path = FilesystemPath(
-        locator.locateResource("package://tesseract_support/urdf/abb_irb2400.srdf").getFilePath()
+        locator.locateResource("package://tesseract/support/urdf/abb_irb2400.srdf").getFilePath()
     )
 
     t_env = Environment()

--- a/tests/tesseract_motion_planners/test_motion_planners.py
+++ b/tests/tesseract_motion_planners/test_motion_planners.py
@@ -39,10 +39,10 @@ def abb_irb2400_environment():
     """Load ABB IRB2400 robot environment for testing."""
     locator = GeneralResourceLocator()
     urdf_path = FilesystemPath(
-        locator.locateResource("package://tesseract_support/urdf/abb_irb2400.urdf").getFilePath()
+        locator.locateResource("package://tesseract/support/urdf/abb_irb2400.urdf").getFilePath()
     )
     srdf_path = FilesystemPath(
-        locator.locateResource("package://tesseract_support/urdf/abb_irb2400.srdf").getFilePath()
+        locator.locateResource("package://tesseract/support/urdf/abb_irb2400.srdf").getFilePath()
     )
     t_env = Environment()
     assert t_env.init(urdf_path, srdf_path, locator), "Failed to initialize ABB IRB2400"

--- a/tests/tesseract_motion_planners/test_trajopt_ifopt_planner.py
+++ b/tests/tesseract_motion_planners/test_trajopt_ifopt_planner.py
@@ -39,12 +39,12 @@ def kuka_iiwa_environment():
     locator = GeneralResourceLocator()
     urdf_path = FilesystemPath(
         locator.locateResource(
-            "package://tesseract_support/urdf/lbr_iiwa_14_r820.urdf"
+            "package://tesseract/support/urdf/lbr_iiwa_14_r820.urdf"
         ).getFilePath()
     )
     srdf_path = FilesystemPath(
         locator.locateResource(
-            "package://tesseract_support/urdf/lbr_iiwa_14_r820.srdf"
+            "package://tesseract/support/urdf/lbr_iiwa_14_r820.srdf"
         ).getFilePath()
     )
 

--- a/tests/tesseract_motion_planners/test_trajopt_planner.py
+++ b/tests/tesseract_motion_planners/test_trajopt_planner.py
@@ -54,12 +54,12 @@ def lbr_iiwa_environment():
     locator = GeneralResourceLocator()
     urdf_path = FilesystemPath(
         locator.locateResource(
-            "package://tesseract_support/urdf/lbr_iiwa_14_r820.urdf"
+            "package://tesseract/support/urdf/lbr_iiwa_14_r820.urdf"
         ).getFilePath()
     )
     srdf_path = FilesystemPath(
         locator.locateResource(
-            "package://tesseract_support/urdf/lbr_iiwa_14_r820.srdf"
+            "package://tesseract/support/urdf/lbr_iiwa_14_r820.srdf"
         ).getFilePath()
     )
 

--- a/tests/tesseract_planning/test_planning_api.py
+++ b/tests/tesseract_planning/test_planning_api.py
@@ -630,7 +630,7 @@ class TestGeometry:
 
         # Use mesh from tesseract_support package
         mesh = mesh_from_file(
-            "package://tesseract_support/meshes/car_seat/visual/end_effector_open.stl"
+            "package://tesseract/support/meshes/car_seat/visual/end_effector_open.stl"
         )
         assert mesh is not None
 
@@ -640,7 +640,7 @@ class TestGeometry:
 
         # Use mesh from tesseract_support package
         mesh = convex_mesh_from_file(
-            "package://tesseract_support/meshes/car_seat/visual/end_effector_open.stl"
+            "package://tesseract/support/meshes/car_seat/visual/end_effector_open.stl"
         )
         assert mesh is not None
 

--- a/tests/test_clone_methods.py
+++ b/tests/test_clone_methods.py
@@ -15,10 +15,10 @@ def abb_environment():
     """Load ABB IRB2400 environment."""
     locator = GeneralResourceLocator()
     urdf_path = FilesystemPath(
-        locator.locateResource("package://tesseract_support/urdf/abb_irb2400.urdf").getFilePath()
+        locator.locateResource("package://tesseract/support/urdf/abb_irb2400.urdf").getFilePath()
     )
     srdf_path = FilesystemPath(
-        locator.locateResource("package://tesseract_support/urdf/abb_irb2400.srdf").getFilePath()
+        locator.locateResource("package://tesseract/support/urdf/abb_irb2400.srdf").getFilePath()
     )
     env = Environment()
     assert env.init(urdf_path, srdf_path, locator)

--- a/tests/test_kinematics_plugin_loading.py
+++ b/tests/test_kinematics_plugin_loading.py
@@ -22,10 +22,10 @@ def test_kdl_kinematics_plugin_loads():
     locator = GeneralResourceLocator()
     env = Environment()
     urdf = locator.locateResource(
-        "package://tesseract_support/urdf/lbr_iiwa_14_r820.urdf"
+        "package://tesseract/support/urdf/lbr_iiwa_14_r820.urdf"
     ).getFilePath()
     srdf = locator.locateResource(
-        "package://tesseract_support/urdf/lbr_iiwa_14_r820.srdf"
+        "package://tesseract/support/urdf/lbr_iiwa_14_r820.srdf"
     ).getFilePath()
     assert env.init(FilesystemPath(urdf), FilesystemPath(srdf), locator)
 
@@ -42,8 +42,8 @@ def test_opw_kinematics_plugin_loads():
     """Test OPW kinematics plugin loads for ABB robot."""
     locator = GeneralResourceLocator()
     env = Environment()
-    urdf = locator.locateResource("package://tesseract_support/urdf/abb_irb2400.urdf").getFilePath()
-    srdf = locator.locateResource("package://tesseract_support/urdf/abb_irb2400.srdf").getFilePath()
+    urdf = locator.locateResource("package://tesseract/support/urdf/abb_irb2400.urdf").getFilePath()
+    srdf = locator.locateResource("package://tesseract/support/urdf/abb_irb2400.srdf").getFilePath()
     assert env.init(FilesystemPath(urdf), FilesystemPath(srdf), locator)
 
     # This should not raise RuntimeError if plugins load correctly

--- a/tests/trajopt_sqp/test_trajopt_sqp_bindings.py
+++ b/tests/trajopt_sqp/test_trajopt_sqp_bindings.py
@@ -56,12 +56,12 @@ def kuka_setup():
     locator = GeneralResourceLocator()
     urdf_path = FilesystemPath(
         locator.locateResource(
-            "package://tesseract_support/urdf/lbr_iiwa_14_r820.urdf"
+            "package://tesseract/support/urdf/lbr_iiwa_14_r820.urdf"
         ).getFilePath()
     )
     srdf_path = FilesystemPath(
         locator.locateResource(
-            "package://tesseract_support/urdf/lbr_iiwa_14_r820.srdf"
+            "package://tesseract/support/urdf/lbr_iiwa_14_r820.srdf"
         ).getFilePath()
     )
 


### PR DESCRIPTION
Closes #82.

## Summary

Lands the tesseract 0.35.0 upgrade across the whole stack:

- `tesseract`, `tesseract_planning`, `trajopt` → 0.35.0
- `descartes_light` → 0.4.10 (synced with tesseract release)
- `opw_kinematics` → 0.5.3 (tesseract 0.35.0 PR #1280)
- `ruckig` → switched to `Levi-Armstrong/ruckig @ cpack-v0.9.2` (matches upstream `tesseract_planning` 0.35.0 pin; we were previously diverging on `pantor/ruckig`)
- `dependencies.rosinstall` → `dependencies.repos` (upstream's ros2 vcs-tool convention)

## Structural absorption

Both `tesseract` and `tesseract_planning` 0.35.0 consolidated their many small CMake packages into single multi-component packages, with the `tesseract_` prefix dropped from headers, namespaces, and CMake targets. Applied via the upstream `MIGRATION.md` sed scripts (commit 8305948), then manual cleanup of cases sed missed (commit b9d1c15):

- `#include <tesseract_X/...>` → `<tesseract/X/...>` (and `core/` flattened)
- `tesseract_X::Foo` → `tesseract::X::Foo`
- `tesseract::tesseract_X` → `tesseract::X` (CMake)
- `find_package(tesseract_X)` → `find_package(tesseract REQUIRED COMPONENTS X)`
- `namespace tp = tesseract_planning;` (no 0.35 umbrella ns) → per-file split (`command_language` / `motion_planners` / `task_composer` / `time_parameterization`)

## Runtime resource resolution

In 0.35, `tesseract_support` is no longer a standalone ROS-style package — it's a subdirectory of the consolidated `tesseract` package. Updated 25 files (tests + examples + `__init__.py` + `scripts/env.sh` + `CMakeLists.txt`):

- URDF/SRDF URIs: `package://tesseract_support/` → `package://tesseract/support/`
- Dev-workspace fallback paths: `ws/src/tesseract/tesseract_support/` → `ws/src/tesseract/support/`, same for `tesseract_task_composer/` → `task_composer/`

## Cereal Windows workaround obsoleted

In 0.34 our `tesseract_serialization_bindings.cpp` carried a hand-rolled mirror of upstream's `CEREAL_REGISTER_TYPE` macros to populate the Windows `.pyd`'s per-DLL cereal registry. In 0.35, upstream's `<tesseract/command_language/cereal_serialization.h>` transitively includes a new `cereal_serialization_impl.hpp` registration-only header — every consumer TU gets the registrations automatically, including Windows `.pyd` consumers. The consumer-side mirror became actively harmful (triggered `redefinition of binding_name<...>` errors); removed.

The CLAUDE.md note about the per-DLL cereal registry workaround is now obsolete and should be trimmed once Windows CI confirms.

## Test status (macOS arm64, local)

| | |
|--- |---|
| Passed | **560** (up from 352 pre-upgrade) |
| Failed | 7 |
| Skipped | 14 |

All 23 nanobind modules import cleanly.

## Known issue — out of scope for this PR

All 7 failures are in `tests/benchmarks/test_parallel_scaling.py` "harder problem" stress cases, throwing the same `Planning failed: ErrorTask: Error (Abort Triggered)`. Likely a task composer abort-condition or tolerance change in 0.35 — not a binding-layer break. Worth a separate ticket once Linux/Windows CI confirms the failures are platform-independent.

## Documentation

`docs/changes.md` has a new `0.34 → 0.35` section mirroring the prior `0.33 → 0.34` format — dependency versions, structural changes, Python-side resource-resolution notes, migration checklist.

## Test plan

- [x] macOS arm64: 560 / 567 pass
- [ ] Linux x86_64 wheel build (CI)
- [ ] Windows wheel build (CI)
- [ ] Triage 7 `test_parallel_scaling` benchmark failures (separate ticket)