### PR TITLE
docs(readme): add Python 3.13/3.14 to version badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Tesseract Python (nanobind)
 
 [![PyPI](https://img.shields.io/pypi/v/tesseract-robotics-nanobind.svg)](https://pypi.org/project/tesseract-robotics-nanobind/)
-[![Python](https://img.shields.io/badge/python-3.9%20|%203.10%20|%203.11%20|%203.12-blue.svg)](https://github.com/tesseract-robotics/tesseract_nanobind)
+[![Python](https://img.shields.io/badge/python-3.9%20|%203.10%20|%203.11%20|%203.12%20|%203.13%20|%203.14-blue.svg)](https://github.com/tesseract-robotics/tesseract_nanobind)
 [![Linux](https://github.com/tesseract-robotics/tesseract_nanobind/actions/workflows/wheels-linux.yml/badge.svg)](https://github.com/tesseract-robotics/tesseract_nanobind/actions/workflows/wheels-linux.yml)
 [![macOS](https://github.com/tesseract-robotics/tesseract_nanobind/actions/workflows/wheels-macos.yml/badge.svg)](https://github.com/tesseract-robotics/tesseract_nanobind/actions/workflows/wheels-macos.yml)
 [![Windows](https://github.com/tesseract-robotics/tesseract_nanobind/actions/workflows/wheels-windows.yml/badge.svg)](https://github.com/tesseract-robotics/tesseract_nanobind/actions/workflows/wheels-windows.yml)


### PR DESCRIPTION
Adds Python 3.13/3.14 to the README version badge, now that 0.35.0.3 (PR #98) verifies the `cp312-abi3` wheel installs + passes the suite on 3.13/3.14 across macOS, Linux, and Windows. README-only — no code/CI impact.