### PR TITLE
feat(trajopt_ifopt): bind the collision configs and the SQP parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased] — TrajOptIfopt collision configs + SQP tunability
+
+- **TrajOptIfopt collision configs and SQP parameters bound** — `TrajOptIfoptDefaultCompositeProfile` exposed only smoothing and `TrajOptIfoptSolverProfile` only OSQP settings, so from Python the IFOPT planner ran on C++ collision and SQP-loop defaults with no way to reach them. `collision_cost_config` / `collision_constraint_config` (`trajopt_common::TrajOptCollisionConfig`) and `opt_params` (`trajopt_sqp::SQPParameters`) are now bound. `opt_params` sits on the base solver profile — `create()` assigns it straight onto the `TrustRegionSQPSolver`, making it the only route to `max_iterations` (50), `max_qp_solver_failures` (3), the trust-region ratios, and merit-coeff inflation; the sco back-end has always exposed these via `TrajOptOSQPSolverProfile`, so an IFOPT migration silently lost them. The collision configs carry `max_num_cnt`, which **only** trajopt_ifopt honours (the constraint size must be fixed): it caps the collision constraint at that many rows per timestep, one per worst link pair, so QP size stops tracking contact count ([eb92e15]).
+- **`tesseract_motion_planners_trajopt_ifopt` re-exports the types its profiles need** — `TrajOptCollisionConfig`, `SQPParameters`, and `CollisionEvaluatorType` are re-exported from the planner module, matching `tesseract_motion_planners_trajopt`, so configuring a composite or solver profile no longer means importing from `trajopt_ifopt` / `trajopt_sqp` / `tesseract_collision` alongside it. The module's `__all__` also regains `TrajOptIfoptMoveProfile`, `TrajOptIfoptDefaultMoveProfile`, and `ProfileDictionary_addTrajOptIfoptMoveProfile`, which the stub declared but the package never re-exported.
+
 ## [0.35.0.7] — multi-brand emitter subsystem + coordinated external axes
 
 - **Brand-independent multi-dialect emitter** — the ABB-only RAPID emitter (shipped in [0.35.0.1]) is generalised into a typed intermediate representation and lowering pass feeding per-dialect backends over a shared `ProgramBackend` ABC, so a new controller language is a backend, not a fork. Five dialects emit from one tesseract `CompositeInstruction` — ABB **RAPID**, KUKA **KRL**, Fanuc **LS** (TP ASCII), Yaskawa Motoman **JBI** (INFORM), and Universal Robots **URScript** — all exported from `tesseract_robotics.emitters` with a mermaid architecture page. RAPID is reseated onto the core IR and decomposed into `profile` / `targets` / `emit` / `backend` modules; its public surface (`emit_rapid`, `RapidProfile`, `rapid_writer`) is preserved through re-exports, so existing callers are unaffected ([#128]).
@@ -120,7 +125,8 @@ First PyPI-published macOS arm64 wheels, shipping via a dedicated `wheels-macos.
 - Non-benchmark tests fail loud instead of being silently skipped ([a1d7607]).
 - Python 3.9 compatibility for example modules via `from __future__ import annotations` ([87ce68e]).
 
-[0.35.0.7]: https://github.com/tesseract-robotics/tesseract_nanobind/compare/0.35.0.6...HEAD
+[0.35.0.8]: https://github.com/tesseract-robotics/tesseract_nanobind/compare/0.35.0.7...HEAD
+[0.35.0.7]: https://github.com/tesseract-robotics/tesseract_nanobind/compare/0.35.0.6...0.35.0.7
 [0.35.0.6]: https://github.com/tesseract-robotics/tesseract_nanobind/compare/0.35.0.5...0.35.0.6
 [0.35.0.5]: https://github.com/tesseract-robotics/tesseract_nanobind/compare/0.35.0.4...0.35.0.5
 [0.35.0.4]: https://github.com/tesseract-robotics/tesseract_nanobind/compare/0.35.0.3...0.35.0.4
@@ -259,6 +265,7 @@ First PyPI-published macOS arm64 wheels, shipping via a dedicated `wheels-macos.
 [e51946f]: https://github.com/tesseract-robotics/tesseract_nanobind/commit/e51946f
 [0f12535]: https://github.com/tesseract-robotics/tesseract_nanobind/commit/0f12535
 [bcac229]: https://github.com/tesseract-robotics/tesseract_nanobind/commit/bcac229
+[eb92e15]: https://github.com/tesseract-robotics/tesseract_nanobind/commit/eb92e15
 [@Joelkang]: https://github.com/Joelkang
 [@johnwason]: https://github.com/johnwason
 [@marip8]: https://github.com/marip8

--- a/src/tesseract_motion_planners_trajopt_ifopt/tesseract_motion_planners_trajopt_ifopt_bindings.cpp
+++ b/src/tesseract_motion_planners_trajopt_ifopt/tesseract_motion_planners_trajopt_ifopt_bindings.cpp
@@ -28,6 +28,9 @@
 // trajopt_common for collision config
 #include <trajopt_common/collision_types.h>
 
+// trajopt_sqp for SQPParameters (TrajOptIfoptSolverProfile::opt_params)
+#include <trajopt_sqp/types.h>
+
 // OsqpEigen settings (forwarded setters on TrajOptIfoptOSQPSolverProfile)
 #include <OsqpEigen/Settings.hpp>
 
@@ -42,6 +45,17 @@ NB_MODULE(_tesseract_motion_planners_trajopt_ifopt, m) {
 
     // Import MotionPlanner base type for clone() return type
     nb::module_::import_("tesseract_robotics.tesseract_motion_planners._tesseract_motion_planners");
+
+    // ========== trajopt_common::TrajOptCollisionConfig ==========
+    // Owned by the trajopt_ifopt module; import so the composite profile's
+    // collision_cost_config / collision_constraint_config members resolve
+    // (same pattern as tesseract_motion_planners_trajopt).
+    nb::module_::import_("tesseract_robotics.trajopt_ifopt._trajopt_ifopt");
+
+    // ========== trajopt_sqp::SQPParameters ==========
+    // Owned by the trajopt_sqp module; import so TrajOptIfoptSolverProfile's
+    // opt_params member resolves.
+    nb::module_::import_("tesseract_robotics.trajopt_sqp._trajopt_sqp");
 
     // ========== TrajOptIfoptCartesianWaypointConfig ==========
     nb::class_<tp::TrajOptIfoptCartesianWaypointConfig>(m, "TrajOptIfoptCartesianWaypointConfig")
@@ -73,7 +87,14 @@ NB_MODULE(_tesseract_motion_planners_trajopt_ifopt, m) {
         .def("getKey", &tp::TrajOptIfoptCompositeProfile::getKey);
 
     // ========== TrajOptIfoptSolverProfile (base) ==========
+    // opt_params is the SQP loop itself (max_iterations, max_qp_solver_failures,
+    // trust-region ratios, merit-coeff inflation) -- create() assigns it straight
+    // onto the TrustRegionSQPSolver, so it is the only route to those knobs. The
+    // sco back-end exposes them via TrajOptOSQPSolverProfile; unbound here, an
+    // IFOPT migration silently loses them and runs on C++ defaults (max_iterations
+    // 50, max_qp_solver_failures 3).
     nb::class_<tp::TrajOptIfoptSolverProfile, tc::Profile>(m, "TrajOptIfoptSolverProfile")
+        .def_rw("opt_params", &tp::TrajOptIfoptSolverProfile::opt_params)
         .def("getKey", &tp::TrajOptIfoptSolverProfile::getKey);
 
     // ========== TrajOptIfoptDefaultMoveProfile (was TrajOptIfoptDefaultPlanProfile) ==========
@@ -88,9 +109,17 @@ NB_MODULE(_tesseract_motion_planners_trajopt_ifopt, m) {
     m.attr("TrajOptIfoptDefaultPlanProfile") = m.attr("TrajOptIfoptDefaultMoveProfile");
 
     // ========== TrajOptIfoptDefaultCompositeProfile ==========
-    // Note: longest_valid_segment_fraction/length removed in 0.33, collision config via TrajOptCollisionConfig
+    // Note: longest_valid_segment_fraction/length removed in 0.33, collision config via TrajOptCollisionConfig.
+    // The two collision configs carry max_num_cnt, which ONLY trajopt_ifopt honours
+    // (trajopt_common/collision_types.h: "only used by trajopt_ifopt because the
+    // constraints size must be fixed") -- it caps the collision constraint at that
+    // many rows per timestep, one per worst link pair, so QP size stops tracking
+    // contact count. Unbound they are unreachable and the planner silently runs on
+    // C++ defaults: no margins, no buffers, no modify_collision_objects scoping.
     nb::class_<tp::TrajOptIfoptDefaultCompositeProfile, tp::TrajOptIfoptCompositeProfile>(m, "TrajOptIfoptDefaultCompositeProfile")
         .def(nb::init<>())
+        .def_rw("collision_cost_config", &tp::TrajOptIfoptDefaultCompositeProfile::collision_cost_config)
+        .def_rw("collision_constraint_config", &tp::TrajOptIfoptDefaultCompositeProfile::collision_constraint_config)
         .def_rw("smooth_velocities", &tp::TrajOptIfoptDefaultCompositeProfile::smooth_velocities)
         .def_rw("velocity_coeff", &tp::TrajOptIfoptDefaultCompositeProfile::velocity_coeff)
         .def_rw("smooth_accelerations", &tp::TrajOptIfoptDefaultCompositeProfile::smooth_accelerations)

--- a/src/tesseract_robotics/planning/profiles.py
+++ b/src/tesseract_robotics/planning/profiles.py
@@ -154,6 +154,10 @@ def create_trajopt_ifopt_default_profiles(
         - smooth_velocities: False (disabled; requires velocity_coeff sized to DOF)
         - smooth_accelerations: False
         - smooth_jerks: False
+        - collision_cost_config / collision_constraint_config: left at the C++
+          defaults (both enabled, no margins set). Unlike the sco TrajOpt
+          profiles, these are not pre-configured here because the useful margin
+          depends on the robot and scene — see Tuning below.
 
         Plan Profile (applies per waypoint):
         - cartesian_constraint: enabled (enforce Cartesian targets exactly)
@@ -161,6 +165,8 @@ def create_trajopt_ifopt_default_profiles(
 
         Solver Profile (OSQP configuration):
         - Uses default OSQP settings for QP solving
+        - opt_params (the SQP loop) left at the C++ defaults: max_iterations=50,
+          max_qp_solver_failures=3
 
     Args:
         profile_names: Profile names to register (default: TRAJOPT_PROFILE_NAMES)
@@ -181,6 +187,40 @@ def create_trajopt_ifopt_default_profiles(
         result = composer.plan(robot, program,
                               pipeline='TrajOptIfoptPipeline',
                               profiles=profiles)
+
+    Tuning:
+        Both knob sets are reachable from the planner module, which re-exports
+        CollisionEvaluatorType and TrajOptCollisionConfig for this purpose:
+
+        from tesseract_robotics.tesseract_motion_planners_trajopt_ifopt import (
+            CollisionEvaluatorType,
+            TrajOptIfoptDefaultCompositeProfile,
+            TrajOptIfoptOSQPSolverProfile,
+        )
+
+        composite = TrajOptIfoptDefaultCompositeProfile()
+        composite.collision_constraint_config.contact_manager_config.default_margin = 0.01
+        composite.collision_constraint_config.collision_check_config.type = (
+            CollisionEvaluatorType.LVS_DISCRETE
+        )
+        # max_num_cnt is honoured by trajopt_ifopt only — it fixes the number of
+        # collision constraint rows per timestep so QP size stops tracking contact count
+        composite.collision_constraint_config.max_num_cnt = 3
+
+        solver = TrajOptIfoptOSQPSolverProfile()
+        solver.opt_params.max_iterations = 100
+
+        The profiles this helper builds can also be retrieved and edited in
+        place — getProfile returns the concrete profile type, not the Profile
+        base. Note that one composite/plan/solver instance is shared by all
+        profile_names, so an edit applies to every registered name:
+
+        composite = profiles.getProfile(
+            TrajOptIfoptDefaultCompositeProfile().getKey(),
+            TRAJOPT_IFOPT_DEFAULT_NAMESPACE,
+            "DEFAULT",
+        )
+        composite.collision_constraint_config.max_num_cnt = 3
     """
     from tesseract_robotics.tesseract_motion_planners_trajopt_ifopt import (
         ProfileDictionary_addTrajOptIfoptCompositeProfile,

--- a/src/tesseract_robotics/tesseract_motion_planners_trajopt_ifopt/__init__.py
+++ b/src/tesseract_robotics/tesseract_motion_planners_trajopt_ifopt/__init__.py
@@ -1,16 +1,31 @@
 # tesseract_motion_planners_trajopt_ifopt Python bindings
+# TrajOptCollisionConfig lives in trajopt_ifopt (trajopt_common) and SQPParameters in
+# trajopt_sqp; both are needed to configure TrajOptIfoptDefaultCompositeProfile's
+# collision_{cost,constraint}_config and TrajOptIfoptSolverProfile's opt_params, so
+# re-export them here for parity with tesseract_motion_planners_trajopt.
+# CollisionEvaluatorType lives in tesseract_collision (0.33 API) — re-exported too.
+from tesseract_robotics.tesseract_collision import CollisionEvaluatorType
+from tesseract_robotics.trajopt_ifopt import TrajOptCollisionConfig
+from tesseract_robotics.trajopt_sqp import SQPParameters
+
 from ._tesseract_motion_planners_trajopt_ifopt import *
 
 __all__ = [
+    "CollisionEvaluatorType",
     "ProfileDictionary_addTrajOptIfoptCompositeProfile",
+    "ProfileDictionary_addTrajOptIfoptMoveProfile",
     "ProfileDictionary_addTrajOptIfoptPlanProfile",
     "ProfileDictionary_addTrajOptIfoptSolverProfile",
+    "SQPParameters",
+    "TrajOptCollisionConfig",
     "TrajOptIfoptCartesianWaypointConfig",
     "TrajOptIfoptCompositeProfile",
     "TrajOptIfoptDefaultCompositeProfile",
+    "TrajOptIfoptDefaultMoveProfile",
     "TrajOptIfoptDefaultPlanProfile",
     "TrajOptIfoptJointWaypointConfig",
     "TrajOptIfoptMotionPlanner",
+    "TrajOptIfoptMoveProfile",
     "TrajOptIfoptOSQPSolverProfile",
     "TrajOptIfoptPlanProfile",
     "TrajOptIfoptSolverProfile",

--- a/src/tesseract_robotics/tesseract_motion_planners_trajopt_ifopt/_tesseract_motion_planners_trajopt_ifopt.pyi
+++ b/src/tesseract_robotics/tesseract_motion_planners_trajopt_ifopt/_tesseract_motion_planners_trajopt_ifopt.pyi
@@ -5,6 +5,7 @@ from numpy.typing import NDArray
 
 import tesseract_robotics.tesseract_command_language._tesseract_command_language
 import tesseract_robotics.tesseract_motion_planners._tesseract_motion_planners
+import tesseract_robotics.trajopt_ifopt._trajopt_ifopt
 
 
 class TrajOptIfoptCartesianWaypointConfig:
@@ -115,6 +116,18 @@ TrajOptIfoptDefaultPlanProfile: TypeAlias = TrajOptIfoptDefaultMoveProfile
 
 class TrajOptIfoptDefaultCompositeProfile(TrajOptIfoptCompositeProfile):
     def __init__(self) -> None: ...
+
+    @property
+    def collision_cost_config(self) -> tesseract_robotics.trajopt_ifopt._trajopt_ifopt.TrajOptCollisionConfig: ...
+
+    @collision_cost_config.setter
+    def collision_cost_config(self, arg: tesseract_robotics.trajopt_ifopt._trajopt_ifopt.TrajOptCollisionConfig, /) -> None: ...
+
+    @property
+    def collision_constraint_config(self) -> tesseract_robotics.trajopt_ifopt._trajopt_ifopt.TrajOptCollisionConfig: ...
+
+    @collision_constraint_config.setter
+    def collision_constraint_config(self, arg: tesseract_robotics.trajopt_ifopt._trajopt_ifopt.TrajOptCollisionConfig, /) -> None: ...
 
     @property
     def smooth_velocities(self) -> bool: ...

--- a/tests/tesseract_motion_planners/test_trajopt_ifopt_planner.py
+++ b/tests/tesseract_motion_planners/test_trajopt_ifopt_planner.py
@@ -3,6 +3,7 @@
 import numpy as np
 import pytest
 
+from tesseract_robotics.tesseract_collision import CollisionEvaluatorType
 from tesseract_robotics.tesseract_command_language import (
     CompositeInstruction,
     JointWaypoint,
@@ -28,7 +29,10 @@ from tesseract_robotics.tesseract_motion_planners_trajopt_ifopt import (
     TrajOptIfoptDefaultPlanProfile,
     TrajOptIfoptMotionPlanner,
     TrajOptIfoptOSQPSolverProfile,
+    TrajOptIfoptSolverProfile,
 )
+from tesseract_robotics.trajopt_ifopt import TrajOptCollisionConfig
+from tesseract_robotics.trajopt_sqp import SQPParameters
 
 TRAJOPT_IFOPT_NAMESPACE = "TrajOptIfoptMotionPlannerTask"
 
@@ -92,6 +96,153 @@ class TestTrajOptIfoptProfiles:
         profile.setAbsoluteTolerance(1e-5)
         profile.setRelativeTolerance(1e-7)
         profile.setVerbosity(False)
+
+    def test_solver_profile_opt_params_defaults(self):
+        """opt_params is exposed and reports the C++ SQP defaults."""
+        profile = TrajOptIfoptOSQPSolverProfile()
+        assert isinstance(profile.opt_params, SQPParameters)
+        assert profile.opt_params.max_iterations == 50
+        assert profile.opt_params.max_qp_solver_failures == 3
+
+    def test_solver_profile_opt_params_on_base_class(self):
+        """opt_params is bound on the base profile, not just the OSQP subclass."""
+        assert hasattr(TrajOptIfoptSolverProfile, "opt_params")
+
+    def test_solver_profile_opt_params_in_place(self):
+        """In-place writes to opt_params reach the profile (reference, not copy)."""
+        profile = TrajOptIfoptOSQPSolverProfile()
+        profile.opt_params.max_iterations = 5
+        profile.opt_params.max_qp_solver_failures = 1
+        profile.opt_params.initial_trust_box_size = 0.05
+        profile.opt_params.max_time = 2.5
+
+        assert profile.opt_params.max_iterations == 5
+        assert profile.opt_params.max_qp_solver_failures == 1
+        assert profile.opt_params.initial_trust_box_size == 0.05
+        assert profile.opt_params.max_time == 2.5
+
+    def test_solver_profile_opt_params_assignment(self):
+        """Assigning a whole SQPParameters copies its values onto the profile."""
+        params = SQPParameters()
+        params.max_iterations = 11
+        params.trust_shrink_ratio = 0.2
+        params.trust_expand_ratio = 2.0
+        params.cnt_tolerance = 1e-3
+        params.max_merit_coeff_increases = 2
+        params.merit_coeff_increase_ratio = 5.0
+        params.initial_merit_error_coeff = 20.0
+        params.inflate_constraints_individually = False
+
+        profile = TrajOptIfoptOSQPSolverProfile()
+        profile.opt_params = params
+
+        assert profile.opt_params.max_iterations == 11
+        assert profile.opt_params.trust_shrink_ratio == 0.2
+        assert profile.opt_params.trust_expand_ratio == 2.0
+        assert profile.opt_params.cnt_tolerance == 1e-3
+        assert profile.opt_params.max_merit_coeff_increases == 2
+        assert profile.opt_params.merit_coeff_increase_ratio == 5.0
+        assert profile.opt_params.initial_merit_error_coeff == 20.0
+        assert profile.opt_params.inflate_constraints_individually is False
+
+        # Assignment copies: later edits to the source do not leak into the profile.
+        params.max_iterations = 99
+        assert profile.opt_params.max_iterations == 11
+
+    def test_composite_profile_collision_config_defaults(self):
+        """Both collision configs are exposed as trajopt_common::TrajOptCollisionConfig."""
+        profile = TrajOptIfoptDefaultCompositeProfile()
+
+        for config in (profile.collision_cost_config, profile.collision_constraint_config):
+            assert isinstance(config, TrajOptCollisionConfig)
+            assert config.enabled is True
+            assert config.collision_margin_buffer == 0.01
+            # max_num_cnt is the ifopt-only fixed constraint-row cap
+            assert config.max_num_cnt > 0
+
+    def test_composite_profile_collision_config_in_place(self):
+        """In-place writes to the collision configs reach the profile."""
+        profile = TrajOptIfoptDefaultCompositeProfile()
+
+        profile.collision_cost_config.enabled = False
+        profile.collision_cost_config.collision_margin_buffer = 0.025
+        profile.collision_cost_config.max_num_cnt = 7
+
+        assert profile.collision_cost_config.enabled is False
+        assert profile.collision_cost_config.collision_margin_buffer == 0.025
+        assert profile.collision_cost_config.max_num_cnt == 7
+
+    def test_composite_profile_collision_configs_are_independent(self):
+        """Cost and constraint configs are separate members."""
+        profile = TrajOptIfoptDefaultCompositeProfile()
+
+        profile.collision_cost_config.max_num_cnt = 3
+        profile.collision_constraint_config.max_num_cnt = 9
+
+        assert profile.collision_cost_config.max_num_cnt == 3
+        assert profile.collision_constraint_config.max_num_cnt == 9
+
+    def test_composite_profile_collision_config_assignment(self):
+        """Assigning whole configs copies their values onto the profile."""
+        cost_config = TrajOptCollisionConfig(0.05, 20.0)
+        cost_config.enabled = True
+        cost_config.collision_margin_buffer = 0.02
+        cost_config.max_num_cnt = 4
+
+        constraint_config = TrajOptCollisionConfig()
+        constraint_config.enabled = False
+        constraint_config.collision_margin_buffer = 0.005
+        constraint_config.max_num_cnt = 1
+
+        profile = TrajOptIfoptDefaultCompositeProfile()
+        profile.collision_cost_config = cost_config
+        profile.collision_constraint_config = constraint_config
+
+        assert profile.collision_cost_config.enabled is True
+        assert profile.collision_cost_config.collision_margin_buffer == 0.02
+        assert profile.collision_cost_config.max_num_cnt == 4
+        assert profile.collision_constraint_config.enabled is False
+        assert profile.collision_constraint_config.collision_margin_buffer == 0.005
+        assert profile.collision_constraint_config.max_num_cnt == 1
+
+        # Assignment copies: later edits to the source do not leak into the profile.
+        cost_config.max_num_cnt = 99
+        assert profile.collision_cost_config.max_num_cnt == 4
+
+    def test_composite_profile_collision_config_nested_members(self):
+        """The nested margin/check/coeff configs are reachable through the profile."""
+        profile = TrajOptIfoptDefaultCompositeProfile()
+        config = profile.collision_constraint_config
+
+        config.contact_manager_config.default_margin = 0.03
+        config.collision_check_config.type = CollisionEvaluatorType.LVS_DISCRETE
+        config.collision_check_config.longest_valid_segment_length = 0.05
+        config.collision_coeff_data.setDefaultCollisionCoeff(15.0)
+
+        assert profile.collision_constraint_config.contact_manager_config.default_margin == 0.03
+        assert (
+            profile.collision_constraint_config.collision_check_config.type
+            == CollisionEvaluatorType.LVS_DISCRETE
+        )
+        assert (
+            profile.collision_constraint_config.collision_check_config.longest_valid_segment_length
+            == 0.05
+        )
+        assert (
+            profile.collision_constraint_config.collision_coeff_data.getDefaultCollisionCoeff()
+            == 15.0
+        )
+
+    def test_composite_profile_modify_collision_objects_scoping(self):
+        """modify_object_enabled scoping is settable through the collision config."""
+        profile = TrajOptIfoptDefaultCompositeProfile()
+        profile.collision_cost_config.contact_manager_config.modify_object_enabled = {
+            "link_1": False,
+            "link_2": True,
+        }
+
+        enabled = profile.collision_cost_config.contact_manager_config.modify_object_enabled
+        assert enabled == {"link_1": False, "link_2": True}
 
     def test_add_profiles_to_dictionary(self):
         """Test adding TrajOptIfopt profiles to ProfileDictionary."""
@@ -181,6 +332,72 @@ class TestTrajOptIfoptPlanner:
         request.profiles = profiles
 
         # Solve
+        planner = TrajOptIfoptMotionPlanner(TRAJOPT_IFOPT_NAMESPACE)
+        response = planner.solve(request)
+
+        assert response.successful, f"Planning failed: {response.message}"
+        assert response.results is not None
+
+    def test_planning_with_collision_configs_and_opt_params(self, kuka_iiwa_environment):
+        """Plan with the newly bound collision configs and SQP parameters set."""
+        t_env, manip_info, joint_names = kuka_iiwa_environment
+
+        start_pos = np.array([0.0, 0.0, 0.0, -1.57, 0.0, 0.0, 0.0])
+        end_pos = np.array([0.5, 0.3, 0.0, -1.2, 0.0, 0.5, 0.0])
+        t_env.setState(joint_names, start_pos)
+
+        wp1 = JointWaypoint(joint_names, start_pos)
+        wp2 = JointWaypoint(joint_names, end_pos)
+        start_instr = MoveInstruction(
+            JointWaypointPoly_wrap_JointWaypoint(wp1), MoveInstructionType_FREESPACE, "DEFAULT"
+        )
+        end_instr = MoveInstruction(
+            JointWaypointPoly_wrap_JointWaypoint(wp2), MoveInstructionType_FREESPACE, "DEFAULT"
+        )
+
+        program = CompositeInstruction("DEFAULT")
+        program.setManipulatorInfo(manip_info)
+        program.appendMoveInstruction(MoveInstructionPoly_wrap_MoveInstruction(start_instr))
+        program.appendMoveInstruction(MoveInstructionPoly_wrap_MoveInstruction(end_instr))
+
+        interpolated = generateInterpolatedProgram(program, t_env, 3.14, 1.0, 3.14, 30)
+
+        n_joints = len(joint_names)
+        plan_profile = TrajOptIfoptDefaultPlanProfile()
+        composite_profile = TrajOptIfoptDefaultCompositeProfile()
+        composite_profile.velocity_coeff = np.ones(n_joints)
+        composite_profile.acceleration_coeff = np.ones(n_joints)
+        composite_profile.jerk_coeff = np.ones(n_joints)
+
+        # Collision as a constraint only, with a bounded number of constraint rows
+        # per timestep (max_num_cnt is honoured by trajopt_ifopt only).
+        composite_profile.collision_cost_config.enabled = False
+        composite_profile.collision_constraint_config.enabled = True
+        composite_profile.collision_constraint_config.max_num_cnt = 3
+        composite_profile.collision_constraint_config.collision_margin_buffer = 0.01
+        composite_profile.collision_constraint_config.contact_manager_config.default_margin = 0.01
+
+        solver_profile = TrajOptIfoptOSQPSolverProfile()
+        solver_profile.opt_params.max_iterations = 20
+        solver_profile.opt_params.max_qp_solver_failures = 5
+        solver_profile.opt_params.initial_trust_box_size = 0.1
+
+        profiles = ProfileDictionary()
+        ProfileDictionary_addTrajOptIfoptPlanProfile(
+            profiles, TRAJOPT_IFOPT_NAMESPACE, "DEFAULT", plan_profile
+        )
+        ProfileDictionary_addTrajOptIfoptCompositeProfile(
+            profiles, TRAJOPT_IFOPT_NAMESPACE, "DEFAULT", composite_profile
+        )
+        ProfileDictionary_addTrajOptIfoptSolverProfile(
+            profiles, TRAJOPT_IFOPT_NAMESPACE, "DEFAULT", solver_profile
+        )
+
+        request = PlannerRequest()
+        request.instructions = interpolated
+        request.env = t_env
+        request.profiles = profiles
+
         planner = TrajOptIfoptMotionPlanner(TRAJOPT_IFOPT_NAMESPACE)
         response = planner.solve(request)
 


### PR DESCRIPTION
TrajOptIfoptDefaultCompositeProfile::collision_{cost,constraint}_config and TrajOptIfoptSolverProfile::opt_params exist in C++ but were unbound, so from Python the composite profile exposed only smoothing and the solver profile only OSQP settings.