### PR TITLE
fix(release): prevent local-version wheels + idempotent PyPI publish

### DIFF
--- a/.github/workflows/wheels-linux.yml
+++ b/.github/workflows/wheels-linux.yml
@@ -180,3 +180,5 @@ jobs:
       run: ls -la dist/
     - name: Publish to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        skip-existing: true  # idempotent re-runs: skip already-uploaded wheels instead of 400-aborting the batch

--- a/.github/workflows/wheels-macos.yml
+++ b/.github/workflows/wheels-macos.yml
@@ -86,11 +86,36 @@ jobs:
     - name: build wheel
       working-directory: ws/src/tesseract_nanobind
       run: pixi run build-wheel
+    # actions/upload-artifact@v4 intermittently fails on macOS arm64 runners with
+    # "Failed to CreateArtifact: Request timeout" (~1/3 of uploads) — a long-standing
+    # open GitHub bug (actions/upload-artifact#569, #527) inherent to arm64 mac runners'
+    # network to the artifact service. The action's 5 internal retries exhaust within the
+    # same bad window; a fresh outer re-invocation usually succeeds. Retry up to 3×; the
+    # final attempt has no continue-on-error, so a real outage still fails loud (no silent
+    # wheel loss). overwrite:true on retries clears any half-created artifact.
     - name: archive wheel
+      id: up1
+      continue-on-error: true
       uses: actions/upload-artifact@v4
       with:
         name: python-${{ matrix.python }}-macos-arm64
         path: ws/src/tesseract_nanobind/wheelhouse/tesseract*.whl
+    - name: archive wheel (retry 1)
+      if: steps.up1.outcome == 'failure'
+      id: up2
+      continue-on-error: true
+      uses: actions/upload-artifact@v4
+      with:
+        name: python-${{ matrix.python }}-macos-arm64
+        path: ws/src/tesseract_nanobind/wheelhouse/tesseract*.whl
+        overwrite: true
+    - name: archive wheel (retry 2 — fail loud if still down)
+      if: steps.up1.outcome == 'failure' && steps.up2.outcome == 'failure'
+      uses: actions/upload-artifact@v4
+      with:
+        name: python-${{ matrix.python }}-macos-arm64
+        path: ws/src/tesseract_nanobind/wheelhouse/tesseract*.whl
+        overwrite: true
     - name: archive logs
       if: failure()
       uses: actions/upload-artifact@v4

--- a/.github/workflows/wheels-macos.yml
+++ b/.github/workflows/wheels-macos.yml
@@ -32,7 +32,7 @@ jobs:
   build:
     runs-on: macos-14
     strategy:
-      fail-fast: true  # one failure aborts the others — save CI minutes during iteration
+      fail-fast: false  # release wheels: never let one flaky job cancel sibling builds — a partial matrix fragments the published set (see 0.35.0.2)
       matrix:
         python: ['3.9', '3.10', '3.11', '3.12']
     defaults:
@@ -158,3 +158,5 @@ jobs:
       run: ls -la dist/
     - name: Publish to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        skip-existing: true  # idempotent re-runs: skip already-uploaded wheels instead of 400-aborting the batch

--- a/.github/workflows/wheels-macos.yml
+++ b/.github/workflows/wheels-macos.yml
@@ -127,11 +127,17 @@ jobs:
   test-wheel:
     needs: build
     runs-on: macos-14
-    continue-on-error: ${{ matrix.python == '3.9' }}
+    continue-on-error: ${{ matrix.continue_on_error }}
     strategy:
       fail-fast: false
       matrix:
-        python: ['3.9', '3.12']
+        # 3.13/3.14 install the cp312-abi3 wheel (STABLE_ABI) to verify the
+        # published support matrix on macOS, not just Linux. wheel != python.
+        include:
+          - { python: '3.9',  wheel: '3.9',  continue_on_error: true }
+          - { python: '3.12', wheel: '3.12', continue_on_error: false }
+          - { python: '3.13', wheel: '3.12', continue_on_error: false }
+          - { python: '3.14', wheel: '3.12', continue_on_error: true }
     steps:
       - uses: actions/checkout@v4
         with:
