### PR TITLE
feat(sqp): release the GIL in TrustRegionSQPSolver.solve (+ FK, setCollisionObjectsTransform)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,7 @@ site/
 .pixi/
 pixi.lock
 .testmondata
+
+# Local-only design docs and plans; never commit
+docs/superpowers/
+docs/plans/

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ pixi.lock
 # Local-only design docs and plans; never commit
 docs/superpowers/
 docs/plans/
+AGENTS.md

--- a/src/tesseract_collision/tesseract_collision_bindings.cpp
+++ b/src/tesseract_collision/tesseract_collision_bindings.cpp
@@ -240,7 +240,7 @@ NB_MODULE(_tesseract_collision, m) {
                      tm[p.first] = p.second;
                  }
                  self.setCollisionObjectsTransform(tm);
-             }, "transforms"_a)
+             }, "transforms"_a, nb::call_guard<nb::gil_scoped_release>())
         .def("getCollisionObjects", &tc::DiscreteContactManager::getCollisionObjects)
         .def("setActiveCollisionObjects", &tc::DiscreteContactManager::setActiveCollisionObjects, "names"_a)
         .def("getActiveCollisionObjects", &tc::DiscreteContactManager::getActiveCollisionObjects)

--- a/src/tesseract_environment/tesseract_environment_bindings.cpp
+++ b/src/tesseract_environment/tesseract_environment_bindings.cpp
@@ -328,7 +328,7 @@ NB_MODULE(_tesseract_environment, m) {
                                              const std::vector<std::string>& joint_names,
                                              const Eigen::Ref<const Eigen::VectorXd>& joint_values) {
             return self.getState(joint_names, joint_values);
-        }, "joint_names"_a, "joint_values"_a)
+        }, "joint_names"_a, "joint_values"_a, nb::call_guard<nb::gil_scoped_release>())
         .def("setState", [](te::Environment& self,
                             const std::unordered_map<std::string, double>& joints) {
             std::vector<std::string> names;

--- a/src/trajopt_sqp/trajopt_sqp_bindings.cpp
+++ b/src/trajopt_sqp/trajopt_sqp_bindings.cpp
@@ -302,7 +302,7 @@ NB_MODULE(_trajopt_sqp, m) {
         .def("init", &tsqp::TrustRegionSQPSolver::init, "qp_prob"_a,
              "Initialize the solver with a QP problem for incremental solving")
         .def("solve", &tsqp::TrustRegionSQPSolver::solve, "qp_prob"_a,
-             "Run complete SQP optimization")
+             "Run complete SQP optimization", nb::call_guard<nb::gil_scoped_release>())
         .def("stepSQPSolver", &tsqp::TrustRegionSQPSolver::stepSQPSolver,
              "Run a SINGLE SQP convexification step.\n\n"
              "This is the key method for real-time/online planning.\n"


### PR DESCRIPTION
## Summary

The motion-planner `solve()` methods already bind with `nb::call_guard<nb::gil_scoped_release>()`, but callers driving the **lower-level `trajopt_sqp.TrustRegionSQPSolver` directly** hold the GIL through the entire optimization. This releases the GIL on the raw SQP solve and the two collision/state helpers it leans on per iteration:

| Method | File |
| --- | --- |
| `TrustRegionSQPSolver::solve` | `src/trajopt_sqp/trajopt_sqp_bindings.cpp` |
| `Environment::getStateByNamesAndValues` (FK / state) | `src/tesseract_environment/tesseract_environment_bindings.cpp` |
| `DiscreteContactManager::setCollisionObjectsTransform` (TransformMap overload) | `src/tesseract_collision/tesseract_collision_bindings.cpp` |

## Why

A Python worker thread sweeping a windowed trajectory optimization over **per-thread cloned `Environment`s** previously time-shared the GIL through `solve()` — concurrency, not parallelism. Releasing it lets the trust-region / OSQP machinery run in parallel across threads. Mirrors the `contactTest` GIL guard (#122).

## Safety

- `solve()` calls back into Python `ConstraintSet`s every iteration; nanobind re-acquires the GIL for each callback automatically.
- `getStateByNamesAndValues` takes an `Eigen::Ref` view + a pure-C++ `getState`; safe when each thread owns its own joint vector (no concurrent mutation — the per-thread-clone design).
- `setCollisionObjectsTransform` (map overload) takes a fully-materialized C++ `std::map` (converted before the guard); body is pure C++.

Results are unchanged — a concurrency change, not a numeric one. Verified: builds clean (editable + portable `cp312-abi3` wheel) and the existing suite is unaffected by the guards.
