### PR TITLE
fix(serialization): symmetric shared_ptr<Environment> writers (fixes environment_from_* polymorphic cast)

### DIFF
--- a/src/tesseract_serialization/tesseract_serialization_bindings.cpp
+++ b/src/tesseract_serialization/tesseract_serialization_bindings.cpp
@@ -93,9 +93,20 @@ NB_MODULE(_tesseract_serialization, m)
     // Environment - Full Scene State
     // ============================================================
 
+    // NOTE: the Environment writers serialize a shared_ptr<Environment>, NOT a concrete
+    // Environment. is_polymorphic<Environment> is true, so cereal's shared_ptr format
+    // (with a polymorphic type header) differs from the concrete format. The readers below
+    // deserialize shared_ptr<Environment>, so the writers MUST match or the reader misparses
+    // the stream and throws "unregistered polymorphic cast" (tesseract's own C++ test
+    // round-trips Environment::Ptr on both sides). The no-op deleter wraps the borrowed ref
+    // without taking ownership.
+    auto as_shared = [](const Environment& env) {
+        return std::shared_ptr<Environment>(const_cast<Environment*>(&env), [](Environment*) {});
+    };
+
     m.def("environment_to_xml",
-        [](const Environment& env) {
-            return Serialization::toArchiveStringXML(env);
+        [as_shared](const Environment& env) {
+            return Serialization::toArchiveStringXML(as_shared(env));
         },
         nb::arg("environment"),
         "Serialize Environment to XML string. Includes command history - "
@@ -109,8 +120,8 @@ NB_MODULE(_tesseract_serialization, m)
         "Deserialize Environment from XML string. Returns shared_ptr.");
 
     m.def("environment_to_file",
-        [](const Environment& env, const std::string& path) {
-            return Serialization::toArchiveFileXML(env, path);
+        [as_shared](const Environment& env, const std::string& path) {
+            return Serialization::toArchiveFileXML(as_shared(env), path);
         },
         nb::arg("environment"), nb::arg("path"),
         "Save Environment to XML file.");
@@ -123,8 +134,8 @@ NB_MODULE(_tesseract_serialization, m)
         "Load Environment from XML file. Returns shared_ptr.");
 
     m.def("environment_to_binary",
-        [](const Environment& env) {
-            return Serialization::toArchiveBinaryData(env);
+        [as_shared](const Environment& env) {
+            return Serialization::toArchiveBinaryData(as_shared(env));
         },
         nb::arg("environment"),
         "Serialize Environment to binary data.");

--- a/tests/tesseract_serialization/test_serialization.py
+++ b/tests/tesseract_serialization/test_serialization.py
@@ -6,6 +6,7 @@ Tests XML/binary serialization roundtrip for root types:
 - SceneState (joint/link state snapshots)
 """
 
+import os
 import tempfile
 from pathlib import Path
 
@@ -20,6 +21,8 @@ from tesseract_robotics.tesseract_command_language import (
     MoveInstructionType,
     WaypointPoly_as_JointWaypointPoly,
 )
+from tesseract_robotics.tesseract_common import GeneralResourceLocator
+from tesseract_robotics.tesseract_environment import Environment
 from tesseract_robotics.tesseract_serialization import (
     composite_instruction_from_binary,
     composite_instruction_from_file,
@@ -27,6 +30,12 @@ from tesseract_robotics.tesseract_serialization import (
     composite_instruction_to_binary,
     composite_instruction_to_file,
     composite_instruction_to_xml,
+    environment_from_binary,
+    environment_from_file,
+    environment_from_xml,
+    environment_to_binary,
+    environment_to_file,
+    environment_to_xml,
 )
 
 
@@ -120,5 +129,70 @@ class TestCompositeInstructionSerialization:
         assert restored.getProfile() == "EMPTY"
 
 
-# SceneState and Environment serialization tests require environment loading
-# These are tested via integration tests in examples/
+def make_test_environment():
+    """Build an Environment from the bundled lbr_iiwa support model.
+
+    Located via TESSERACT_RESOURCE_PATH (set by tesseract_robotics for bundled
+    data) so the test does not depend on a TESSERACT_SUPPORT_DIR override.
+    """
+    base = None
+    for entry in os.environ.get("TESSERACT_RESOURCE_PATH", "").split(os.pathsep):
+        cand = Path(entry) / "tesseract" / "support" / "urdf"
+        if (cand / "lbr_iiwa_14_r820.urdf").exists():
+            base = cand
+            break
+    assert base is not None, "lbr_iiwa_14_r820 support model not on TESSERACT_RESOURCE_PATH"
+
+    env = Environment()
+    assert env.initFromUrdfSrdf(
+        (base / "lbr_iiwa_14_r820.urdf").read_text(),
+        (base / "lbr_iiwa_14_r820.srdf").read_text(),
+        GeneralResourceLocator(),
+    )
+    return env
+
+
+def _env_fingerprint(env):
+    return (
+        sorted(env.getLinkNames()),
+        sorted(env.getJointNames()),
+        sorted(env.getActiveLinkNames()),
+    )
+
+
+class TestEnvironmentSerialization:
+    """Round-trip the full Environment (scene graph + command history + resource locator).
+
+    Regression for a writer/reader type asymmetry: the writers serialized a *concrete*
+    `Environment` while the readers deserialized a *polymorphic* `shared_ptr<Environment>`
+    (``is_polymorphic<Environment>`` is true), so the reader misparsed the stream and every
+    ``environment_from_*`` failed with "Trying to load a registered polymorphic type with an
+    unregistered polymorphic cast". Both sides must use ``shared_ptr<Environment>`` — as
+    tesseract's own C++ ``EnvironmentSerializeUnit`` test does.
+    """
+
+    def test_binary_roundtrip(self):
+        env = make_test_environment()
+        restored = environment_from_binary(environment_to_binary(env))
+        assert _env_fingerprint(restored) == _env_fingerprint(env)
+
+    def test_xml_roundtrip(self):
+        env = make_test_environment()
+        restored = environment_from_xml(environment_to_xml(env))
+        assert _env_fingerprint(restored) == _env_fingerprint(env)
+
+    def test_file_roundtrip(self):
+        env = make_test_environment()
+        with tempfile.TemporaryDirectory() as d:
+            path = str(Path(d) / "env.xml")
+            environment_to_file(env, path)
+            restored = environment_from_file(path)
+        assert _env_fingerprint(restored) == _env_fingerprint(env)
+
+    def test_roundtrip_preserves_contact_manager(self):
+        """The deserialized env must still produce a working discrete contact manager —
+        the polymorphic ResourceLocator load is exactly what the asymmetry broke."""
+        env = make_test_environment()
+        restored = environment_from_binary(environment_to_binary(env))
+        restored.clearCachedDiscreteContactManager()
+        assert restored.getDiscreteContactManager() is not None


### PR DESCRIPTION
## Problem

`environment_from_xml` / `environment_from_binary` / `environment_from_file` fail on **every** Environment with:

```
Trying to load a registered polymorphic type with an unregistered polymorphic cast.
Could not find a path to a base class (tesseract::environment::Environment)
for type: tesseract::common::GeneralResourceLocator
```

`composite_instruction_*` and `scene_state_*` round-trip fine — only `environment_*` is affected.

## Root cause

A writer/reader **type asymmetry** in the bindings: the writers serialize a *concrete* `Environment` (`Serialization::toArchive*(env)`), but the readers deserialize a *polymorphic* `shared_ptr<Environment>`. `is_polymorphic<Environment>` is true, so cereal's `shared_ptr` format carries a polymorphic type header the concrete writer never emits. The reader misparses the stream, resolves the leading bytes to `GeneralResourceLocator`, and tries to upcast it to `Environment` → the error above (an lldb backtrace shows `cereal::load<…, Environment>(shared_ptr) → InputBindingCreator<…, GeneralResourceLocator> → upcast<GeneralResourceLocator>(…, Environment)`).

tesseract's own C++ `EnvironmentSerializeUnit` test passes because it round-trips `Environment::Ptr` (a `shared_ptr`) on **both** sides.

## Fix

Make the `environment_to_{xml,file,binary}` writers serialize a `shared_ptr<Environment>` (a no-op-deleter wrap of the borrowed reference) so writer and reader use the same cereal format.

## Tests

Adds `TestEnvironmentSerialization` (binary / xml / file round-trips + a "contact manager survives deserialize" check — the polymorphic ResourceLocator load is exactly what broke). All 9 serialization tests pass.
