### PR TITLE
fix(ci): pin tag-build version + version==tag publish gate

### DIFF
--- a/.github/workflows/wheels-linux.yml
+++ b/.github/workflows/wheels-linux.yml
@@ -31,6 +31,11 @@ concurrency:
 jobs:
   build:
     runs-on: ${{ matrix.runner }}
+    env:
+      # Tag builds must yield EXACTLY the tag version. A dirty CI tree otherwise makes
+      # setuptools_scm guess-next-dev (e.g. 0.35.0.4.dev0) which — local segment stripped —
+      # would publish as a stray dev release (see 0.35.0.3). Pin the version on tag builds.
+      SETUPTOOLS_SCM_PRETEND_VERSION_FOR_TESSERACT_ROBOTICS_NANOBIND: ${{ github.ref_type == 'tag' && github.ref_name || '' }}
     strategy:
       fail-fast: false
       matrix:
@@ -178,6 +183,13 @@ jobs:
         path: dist/
     - name: List wheels
       run: ls -la dist/
+    - name: assert wheel version == tag (block stray dev/mismatched release)
+      run: |
+        for whl in dist/*.whl; do
+          v=$(basename "$whl" | cut -d- -f2)
+          [ "$v" = "$GITHUB_REF_NAME" ] || { echo "::error::$whl is version $v, expected tag $GITHUB_REF_NAME — refusing to publish"; exit 1; }
+        done
+        echo "✓ all wheels are version $GITHUB_REF_NAME"
     - name: Publish to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
       with:

--- a/.github/workflows/wheels-macos.yml
+++ b/.github/workflows/wheels-macos.yml
@@ -31,6 +31,11 @@ concurrency:
 jobs:
   build:
     runs-on: macos-14
+    env:
+      # Tag builds must yield EXACTLY the tag version. A dirty CI tree otherwise makes
+      # setuptools_scm guess-next-dev (e.g. 0.35.0.4.dev0) which — local segment stripped —
+      # would publish as a stray dev release (see 0.35.0.3). Pin the version on tag builds.
+      SETUPTOOLS_SCM_PRETEND_VERSION_FOR_TESSERACT_ROBOTICS_NANOBIND: ${{ github.ref_type == 'tag' && github.ref_name || '' }}
     strategy:
       fail-fast: false  # release wheels: never let one flaky job cancel sibling builds — a partial matrix fragments the published set (see 0.35.0.2)
       matrix:
@@ -188,6 +193,13 @@ jobs:
         path: dist/
     - name: List wheels
       run: ls -la dist/
+    - name: assert wheel version == tag (block stray dev/mismatched release)
+      run: |
+        for whl in dist/*.whl; do
+          v=$(basename "$whl" | cut -d- -f2)
+          [ "$v" = "$GITHUB_REF_NAME" ] || { echo "::error::$whl is version $v, expected tag $GITHUB_REF_NAME — refusing to publish"; exit 1; }
+        done
+        echo "✓ all wheels are version $GITHUB_REF_NAME"
     - name: Publish to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
       with:

--- a/.github/workflows/wheels-windows.yml
+++ b/.github/workflows/wheels-windows.yml
@@ -34,6 +34,11 @@ concurrency:
 jobs:
   build:
     runs-on: windows-2022
+    env:
+      # Tag builds must yield EXACTLY the tag version. A dirty CI tree otherwise makes
+      # setuptools_scm guess-next-dev (e.g. 0.35.0.4.dev0) which — local segment stripped —
+      # would publish as a stray dev release (see 0.35.0.3). Pin the version on tag builds.
+      SETUPTOOLS_SCM_PRETEND_VERSION_FOR_TESSERACT_ROBOTICS_NANOBIND: ${{ github.ref_type == 'tag' && github.ref_name || '' }}
     strategy:
       fail-fast: false  # don't kill siblings on transient network failures
       matrix:
@@ -452,6 +457,13 @@ jobs:
         path: dist/
     - name: List wheels
       run: ls -la dist/
+    - name: assert wheel version == tag (block stray dev/mismatched release)
+      run: |
+        for whl in dist/*.whl; do
+          v=$(basename "$whl" | cut -d- -f2)
+          [ "$v" = "$GITHUB_REF_NAME" ] || { echo "::error::$whl is version $v, expected tag $GITHUB_REF_NAME — refusing to publish"; exit 1; }
+        done
+        echo "✓ all wheels are version $GITHUB_REF_NAME"
     - name: Publish to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
       with:


### PR DESCRIPTION
**Root cause of the `0.35.0.4.dev0` stray publish during the 0.35.0.3 release.**

A dirty CI tree makes `setuptools_scm` guess-next-dev on *tag* builds (`0.35.0.4.dev0`). `no-local-version` (added for the 0.35.0.2 fix) strips the `+d<date>` that PyPI would have rejected, so the dev version published cleanly. The publish gate (`startsWith(github.ref,'refs/tags/')`) only checks *ref is a tag*, never *version == tag*.

**Fix (defense-in-depth):**
- `SETUPTOOLS_SCM_PRETEND_VERSION_FOR_TESSERACT_ROBOTICS_NANOBIND=<tag>` on tag builds → exact tag version regardless of tree state. Verified locally: dirty tree + pin → `0.35.0.3` (not `0.35.0.4.dev1`).
- `publish` asserts every wheel version == tag, else refuses to upload — makes a stray `.dev` publish *impossible*.

Needed to recut a complete `0.35.0.3` (currently Windows-only).