@@ -139,9 +145,10 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
+          allow-prereleases: true
       - uses: actions/download-artifact@v4
         with:
-          name: python-${{ matrix.python }}-macos-arm64
+          name: python-${{ matrix.wheel }}-macos-arm64
           path: wheelhouse/
       - name: install wheel in virgin env
         run: |

--- a/.github/workflows/wheels-windows.yml
+++ b/.github/workflows/wheels-windows.yml
@@ -381,11 +381,17 @@ jobs:
   test-wheel:
     needs: build
     runs-on: windows-2022
-    continue-on-error: ${{ matrix.python == '3.9' }}
+    continue-on-error: ${{ matrix.continue_on_error }}
     strategy:
       fail-fast: false
       matrix:
-        python: ['3.9', '3.12']
+        # 3.13/3.14 install the cp312-abi3 wheel (STABLE_ABI) to verify the
+        # published support matrix on Windows, not just Linux. wheel != python.
+        include:
+          - { python: '3.9',  wheel: '3.9',  continue_on_error: true }
+          - { python: '3.12', wheel: '3.12', continue_on_error: false }
+          - { python: '3.13', wheel: '3.12', continue_on_error: false }
+          - { python: '3.14', wheel: '3.12', continue_on_error: true }
     defaults:
       run:
         shell: bash -el {0}
@@ -397,9 +403,10 @@ jobs:
       with:
         python-version: ${{ matrix.python }}
         architecture: x64
+        allow-prereleases: true
     - uses: actions/download-artifact@v4
       with:
-        name: python-${{ matrix.python }}-windows-x64-pixi
+        name: python-${{ matrix.wheel }}-windows-x64-pixi
         path: wheelhouse
 
     - name: install wheel in clean venv

