### PR TITLE
fix(config): task composer config resolution + py39 lint gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 - **`get_task_composer_config_path()` resolves like the runtime** — returns the `@PLUGIN_PATH@`-patched config that `_configure_environment()` publishes via `TESSERACT_TASK_COMPOSER_CONFIG_FILE` (env var → bundled data → conda share) instead of unconditionally returning the bundled-only path, which doesn't exist in dev envs and was unpatched in wheels; raises the new `TaskComposerConfigNotFoundError` when nothing resolves; the hand-rolled fallback chains in the task composer tests, `TaskComposer.from_config`, and `scripts/generate_pipeline_dotgraphs.py` now delegate to it ([#110]).
+- **ruff enforces the py39 floor** — `FA102` added to lint select so PEP 604 unions without `from __future__ import annotations` fail the hooks; with `target-version = "py39"` (rejects 3.10+ syntax) this turns 3.9 compatibility from convention into a gate ([#92]).
 
 ## [0.35.0.4] - 2026-06-08 — conda-forge C++ deps + OSQP tunability + Linux libstdc++ preload + CI hardening
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- **`get_task_composer_config_path()` resolves like the runtime** — returns the `@PLUGIN_PATH@`-patched config that `_configure_environment()` publishes via `TESSERACT_TASK_COMPOSER_CONFIG_FILE` (env var → bundled data → conda share) instead of unconditionally returning the bundled-only path, which doesn't exist in dev envs and was unpatched in wheels; raises the new `TaskComposerConfigNotFoundError` when nothing resolves; the hand-rolled fallback chains in the task composer tests, `TaskComposer.from_config`, and `scripts/generate_pipeline_dotgraphs.py` now delegate to it ([#110]).
+
 ## [0.35.0.4] - 2026-06-08 — conda-forge C++ deps + OSQP tunability + Linux libstdc++ preload + CI hardening
 
 - **OSQP solver settings exposed** — `OSQPEigenSolver` gains seven tunable setters (`setPolish`, `setWarmStart`, `setAdaptiveRho`, `setMaxIteration`, `setAbsoluteTolerance`, `setRelativeTolerance`, `setVerbosity`) and `TrajOptIfoptOSQPSolverProfile` gains `setAdaptiveRhoInterval`, enabling iteration-based (deterministic) rho adaptation for reproducible SQP solves; fixes dangling-pointer segfault in `getJacobian()` via `rv_policy::reference_internal` on `getVar`/`getNode`/`getNodes` ([0f40048], [c984044], [c083f5e], [#103]).

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ See [CHANGELOG.md](CHANGELOG.md) for release notes.
 
 ## Development
 
-This project uses [pixi](https://pixi.sh) exclusively for dependency management and task running — no pip, conda, or venv needed. Pixi manages the build toolchain (cmake, ninja, nanobind), the prebuilt tesseract C++ libraries (from the `tesseract-robotics` conda channel), and Python deps in a single lockfile.
+This project uses [pixi](https://pixi.sh) exclusively for dependency management and task running — no pip, conda, or venv needed. Pixi manages the build toolchain (cmake, ninja, nanobind), the prebuilt tesseract C++ libraries (from the [`tesseract-robotics` conda channel](https://github.com/tesseract-robotics-packaging)), and Python deps in a single lockfile.
 
 ### Prerequisites
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,12 +125,15 @@ line-length = 100
 extend-exclude = ["*.pyi"] # auto-generated stubs have C++ type strings
 
 [tool.ruff.lint]
-select = ["E", "F", "I", "UP"] # errors, pyflakes, isort, pyupgrade
-ignore = ["E501"]              # line too long (handled by formatter)
+# FA102: PEP 604 unions need `from __future__ import annotations` on the py39 floor (gh-92)
+select = ["E", "F", "I", "UP", "FA102"] # errors, pyflakes, isort, pyupgrade, py39 unions
+ignore = ["E501"]                       # line too long (handled by formatter)
 
 [tool.ruff.lint.per-file-ignores]
 # nanobind extension modules use star imports - ruff can't see into .so files
 "src/tesseract_robotics/tesseract_*/__init__.py" = ["F403", "F405"]
+# examples __init__.py re-export run()/main() entry points for REPL/`python -m` use
+"src/tesseract_robotics/examples/**/__init__.py" = ["F401", "F403", "I001"]
 
 [tool.ruff.format]
 quote-style = "double"

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -5,7 +5,7 @@ Development scripts for tesseract_python_nanobind.
 ## Setup
 
 The tesseract C++ libraries are no longer built from source — they come prebuilt
-from the `tesseract-robotics` conda channel (declared in `pyproject.toml`). Just
+from the [`tesseract-robotics` conda channel](https://github.com/tesseract-robotics-packaging) (declared in `pyproject.toml`). Just
 `pixi run install` (editable) or `pixi run build-wheel` (portable wheel); pixi
 installs the C++ libs into the env automatically.
 

--- a/scripts/generate_pipeline_dotgraphs.py
+++ b/scripts/generate_pipeline_dotgraphs.py
@@ -18,14 +18,14 @@ import argparse
 import re
 import shutil
 import subprocess
-from os import environ
 from pathlib import Path
 
 import numpy as np
 from loguru import logger
 
-# Importing the package resolves TESSERACT_TASK_COMPOSER_CONFIG_FILE for both
-# installed wheels (bundled data) and dev envs (conda share/).
+# get_task_composer_config_path resolves the config for both installed wheels
+# (bundled data) and dev envs (conda share/), raising if neither exists (gh-110).
+from tesseract_robotics import get_task_composer_config_path
 from tesseract_robotics.planning import JointTarget, MotionProgram, Robot, TaskComposer
 from tesseract_robotics.planning.profiles import create_freespace_pipeline_profiles
 from tesseract_robotics.tesseract_collision import (
@@ -199,15 +199,7 @@ def main() -> None:
             "(e.g. `brew install graphviz` / `apt install graphviz`)"
         )
 
-    config_file = environ.get("TESSERACT_TASK_COMPOSER_CONFIG_FILE")
-    if not config_file:
-        raise FileNotFoundError(
-            "TESSERACT_TASK_COMPOSER_CONFIG_FILE not set — importing "
-            "tesseract_robotics should have resolved it (broken install?)"
-        )
-    config = Path(config_file)
-    if not config.is_file():
-        raise FileNotFoundError(f"task composer config not found: {config}")
+    config = get_task_composer_config_path()
 
     factory = TaskComposerPluginFactory(FilesystemPath(str(config)), GeneralResourceLocator())
 

--- a/src/tesseract_robotics/__init__.py
+++ b/src/tesseract_robotics/__init__.py
@@ -267,9 +267,29 @@ def get_tesseract_support_path() -> Path:
     return Path(__file__).parent / "data" / "tesseract" / "support"
 
 
+class TaskComposerConfigNotFoundError(FileNotFoundError):
+    """No task composer config found via env var, bundled data, or conda share."""
+
+
 def get_task_composer_config_path() -> Path:
-    """Get path to bundled task composer config file."""
-    return Path(__file__).parent / "data" / "task_composer_config" / "task_composer_plugins.yaml"
+    """Get the resolved task composer plugin config file.
+
+    Resolution is owned by `_configure_environment()` (env var → bundled data →
+    conda share, with plugin-path placeholders patched) and published via
+    TESSERACT_TASK_COMPOSER_CONFIG_FILE; this returns that single source of
+    truth as a `Path`.
+
+    Raises:
+        TaskComposerConfigNotFoundError: nothing resolves to an existing file.
+    """
+    ensure_configured()
+    env_cfg = os.environ.get("TESSERACT_TASK_COMPOSER_CONFIG_FILE")
+    if env_cfg and Path(env_cfg).is_file():
+        return Path(env_cfg)
+    raise TaskComposerConfigNotFoundError(
+        f"no task composer config found (TESSERACT_TASK_COMPOSER_CONFIG_FILE={env_cfg!r}); "
+        "checked env var, bundled data/task_composer_config/, and $CONDA_PREFIX share"
+    )
 
 
 # Run at import of tesseract_robotics itself so env vars are set before any

--- a/src/tesseract_robotics/planning/composer.py
+++ b/src/tesseract_robotics/planning/composer.py
@@ -295,14 +295,16 @@ class TaskComposer:
                         config_path = str(nested)
 
         if config_path is None:
-            # Last resort: use bundled config
-            from tesseract_robotics import get_task_composer_config_path
+            # Last resort: package helper (env var → bundled data → conda share)
+            from tesseract_robotics import (
+                TaskComposerConfigNotFoundError,
+                get_task_composer_config_path,
+            )
 
-            bundled = get_task_composer_config_path()
-            if bundled:
-                tried_paths.append(f"bundled config: {bundled}")
-                if bundled.is_file():
-                    config_path = str(bundled)
+            try:
+                config_path = str(get_task_composer_config_path())
+            except TaskComposerConfigNotFoundError as e:
+                tried_paths.append(str(e))
 
         if config_path is None:
             paths_tried = "\n  - ".join(tried_paths) if tried_paths else "(none)"

--- a/tests/tesseract_task_composer/test_tesseract_task_composer.py
+++ b/tests/tesseract_task_composer/test_tesseract_task_composer.py
@@ -1,8 +1,6 @@
 """Tests for tesseract_task_composer bindings."""
 
 import gc
-import os
-from pathlib import Path
 
 import pytest
 
@@ -16,25 +14,8 @@ from tesseract_robotics.tesseract_task_composer import (
 
 
 def _resolve_task_composer_config():
-    """Resolve task composer plugin config via env var, package data, or workspace."""
-    env_cfg = os.environ.get("TESSERACT_TASK_COMPOSER_CONFIG_FILE")
-    if env_cfg and Path(env_cfg).is_file():
-        return env_cfg
-
-    pkg_config = tesseract_robotics.get_task_composer_config_path()
-    if pkg_config.is_file():
-        return str(pkg_config)
-
-    conda_prefix = os.environ.get("CONDA_PREFIX")
-    if conda_prefix:
-        ws_config = (
-            Path(conda_prefix)
-            / "share/tesseract_planning/task_composer/config/task_composer_plugins.yaml"
-        )
-        if ws_config.is_file():
-            return str(ws_config)
-
-    return None
+    """Resolved task composer plugin config via the package helper (gh-110)."""
+    return str(tesseract_robotics.get_task_composer_config_path())
 
 
 class TestTaskComposerPluginFactory:
@@ -42,36 +23,7 @@ class TestTaskComposerPluginFactory:
 
     def test_create_factory_and_nodes(self):
         """Test factory creation and pipeline node creation."""
-        from pathlib import Path
-
-        # Try multiple fallbacks to find config
-        config_file = None
-
-        # 1. Try env var first (may be set by test runner)
-        env_cfg = os.environ.get("TESSERACT_TASK_COMPOSER_CONFIG_FILE")
-        if env_cfg and Path(env_cfg).is_file():
-            config_file = env_cfg
-
-        # 2. Try package bundled config (installed wheels)
-        if not config_file:
-            pkg_config = tesseract_robotics.get_task_composer_config_path()
-            if pkg_config.is_file():
-                config_file = str(pkg_config)
-
-        # 3. Editable install: config ships with the tesseract-robotics conda pkg
-        if not config_file:
-            conda_prefix = os.environ.get("CONDA_PREFIX")
-            if conda_prefix:
-                ws_config = (
-                    Path(conda_prefix)
-                    / "share/tesseract_planning/task_composer/config/task_composer_plugins.yaml"
-                )
-                if ws_config.is_file():
-                    config_file = str(ws_config)
-
-        assert config_file and Path(config_file).is_file(), (
-            "No task composer config found. Tried env var, package config, and workspace"
-        )
+        config_file = _resolve_task_composer_config()
         config_path = FilesystemPath(config_file)
         locator = GeneralResourceLocator()
         factory = TaskComposerPluginFactory(config_path, locator)
@@ -99,8 +51,6 @@ class TestTaskComposerPluginFactory:
 
     def test_all_pipelines_loadable(self):
         """Test all 36 expected pipelines are loadable via the factory."""
-        from pathlib import Path
-
         # Explicit list of all 36 pipelines that must be loadable
         EXPECTED_PIPELINES = [
             # Core pipelines
@@ -144,25 +94,7 @@ class TestTaskComposerPluginFactory:
             "RasterFtTask",
         ]
 
-        # Get config file (same fallback logic as test_create_factory_and_nodes)
-        config_file = os.environ.get("TESSERACT_TASK_COMPOSER_CONFIG_FILE")
-        if not config_file or not Path(config_file).is_file():
-            pkg_config = tesseract_robotics.get_task_composer_config_path()
-            if pkg_config.is_file():
-                config_file = str(pkg_config)
-
-        if not config_file:
-            conda_prefix = os.environ.get("CONDA_PREFIX")
-            if conda_prefix:
-                ws_config = (
-                    Path(conda_prefix)
-                    / "share/tesseract_planning/task_composer/config/task_composer_plugins.yaml"
-                )
-                if ws_config.is_file():
-                    config_file = str(ws_config)
-
-        assert config_file and Path(config_file).is_file(), "No task composer config found"
-
+        config_file = _resolve_task_composer_config()
         locator = GeneralResourceLocator()
         factory = TaskComposerPluginFactory(FilesystemPath(config_file), locator)
 
@@ -410,8 +342,6 @@ class TestPipelineDataStorageExposure:
         pytest.importorskip("tesseract_robotics.planning")
 
         config_file = _resolve_task_composer_config()
-        if not config_file:
-            pytest.skip("No task composer config found")
 
         from tesseract_robotics.planning import (
             JointTarget,

--- a/tests/test_config_resolution.py
+++ b/tests/test_config_resolution.py
@@ -1,0 +1,31 @@
+"""Contract tests for get_task_composer_config_path resolution (gh-110).
+
+The helper must return the same env-var-published, plugin-path-patched config
+the runtime uses — in every install flavour (wheel, editable/conda) — and fail
+loudly instead of returning a phantom path.
+"""
+
+import pytest
+
+from tesseract_robotics import TaskComposerConfigNotFoundError, get_task_composer_config_path
+
+
+def test_resolves_to_existing_yaml():
+    """Helper returns an existing config in every supported environment."""
+    config = get_task_composer_config_path()
+    assert config.is_file()
+    assert config.suffix == ".yaml"
+
+
+def test_resolved_config_is_plugin_path_patched():
+    """The returned config is loadable as-is — no unresolved plugin placeholders."""
+    assert "@PLUGIN_PATH@" not in get_task_composer_config_path().read_text()
+
+
+def test_stale_env_var_raises(monkeypatch):
+    """A stale TESSERACT_TASK_COMPOSER_CONFIG_FILE raises, not a nonexistent Path."""
+    monkeypatch.setenv(
+        "TESSERACT_TASK_COMPOSER_CONFIG_FILE", "/nonexistent/task_composer_plugins.yaml"
+    )
+    with pytest.raises(TaskComposerConfigNotFoundError):
+        get_task_composer_config_path()


### PR DESCRIPTION
Two bugtracker fixes:

**gh-110** — `get_task_composer_config_path()` returned the bundled-only path: nonexistent in dev envs, `@PLUGIN_PATH@`-unpatched in wheels. Now reads `TESSERACT_TASK_COMPOSER_CONFIG_FILE` as published by `_configure_environment()` (env var → bundled → conda share), raises named `TaskComposerConfigNotFoundError` when nothing resolves. 5 hand-rolled fallback chains (task composer tests ×3, `TaskComposer.from_config`, dotgraph script) migrated to it; contract tests pin resolution + fail-loud.

**gh-92** — `target-version = "py39"` existed since January but nothing enforced the floor. `FA102` added to lint select (PEP 604 unions without future-import fail hooks); examples `__init__` re-export hubs registered in per-file-ignores (36 pre-existing F401/I001 — repo-wide ruff was never green). Verified with real py39 `compileall` over src/tests/scripts.

Validation: 137 tests pass (`-n auto`), pyright 0 errors, ruff repo-wide green, dotgraph script smoke-run renders all pipelines.

closes #110
closes #92