### PR TITLE
fix(examples): hand TrajOpt its ProfileDictionary in lowlevel example (gh-115)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- **Lowlevel planning example: TrajOpt profiles reach the solver** — `tesseract_planning_lowlevel_c_api_example.py` added its TrajOpt plan/composite profiles to the OMPL dictionary while handing the solver an empty `trajopt_profiles`; TrajOpt silently planned on fallback defaults ([#115]).
 - **`get_task_composer_config_path()` resolves like the runtime** — returns the `@PLUGIN_PATH@`-patched config that `_configure_environment()` publishes via `TESSERACT_TASK_COMPOSER_CONFIG_FILE` (env var → bundled data → conda share) instead of unconditionally returning the bundled-only path, which doesn't exist in dev envs and was unpatched in wheels; raises the new `TaskComposerConfigNotFoundError` when nothing resolves; the hand-rolled fallback chains in the task composer tests, `TaskComposer.from_config`, and `scripts/generate_pipeline_dotgraphs.py` now delegate to it ([#110]).
 - **ruff enforces the py39 floor** — `FA102` added to lint select so PEP 604 unions without `from __future__ import annotations` fail the hooks; with `target-version = "py39"` (rejects 3.10+ syntax) this turns 3.9 compatibility from convention into a gate ([#92]).
 

--- a/src/tesseract_robotics/examples/lowlevel/tesseract_planning_lowlevel_c_api_example.py
+++ b/src/tesseract_robotics/examples/lowlevel/tesseract_planning_lowlevel_c_api_example.py
@@ -163,8 +163,8 @@ def main():
     trajopt_composite_profile = TrajOptDefaultCompositeProfile()
 
     trajopt_profiles = ProfileDictionary()
-    profiles.addProfile(TRAJOPT_DEFAULT_NAMESPACE, "DEFAULT", trajopt_plan_profile)
-    profiles.addProfile(TRAJOPT_DEFAULT_NAMESPACE, "DEFAULT", trajopt_composite_profile)
+    trajopt_profiles.addProfile(TRAJOPT_DEFAULT_NAMESPACE, "DEFAULT", trajopt_plan_profile)
+    trajopt_profiles.addProfile(TRAJOPT_DEFAULT_NAMESPACE, "DEFAULT", trajopt_composite_profile)
 
     # Create the TrajOpt planner
     trajopt_planner = TrajOptMotionPlanner(TRAJOPT_DEFAULT_NAMESPACE)


### PR DESCRIPTION
Two-line fix: `tesseract_planning_lowlevel_c_api_example.py` added its TrajOpt plan/composite profiles to `profiles` (the OMPL dict) while `trajopt_request.profiles = trajopt_profiles` handed the solver the **empty** dict — TrajOpt silently planned on fallback defaults, and the example taught the wrong wiring pattern.

Verified plain `addProfile` registers under the derived type key (`hasProfile(profile.getKey(), ns, "DEFAULT") == True`), and the example test passes with the profiles actually reaching the solver. Unique site — the viewer and trajopt_ifopt examples wire theirs correctly.

closes #115