### PR TITLE
fix(environment): validate setState joint names — ValueError instead of SIGSEGV

### DIFF
--- a/src/tesseract_environment/tesseract_environment_bindings.cpp
+++ b/src/tesseract_environment/tesseract_environment_bindings.cpp
@@ -9,6 +9,9 @@
 #include <nanobind/stl/unique_ptr.h>
 #include <nanobind/stl/set.h>
 
+#include <algorithm>  // std::find (setState validation, GH #43)
+#include <stdexcept>  // std::invalid_argument
+
 // tesseract_environment
 #include <tesseract/environment/environment.h>
 #include <tesseract/environment/events.h>
@@ -60,6 +63,37 @@ namespace te = tesseract::environment;
 namespace tsg = tesseract::scene_graph;
 namespace tc = tesseract::common;
 namespace tk = tesseract::kinematics;
+
+namespace {
+// GH #43: Environment::setState forwards joint names straight into the state
+// solver, which dereferences unknown names unchecked -> SIGSEGV with no Python
+// traceback. The binding owns the Python boundary, so validate here and fail
+// loud (std::invalid_argument -> ValueError). Valid targets are the ACTIVE
+// joints: fixed/mimic joints aren't in the solver's map and crash identically.
+void validate_set_state_joint_names(const te::Environment& env, const std::vector<std::string>& names)
+{
+    const std::vector<std::string> active = env.getActiveJointNames();
+    std::string unknown;
+    for (const auto& name : names) {
+        if (std::find(active.begin(), active.end(), name) == active.end()) {
+            if (!unknown.empty()) unknown += ", ";
+            unknown += name;
+        }
+    }
+    if (!unknown.empty())
+        throw std::invalid_argument("setState: unknown or non-active joint names: " + unknown);
+}
+
+void validate_set_state(const te::Environment& env,
+                        const std::vector<std::string>& names,
+                        const Eigen::Ref<const Eigen::VectorXd>& values)
+{
+    if (static_cast<Eigen::Index>(names.size()) != values.size())
+        throw std::invalid_argument("setState: joint_names length (" + std::to_string(names.size()) +
+                                    ") != joint_values length (" + std::to_string(values.size()) + ")");
+    validate_set_state_joint_names(env, names);
+}
+}  // namespace
 
 // Wrapper for Python event callbacks
 struct PyEventCallbackFn {
@@ -297,17 +331,23 @@ NB_MODULE(_tesseract_environment, m) {
         }, "joint_names"_a, "joint_values"_a)
         .def("setState", [](te::Environment& self,
                             const std::unordered_map<std::string, double>& joints) {
+            std::vector<std::string> names;
+            names.reserve(joints.size());
+            for (const auto& kv : joints) names.push_back(kv.first);
+            validate_set_state_joint_names(self, names);  // GH #43
             self.setState(joints);
         }, "joints"_a)
         .def("setStateByNamesAndValues", [](te::Environment& self,
                                              const std::vector<std::string>& joint_names,
                                              const Eigen::Ref<const Eigen::VectorXd>& joint_values) {
+            validate_set_state(self, joint_names, joint_values);  // GH #43
             self.setState(joint_names, joint_values);
         }, "joint_names"_a, "joint_values"_a)
         // setState with (names, values) - SWIG compatibility
         .def("setState", [](te::Environment& self,
                             const std::vector<std::string>& joint_names,
                             const Eigen::Ref<const Eigen::VectorXd>& joint_values) {
+            validate_set_state(self, joint_names, joint_values);  // GH #43
             self.setState(joint_names, joint_values);
         }, "joint_names"_a, "joint_values"_a)
         // Event callbacks

--- a/tests/tesseract_environment/test_tesseract_environment.py
+++ b/tests/tesseract_environment/test_tesseract_environment.py
@@ -2,6 +2,7 @@ import os
 import traceback
 
 import numpy as np
+import pytest
 
 from tesseract_robotics import tesseract_environment, tesseract_srdf, tesseract_urdf
 
@@ -79,6 +80,53 @@ def get_environment():
     assert command_applied[0]
 
     return env
+
+
+def _fresh_env():
+    scene_graph = get_scene_graph()
+    srdf = get_srdf_model(scene_graph)
+    env = tesseract_environment.Environment()
+    assert env.init(scene_graph, srdf)
+    return env
+
+
+# GH #43: every case below used to SIGSEGV the interpreter (unchecked name
+# lookup in the state solver). The binding owns the boundary: ValueError.
+def test_set_state_dict_unknown_joint_raises():
+    env = _fresh_env()
+    with pytest.raises(ValueError, match="not_a_joint"):
+        env.setState({"not_a_joint": 1.0})
+
+
+def test_set_state_dict_mixed_known_unknown_raises():
+    env = _fresh_env()
+    with pytest.raises(ValueError, match="bogus"):
+        env.setState({"joint_a1": 0.5, "bogus": 1.0})
+
+
+def test_set_state_names_values_unknown_joint_raises():
+    env = _fresh_env()
+    with pytest.raises(ValueError, match="not_a_joint"):
+        env.setState(["not_a_joint"], np.array([1.0]))
+
+
+def test_set_state_names_values_length_mismatch_raises():
+    env = _fresh_env()
+    with pytest.raises(ValueError, match="length"):
+        env.setState([f"joint_a{i + 1}" for i in range(7)], np.array([1.0, 2.0]))
+
+
+def test_set_state_by_names_and_values_unknown_joint_raises():
+    env = _fresh_env()
+    with pytest.raises(ValueError, match="not_a_joint"):
+        env.setStateByNamesAndValues(["not_a_joint"], np.array([1.0]))
+
+
+def test_set_state_valid_dict_still_works():
+    env = _fresh_env()
+    env.setState({f"joint_a{i + 1}": 0.1 * i for i in range(7)})
+    state = env.getState()
+    assert abs(state.joints["joint_a3"] - 0.2) < 1e-12
 
 
 def test_env():


### PR DESCRIPTION
`Environment.setState` forwarded joint names straight into the state solver, which dereferences unknown names unchecked → SIGSEGV with no Python traceback. The binding owns the Python boundary, so it now validates before the call and raises `ValueError`:

- unknown / non-active joint names (all three entry points: dict overload, `(names, values)` overload, `setStateByNamesAndValues`) — non-active matters: fixed/mimic joints aren't in the solver's map and crashed identically
- `names`/`values` length mismatch (same crash class, previously unguarded)

TDD'd: the six new tests segfaulted the interpreter pre-fix, pass post-fix; full suite green (the strictness is real — planners/examples only ever set active joints, confirmed by the run, not assumed).

Closes #43
