### PR TITLE
ci(macos): cache nanobind build dir to halve warm builds

### DIFF
--- a/.github/workflows/wheels-linux.yml
+++ b/.github/workflows/wheels-linux.yml
@@ -31,6 +31,11 @@ concurrency:
 jobs:
   build:
     runs-on: ${{ matrix.runner }}
+    env:
+      # Tag builds must yield EXACTLY the tag version. A dirty CI tree otherwise makes
+      # setuptools_scm guess-next-dev (e.g. 0.35.0.4.dev0) which — local segment stripped —
+      # would publish as a stray dev release (see 0.35.0.3). Pin the version on tag builds.
+      SETUPTOOLS_SCM_PRETEND_VERSION_FOR_TESSERACT_ROBOTICS_NANOBIND: ${{ github.ref_type == 'tag' && github.ref_name || '' }}
     strategy:
       fail-fast: false
       matrix:
@@ -178,6 +183,13 @@ jobs:
         path: dist/
     - name: List wheels
       run: ls -la dist/
+    - name: assert wheel version == tag (block stray dev/mismatched release)
+      run: |
+        for whl in dist/*.whl; do
+          v=$(basename "$whl" | cut -d- -f2)
+          [ "$v" = "$GITHUB_REF_NAME" ] || { echo "::error::$whl is version $v, expected tag $GITHUB_REF_NAME — refusing to publish"; exit 1; }
+        done
+        echo "✓ all wheels are version $GITHUB_REF_NAME"
     - name: Publish to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
       with:

--- a/.github/workflows/wheels-macos.yml
+++ b/.github/workflows/wheels-macos.yml
@@ -31,6 +31,11 @@ concurrency:
 jobs:
   build:
     runs-on: macos-14
+    env:
+      # Tag builds must yield EXACTLY the tag version. A dirty CI tree otherwise makes
+      # setuptools_scm guess-next-dev (e.g. 0.35.0.4.dev0) which — local segment stripped —
+      # would publish as a stray dev release (see 0.35.0.3). Pin the version on tag builds.
+      SETUPTOOLS_SCM_PRETEND_VERSION_FOR_TESSERACT_ROBOTICS_NANOBIND: ${{ github.ref_type == 'tag' && github.ref_name || '' }}
     strategy:
       fail-fast: false  # release wheels: never let one flaky job cancel sibling builds — a partial matrix fragments the published set (see 0.35.0.2)
       matrix:
@@ -188,6 +193,13 @@ jobs:
         path: dist/
     - name: List wheels
       run: ls -la dist/
+    - name: assert wheel version == tag (block stray dev/mismatched release)
+      run: |
+        for whl in dist/*.whl; do
+          v=$(basename "$whl" | cut -d- -f2)
+          [ "$v" = "$GITHUB_REF_NAME" ] || { echo "::error::$whl is version $v, expected tag $GITHUB_REF_NAME — refusing to publish"; exit 1; }
+        done
+        echo "✓ all wheels are version $GITHUB_REF_NAME"
     - name: Publish to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
       with:

--- a/.github/workflows/wheels-macos.yml
+++ b/.github/workflows/wheels-macos.yml
@@ -88,9 +88,25 @@ jobs:
       if: steps.colcon-cache.outputs.cache-hit != 'true'
       working-directory: ws/src/tesseract_nanobind
       run: pixi run build-cpp
+    # Cache the scikit-build dir so a warm macOS build skips the ~15-20 min nanobind
+    # recompile (incremental cmake). Mirrors the Windows pattern; build/ is reused
+    # (build_macos_wheel.sh wipes only dist/wheelhouse). Per-python; any source/config
+    # change invalidates it (same hashFiles set as Windows).
+    - name: restore nanobind wheel build cache
+      id: nanobind-build-cache
+      uses: actions/cache/restore@v4
+      with:
+        path: ws/src/tesseract_nanobind/build
+        key: nanobind-wheel-build-macos-py${{ matrix.python }}-${{ hashFiles('ws/src/tesseract_nanobind/CMakeLists.txt', 'ws/src/tesseract_nanobind/pyproject.toml', 'ws/src/tesseract_nanobind/dependencies.repos', 'ws/src/tesseract_nanobind/src/**/*.cpp', 'ws/src/tesseract_nanobind/src/**/*.h', 'ws/src/tesseract_nanobind/src/**/*.hpp') }}
     - name: build wheel
       working-directory: ws/src/tesseract_nanobind
       run: pixi run build-wheel
+    - name: save nanobind wheel build cache
+      if: steps.nanobind-build-cache.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v4
+      with:
+        path: ws/src/tesseract_nanobind/build
+        key: nanobind-wheel-build-macos-py${{ matrix.python }}-${{ hashFiles('ws/src/tesseract_nanobind/CMakeLists.txt', 'ws/src/tesseract_nanobind/pyproject.toml', 'ws/src/tesseract_nanobind/dependencies.repos', 'ws/src/tesseract_nanobind/src/**/*.cpp', 'ws/src/tesseract_nanobind/src/**/*.h', 'ws/src/tesseract_nanobind/src/**/*.hpp') }}
     # actions/upload-artifact@v4 intermittently fails on macOS arm64 runners with
     # "Failed to CreateArtifact: Request timeout" (~1/3 of uploads) — a long-standing
     # open GitHub bug (actions/upload-artifact#569, #527) inherent to arm64 mac runners'

--- a/.github/workflows/wheels-windows.yml
+++ b/.github/workflows/wheels-windows.yml
@@ -34,6 +34,11 @@ concurrency:
 jobs:
   build:
     runs-on: windows-2022
+    env:
+      # Tag builds must yield EXACTLY the tag version. A dirty CI tree otherwise makes
+      # setuptools_scm guess-next-dev (e.g. 0.35.0.4.dev0) which — local segment stripped —
+      # would publish as a stray dev release (see 0.35.0.3). Pin the version on tag builds.
+      SETUPTOOLS_SCM_PRETEND_VERSION_FOR_TESSERACT_ROBOTICS_NANOBIND: ${{ github.ref_type == 'tag' && github.ref_name || '' }}
     strategy:
       fail-fast: false  # don't kill siblings on transient network failures
       matrix:
@@ -452,6 +457,13 @@ jobs:
         path: dist/
     - name: List wheels
       run: ls -la dist/
+    - name: assert wheel version == tag (block stray dev/mismatched release)
+      run: |
+        for whl in dist/*.whl; do
+          v=$(basename "$whl" | cut -d- -f2)
+          [ "$v" = "$GITHUB_REF_NAME" ] || { echo "::error::$whl is version $v, expected tag $GITHUB_REF_NAME — refusing to publish"; exit 1; }
+        done
+        echo "✓ all wheels are version $GITHUB_REF_NAME"
     - name: Publish to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
       with:


### PR DESCRIPTION
macOS rebuilt all nanobind bindings from scratch every run (~15–20 min). Windows caches its scikit-build dir; macOS didn't — this mirrors that restore/save pattern around `build wheel`.

`build_macos_wheel.sh` wipes only `dist/`/`wheelhouse/` (not `build/`), and scikit-build reuses `build/{wheel_tag}`, so incremental cmake makes a warm build a cache-restore. Per-python; invalidated by any source/config change (same `hashFiles` set as Windows).

First run post-merge is a cache miss (populates the cache); subsequent macOS runs skip the recompile. Cuts the macОS release tail that's been the long pole all session.