--- a/.github/workflows/wheels-windows.yml
+++ b/.github/workflows/wheels-windows.yml
@@ -447,3 +447,5 @@ jobs:
       run: ls -la dist/
     - name: Publish to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        skip-existing: true  # idempotent re-runs: skip already-uploaded wheels instead of 400-aborting the batch

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.35.0.3] - 2026-06-05 — complete wheel matrix for the 0.35.0.2 content
+
+Reissue of [0.35.0.2] with the full wheel set actually published. In 0.35.0.2 a dirty CI build tree made `setuptools_scm` stamp a PEP 440 local segment (`+d<date>`) onto some wheels; PyPI rejects those with HTTP 400, and the non-idempotent publish step aborted mid-upload — so macOS (all) and Linux x86_64 (`cp39`/`cp311`) wheels never landed. 0.35.0.2 is yanked. Identical bindings to 0.35.0.2 — no API changes ([49f1aa9]).
+
+- **Release pipeline hardened** — `setuptools_scm` `local_scheme = "no-local-version"` so a dirty tag build can't produce a PyPI-rejected local version; `skip-existing: true` on all three publish workflows so re-runs fill gaps instead of 400-aborting; macOS `fail-fast: false` so one flaky build can't cancel sibling wheels ([49f1aa9]).
+
 ## [0.35.0.2] - 2026-06-04 — aarch64 / Jetson Linux wheels + collision manager bindings
 
 Extends Linux wheel coverage to `aarch64` (including NVIDIA Jetson), completes the contact-manager binding surface, and hardens the new ROS RPY decomposition against gimbal-lock edge cases ([#97], [669f2da], [f30014b]).
@@ -81,7 +87,8 @@ First PyPI-published macOS arm64 wheels, shipping via a dedicated `wheels-macos.
 - Non-benchmark tests fail loud instead of being silently skipped ([a1d7607]).
 - Python 3.9 compatibility for example modules via `from __future__ import annotations` ([87ce68e]).
 
-[Unreleased]: https://github.com/tesseract-robotics/tesseract_nanobind/compare/0.35.0.2...HEAD
+[Unreleased]: https://github.com/tesseract-robotics/tesseract_nanobind/compare/0.35.0.3...HEAD
+[0.35.0.3]: https://github.com/tesseract-robotics/tesseract_nanobind/compare/0.35.0.2...0.35.0.3
 [0.35.0.2]: https://github.com/tesseract-robotics/tesseract_nanobind/compare/0.35.0.1...0.35.0.2
 [0.35.0.1]: https://github.com/tesseract-robotics/tesseract_nanobind/compare/0.34.1.7...0.35.0.1
 [0.34.1.7]: https://github.com/tesseract-robotics/tesseract_nanobind/compare/0.34.1.6...0.34.1.7
@@ -169,6 +176,7 @@ First PyPI-published macOS arm64 wheels, shipping via a dedicated `wheels-macos.
 [af7bc4e]: https://github.com/tesseract-robotics/tesseract_nanobind/commit/af7bc4e
 [ba0510f]: https://github.com/tesseract-robotics/tesseract_nanobind/commit/ba0510f
 [c897251]: https://github.com/tesseract-robotics/tesseract_nanobind/commit/c897251
+[49f1aa9]: https://github.com/tesseract-robotics/tesseract_nanobind/commit/49f1aa9
 [669f2da]: https://github.com/tesseract-robotics/tesseract_nanobind/commit/669f2da
 [f30014b]: https://github.com/tesseract-robotics/tesseract_nanobind/commit/f30014b
 [7a3b0e3]: https://github.com/tesseract-robotics/tesseract_nanobind/commit/7a3b0e3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 Reissue of [0.35.0.2] with the full wheel set actually published. In 0.35.0.2 a dirty CI build tree made `setuptools_scm` stamp a PEP 440 local segment (`+d<date>`) onto some wheels; PyPI rejects those with HTTP 400, and the non-idempotent publish step aborted mid-upload — so macOS (all) and Linux x86_64 (`cp39`/`cp311`) wheels never landed. 0.35.0.2 is yanked. Identical bindings to 0.35.0.2 — no API changes ([49f1aa9]).
 
 - **Release pipeline hardened** — `setuptools_scm` `local_scheme = "no-local-version"` so a dirty tag build can't produce a PyPI-rejected local version; `skip-existing: true` on all three publish workflows so re-runs fill gaps instead of 400-aborting; macOS `fail-fast: false` so one flaky build can't cancel sibling wheels; plus a 3× retry on the macOS `upload-artifact` step working around GitHub's long-standing arm64-runner `CreateArtifact` timeout (`actions/upload-artifact#569`, still open) that otherwise skips the entire macOS publish ~80% of the time ([49f1aa9], [804d5b8]).
+- **`cp312-abi3` support verified on all platforms** — macOS and Windows `test-wheel` now install the `cp312-abi3` wheel on Python 3.13/3.14 (mirroring Linux; `wheel != python`), so the published 3.9–3.14 support matrix is verified in CI, not just asserted ([14a4cea]).
 
 ## [0.35.0.2] - 2026-06-04 — aarch64 / Jetson Linux wheels + collision manager bindings
 
@@ -178,6 +179,7 @@ First PyPI-published macOS arm64 wheels, shipping via a dedicated `wheels-macos.
 [c897251]: https://github.com/tesseract-robotics/tesseract_nanobind/commit/c897251
 [49f1aa9]: https://github.com/tesseract-robotics/tesseract_nanobind/commit/49f1aa9
 [804d5b8]: https://github.com/tesseract-robotics/tesseract_nanobind/commit/804d5b8
+[14a4cea]: https://github.com/tesseract-robotics/tesseract_nanobind/commit/14a4cea
 [669f2da]: https://github.com/tesseract-robotics/tesseract_nanobind/commit/669f2da
 [f30014b]: https://github.com/tesseract-robotics/tesseract_nanobind/commit/f30014b
 [7a3b0e3]: https://github.com/tesseract-robotics/tesseract_nanobind/commit/7a3b0e3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 Reissue of [0.35.0.2] with the full wheel set actually published. In 0.35.0.2 a dirty CI build tree made `setuptools_scm` stamp a PEP 440 local segment (`+d<date>`) onto some wheels; PyPI rejects those with HTTP 400, and the non-idempotent publish step aborted mid-upload — so macOS (all) and Linux x86_64 (`cp39`/`cp311`) wheels never landed. 0.35.0.2 is yanked. Identical bindings to 0.35.0.2 — no API changes ([49f1aa9]).
 
-- **Release pipeline hardened** — `setuptools_scm` `local_scheme = "no-local-version"` so a dirty tag build can't produce a PyPI-rejected local version; `skip-existing: true` on all three publish workflows so re-runs fill gaps instead of 400-aborting; macOS `fail-fast: false` so one flaky build can't cancel sibling wheels ([49f1aa9]).
+- **Release pipeline hardened** — `setuptools_scm` `local_scheme = "no-local-version"` so a dirty tag build can't produce a PyPI-rejected local version; `skip-existing: true` on all three publish workflows so re-runs fill gaps instead of 400-aborting; macOS `fail-fast: false` so one flaky build can't cancel sibling wheels; plus a 3× retry on the macOS `upload-artifact` step working around GitHub's long-standing arm64-runner `CreateArtifact` timeout (`actions/upload-artifact#569`, still open) that otherwise skips the entire macOS publish ~80% of the time ([49f1aa9], [804d5b8]).
 
 ## [0.35.0.2] - 2026-06-04 — aarch64 / Jetson Linux wheels + collision manager bindings
 
@@ -177,6 +177,7 @@ First PyPI-published macOS arm64 wheels, shipping via a dedicated `wheels-macos.
 [ba0510f]: https://github.com/tesseract-robotics/tesseract_nanobind/commit/ba0510f
 [c897251]: https://github.com/tesseract-robotics/tesseract_nanobind/commit/c897251
 [49f1aa9]: https://github.com/tesseract-robotics/tesseract_nanobind/commit/49f1aa9
+[804d5b8]: https://github.com/tesseract-robotics/tesseract_nanobind/commit/804d5b8
 [669f2da]: https://github.com/tesseract-robotics/tesseract_nanobind/commit/669f2da
 [f30014b]: https://github.com/tesseract-robotics/tesseract_nanobind/commit/f30014b
 [7a3b0e3]: https://github.com/tesseract-robotics/tesseract_nanobind/commit/7a3b0e3

--- a/docs/developer/macos-wheels.md
+++ b/docs/developer/macos-wheels.md
@@ -1,0 +1,98 @@
+# macOS Wheels: arm64 CI Gotchas
+
+Notes captured during the 0.35.0.x release-pipeline hardening
+([PR #98](https://github.com/tesseract-robotics/tesseract_nanobind/pull/98)),
+recorded so future maintainers don't re-diagnose them.
+
+The macOS build runs on `macos-14` (Apple Silicon, arm64) and has sharp edges
+the Linux build doesn't. The dangerous part: each one fragments a *release*
+rather than failing a *build*, so it surfaces as a gappy wheel set on PyPI
+**after** the tag is cut — not as CI red you'd catch in review.
+
+## upload-artifact times out ~1/3 of the time on arm64 runners
+
+!!! danger "`actions/upload-artifact@v4` `CreateArtifact: Request timeout` is a known, unfixed arm64-runner bug"
+    On `macos-14` (and any arm64 macOS runner) the `archive wheel` step fails
+    roughly **one upload in three** with
+    `Failed to CreateArtifact: Failed to make request after 5 attempts: Request timeout`.
+    The wheel built fine — the failure is purely the upload handshake to GitHub's
+    artifact service. It is a long-standing open defect
+    ([actions/upload-artifact#569](https://github.com/actions/upload-artifact/issues/569),
+    [#527](https://github.com/actions/upload-artifact/issues/527)); the Actions
+    team acknowledged it in Dec 2024 and it is still open. The action's own 5
+    internal retries exhaust within the same bad network window, so they don't
+    help — a *fresh outer re-invocation* usually succeeds.
+
+    Why it fragments releases: `publish` has `needs: [build]`, so **one** failed
+    upload marks the whole `build` matrix failed and the entire macOS publish is
+    skipped — zero macOS wheels for that release. At ~1/3 per job across 4 Python
+    builds, P(all 4 upload) = (2/3)⁴ ≈ **20%**, so ~80% of macOS releases would
+    otherwise need a manual job re-run.
+
+    Fix (`wheels-macos.yml`): retry the `archive wheel` step up to 3× with
+    `overwrite: true` on the retries (clears any half-created artifact). The
+    final attempt has **no** `continue-on-error`, so a genuine outage still
+    fails loud — never a silently-missing wheel.
+
+## The runner label is an architecture, not just an OS version
+
+!!! warning "Lowering `runs-on: macos-14` silently flips the wheel from arm64 to x86_64"
+    GitHub's macOS runner labels split by **architecture**, not just OS age:
+
+    | label | arch | notes |
+    |---|---|---|
+    | `macos-12` | Intel x86_64 | removed Dec 2024 |
+    | `macos-13` | Intel x86_64 | deprecation path |
+    | `macos-14` | **arm64** | what we build on |
+    | `macos-15` | arm64 | newer; raises min-OS tag to 15 |
+
+    We ship `macosx_14_0_arm64`. "Lowering the macOS version" to `macos-13`/`-12`
+    to dodge a runner problem (e.g. the upload flakiness above) does **not** keep
+    the same wheel — it switches the build to **x86_64**, orphaning every
+    Apple-Silicon user. And it wouldn't even help: the upload bug reproduces on
+    `macos-13-xl-arm64` too, so it is arm64-runner-inherent, not OS-version
+    specific.
+
+    The legitimate "lower the macOS version" lever is
+    **`MACOSX_DEPLOYMENT_TARGET`** (a build-env var, independent of the runner) —
+    it sets the wheel's *minimum* macOS (`macosx_13_0_arm64`, …) for broader
+    install compatibility without touching the runner or the architecture. Use
+    that, not the runner label.
+
+## colcon cache key over-invalidates on unrelated pyproject edits
+
+!!! warning "The colcon cache key hashes all of `pyproject.toml`, so a one-line edit forces a ~15-min C++ rebuild"
+    The C++ dependency cache key is
+    `colcon-macos-v2-py${python}-${hashFiles('dependencies.repos', 'pyproject.toml')}`.
+    Because it hashes the **entire** `pyproject.toml`, any edit — even one that
+    touches no C++ dependency (a `setuptools_scm` setting, a ruff rule, a trove
+    classifier) — changes the hash, misses the cache, and rebuilds all of
+    tesseract from scratch (~15–18 min per Python). There is no `restore-keys`
+    fallback, so the miss is total.
+
+    This degrades *speed*, never *correctness* (a fresh build is still a correct
+    build), but it makes otherwise-trivial PRs unexpectedly slow. Worth narrowing
+    to a deps-only hash if cold-build time becomes a problem. It is **not** a
+    cause of any wheel-fragmentation failure — those are the upload and publish
+    issues above; the cache only affects how long the green path takes.
+
+## STABLE_ABI: the wheel under test is not the Python under test
+
+!!! note "3.13/3.14 are verified by installing the `cp312-abi3` wheel, not by building a 3.13/3.14 wheel"
+    nanobind's `STABLE_ABI` build emits a single `cp312-abi3` wheel that pip
+    installs on CPython 3.12, 3.13, 3.14+ — on every platform. So 3.13/3.14
+    *support* is real on macOS and Windows even though no 3.13/3.14 wheel is
+    built. To **verify** it in CI, the `test-wheel` matrix decouples the test
+    interpreter from the wheel artifact with a `wheel` field:
+
+    ```yaml
+    include:
+      - { python: '3.13', wheel: '3.12', continue_on_error: false }
+      - { python: '3.14', wheel: '3.12', continue_on_error: true }
+    ```
+
+    The download step then pulls `python-${{ matrix.wheel }}-macos-arm64` (the
+    `cp312-abi3` artifact) and installs it on a 3.13/3.14 interpreter
+    (`allow-prereleases: true`). Before PR #98 only Linux did this; macOS and
+    Windows tested 3.9 + 3.12 only, leaving the cross-platform abi3 claim
+    *asserted* but not *verified*. Now all three platforms verify it.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -176,6 +176,7 @@ nav:
     - SWIG to Nanobind Migration: developer/migration.md
     - TrajOpt-Ifopt Constraints: developer/trajopt_ifopt_missing_constraints.md
     - Windows Wheel Gotchas: developer/windows-wheels.md
+    - macOS Wheel Gotchas: developer/macos-wheels.md
 
 extra:
   version:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,6 +102,12 @@ provider = "scikit_build_core.metadata.setuptools_scm"
 [tool.setuptools_scm]
 root = "."
 tag_regex = "^(?P<version>\\d+\\.\\d+\\.\\d+\\.\\d+)$"
+# PyPI rejects PEP 440 local-version segments (the "+g<sha>.d<date>" suffix the default
+# node-and-date scheme stamps onto a dirty build tree) with HTTP 400. CI wheel jobs can
+# dirty the tree (generated .pyi stubs / in-place YAML patches), so without this twine
+# aborts mid-batch and fragments the release across platforms (see 0.35.0.2). Force a
+# local-free version so every tag build is uploadable.
+local_scheme = "no-local-version"
 
 [tool.scikit-build.cmake.define]
 CMAKE_POLICY_DEFAULT_CMP0135 = "NEW"


### PR DESCRIPTION
## Problem

`0.35.0.2` published an **incoherent wheel set**: Windows got all 4 wheels, but macOS got only `cp310` and Linux x86_64 was missing `cp39`/`cp311` — so macOS has no `cp312-abi3` (3.12/3.13/3.14) coverage at all. ([0.35.0.2 files](https://pypi.org/project/tesseract-robotics-nanobind/0.35.0.2/#files) vs [0.35.0.1](https://pypi.org/project/tesseract-robotics-nanobind/0.35.0.1/#files))

## Root cause

On the `0.35.0.2` tag run, every `build`/`test-wheel` job was green — only `publish` failed:

```
HTTPError: 400 Bad Request — The use of local versions ... is not allowed
```

`[tool.setuptools_scm]` had no `local_scheme`, defaulting to `node-and-date`. A **dirty CI build tree** (generated `.pyi` stubs / in-place YAML patches) made it stamp a PEP 440 local segment (`0.35.0.2+d<date>`) onto some wheels. PyPI 400-rejects local versions, and `pypa/gh-action-pypi-publish` ran with `skip-existing: false`, so twine aborted the batch on the first reject — fragmenting the release permanently (PyPI versions are immutable). Windows happened to produce an all-clean set, so it completed.

Evidence: macOS tag run `26958655953`, Linux tag run `26958656216` (both: all builds green, `publish` red with the 400). The `cp312-abi3` matrix design itself is correct — `0.35.0.1` proves it (clean 12-wheel set).

## Fix

- **`local_scheme = "no-local-version"`** — a dirty tag build can never produce a PyPI-rejected version. Verified locally: dirty tree now yields `0.35.0.3.dev1` (no `+` segment).
- **`skip-existing: true`** on all three publish workflows — re-runs fill gaps instead of 400-aborting (self-healing).
- **macOS `fail-fast: false`** — one flaky build can't cancel sibling wheels (latent footgun; Linux/Windows already use `false`).

## Release plan (after merge)

1. Tag `0.35.0.3` on `main` → all 3 workflows publish the full 13-wheel set (macOS/linux-x64/win: cp39/cp310/cp311/cp312-abi3; linux-aarch64: cp312-abi3).
2. Yank `0.35.0.2`.

No API changes — `0.35.0.3` re-ships `0.35.0.2`'s bindings with complete wheel coverage.

---

closes #93 & #59 
